### PR TITLE
Use latest weco-deploy in 5.6

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,7 +23,7 @@ steps:
     if: build.branch == "main"
     plugins:
       - docker#v3.5.0:
-          image: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/weco-deploy:5.6.16
+          image: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/weco-deploy:5.6
           workdir: /repo
           mount-ssh-agent: true
           command: [

--- a/makefiles/functions.Makefile
+++ b/makefiles/functions.Makefile
@@ -67,7 +67,7 @@ endef
 define publish_service
 	$(ROOT)/docker_run.py \
     	    --aws --dind -- \
-                $(ECR_REGISTRY)/wellcome/weco-deploy:5.6.10 \
+                $(ECR_REGISTRY)/wellcome/weco-deploy:5.6 \
                 --project-id="$(2)" \
                 --verbose \
                 publish \


### PR DESCRIPTION
Removes the patch level version to allow weco-deploy to move to the most recent version in 5.6. 

Uses the work @jamieparkinson did to make keeping in sync with a more recent version.