### PR TITLE
Get container ports from the environment

### DIFF
--- a/items/src/main/resources/application.conf
+++ b/items/src/main/resources/application.conf
@@ -1,6 +1,6 @@
-http.externalBaseURL=${?app_base_url}
 http.host="0.0.0.0"
-http.port=9001
+http.externalBaseURL=${?app_base_url}
+http.port=${?app_port}
 contextURL=${?context_url}
 aws.metrics.namespace=${?metrics_namespace}
 sierra.api.key=${?sierra_api_key}

--- a/search/src/main/resources/application.conf
+++ b/search/src/main/resources/application.conf
@@ -1,3 +1,5 @@
+http.host="0.0.0.0"
+http.port=${?app_port}
 es.host=${?es_host}
 es.port=${?es_port}
 es.username=${?es_username}

--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/Main.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/Main.scala
@@ -48,7 +48,7 @@ object Main extends WellcomeTypesafeApp {
           s"${config.getStringOption("api.apiName").getOrElse("catalogue")}",
         contextSuffix = config
           .getStringOption("api.context.suffix")
-          .getOrElse("context.json"),
+          .getOrElse("context.json")
       )
 
     val queryConfig =
@@ -66,7 +66,11 @@ object Main extends WellcomeTypesafeApp {
 
     () =>
       Http()
-        .bindAndHandle(router.routes, "0.0.0.0", 8888)
+        .bindAndHandle(
+          router.routes,
+          config.getStringOption("http.host").getOrElse("0.0.0.0"),
+          config.getIntOption("http.port").getOrElse(8888)
+        )
         .flatMap(_ => Promise[Done].future)
   }
 }

--- a/terraform/items/main.tf
+++ b/terraform/items/main.tf
@@ -1,3 +1,7 @@
+locals {
+  items_container_port = 9001
+}
+
 module "items_api_stage" {
   source = "../modules/service"
 
@@ -10,7 +14,7 @@ module "items_api_stage" {
   cluster_arn       = local.cluster_arn
   load_balancer_arn = local.nlb_arn
 
-  container_port              = 9000
+  container_port              = local.items_container_port
   load_balancer_listener_port = 6001
 
   container_image = local.api_container_image["stage"]
@@ -25,6 +29,7 @@ module "items_api_stage" {
   ]
 
   environment = {
+    app_port           = local.items_container_port
     app_base_url       = "https://api.wellcomecollection.org/stacks/v1/items"
     context_url        = "https://api.wellcomecollection.org/stacks/v1/context.json"
     catalogue_base_url = "https://api.wellcomecollection.org/catalogue/v2"

--- a/terraform/modules/stack/catalogue_api/main.tf
+++ b/terraform/modules/stack/catalogue_api/main.tf
@@ -38,6 +38,7 @@ module "service" {
     api_host         = "api.wellcomecollection.org"
     apm_service_name = var.namespace
     apm_environment  = var.environment
+    app_port         = local.api_container_port
   }
 
   secrets = {


### PR DESCRIPTION
There is quite a bit of refactoring that could be done to configure our HTTP servers more consistently but here is a start that prevents needless issues of the type seen here https://wellcome.slack.com/archives/CUA669WHH/p1619602388033200