### PR TITLE
V1 gone is gone

### DIFF
--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/Router.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/Router.scala
@@ -23,11 +23,13 @@ import weco.catalogue.internal_model.identifiers.CanonicalId
 import scala.concurrent.ExecutionContext
 import scala.util.{Success, Try}
 
-class Router(elasticClient: ElasticClient,
-             elasticConfig: ElasticConfig,
-             queryConfig: QueryConfig,
-             swaggerDocs: SwaggerDocs,
-             implicit val apiConfig: ApiConfig)(implicit ec: ExecutionContext)
+class Router(
+  elasticClient: ElasticClient,
+  elasticConfig: ElasticConfig,
+  queryConfig: QueryConfig,
+  swaggerDocs: SwaggerDocs,
+  implicit val apiConfig: ApiConfig
+)(implicit ec: ExecutionContext)
     extends CustomDirectives {
 
   def routes: Route = handleRejections(rejectionHandler) {
@@ -73,14 +75,6 @@ class Router(elasticClient: ElasticClient,
               }
             )
           },
-          path("v1" / Remaining) { _ =>
-            gone(
-              """"
-                |This API is now decommissioned.
-                |Please use https://api.wellcomecollection.org/catalogue/v2/works.
-              """.stripMargin.replace('\n', ' ')
-            )
-          },
           pathPrefix("management") {
             concat(
               path("healthcheck") {
@@ -104,14 +98,16 @@ class Router(elasticClient: ElasticClient,
     new WorksController(
       elasticsearchService,
       apiConfig,
-      worksIndex = elasticConfig.worksIndex)
+      worksIndex = elasticConfig.worksIndex
+    )
 
   lazy val imagesController =
     new ImagesController(
       elasticsearchService,
       apiConfig,
       imagesIndex = elasticConfig.imagesIndex,
-      queryConfig)
+      queryConfig
+    )
 
   def swagger: Route = get {
     complete(
@@ -134,20 +130,21 @@ class Router(elasticClient: ElasticClient,
     val worksSearchTemplate = SearchTemplate(
       "multi_matcher_search_query",
       elasticConfig.worksIndex.name,
-      WorksMultiMatcher("{{query}}").filter(
-        termQuery(field = "type", value = "Visible")),
+      WorksMultiMatcher("{{query}}")
+        .filter(termQuery(field = "type", value = "Visible"))
     )
 
     val imageSearchTemplate = SearchTemplate(
       "image_search_query",
       elasticConfig.imagesIndex.name,
-      ImagesMultiMatcher("{{query}}"),
+      ImagesMultiMatcher("{{query}}")
     )
 
     complete(
       SearchTemplateResponse(
         List(worksSearchTemplate, imageSearchTemplate)
-      ))
+      )
+    )
   }
 
   def rejectionHandler =

--- a/terraform/modules/static_response/main.tf
+++ b/terraform/modules/static_response/main.tf
@@ -1,0 +1,46 @@
+resource "aws_api_gateway_resource" "static" {
+  rest_api_id = var.rest_api_id
+  parent_id   = var.parent_id
+  path_part   = var.path_part
+}
+
+resource "aws_api_gateway_method" "static" {
+  rest_api_id   = var.rest_api_id
+  resource_id   = aws_api_gateway_resource.static.id
+  authorization = "NONE"
+  http_method   = var.http_method
+}
+
+resource "aws_api_gateway_method_response" "static" {
+  rest_api_id = var.rest_api_id
+  resource_id = aws_api_gateway_resource.static.id
+  http_method = aws_api_gateway_method.static.http_method
+  status_code = var.status_code
+}
+
+resource "aws_api_gateway_integration" "static" {
+  rest_api_id          = var.rest_api_id
+  resource_id          = aws_api_gateway_resource.static.id
+  http_method          = aws_api_gateway_method.static.http_method
+  type                 = "MOCK"
+  passthrough_behavior = "WHEN_NO_TEMPLATES"
+
+  request_templates = {
+    "application/json" = jsonencode({
+      statusCode = var.status_code
+    })
+  }
+}
+
+resource "aws_api_gateway_integration_response" "static" {
+  rest_api_id = var.rest_api_id
+  resource_id = aws_api_gateway_resource.static.id
+  http_method = aws_api_gateway_method.static.http_method
+  status_code = aws_api_gateway_method_response.static.status_code
+
+  response_templates = {
+    "application/json" = var.body
+  }
+
+  depends_on = [aws_api_gateway_integration.static]
+}

--- a/terraform/modules/static_response/output.tf
+++ b/terraform/modules/static_response/output.tf
@@ -1,0 +1,3 @@
+output "resource_id" {
+  value = aws_api_gateway_resource.static.id
+}

--- a/terraform/modules/static_response/variables.tf
+++ b/terraform/modules/static_response/variables.tf
@@ -1,0 +1,23 @@
+variable "path_part" {
+  type = string
+}
+
+variable "body" {
+  type = string
+}
+
+variable "http_method" {
+  type = string
+}
+
+variable "status_code" {
+  type = number
+}
+
+variable "rest_api_id" {
+  type = string
+}
+
+variable "parent_id" {
+  type = string
+}

--- a/terraform/stack/api_gateway.tf
+++ b/terraform/stack/api_gateway.tf
@@ -15,7 +15,7 @@ resource "aws_api_gateway_deployment" "default" {
     // since we don't expect the gateway config to change often it's been left as-is
     // with the proviso that sometimes a manual deploy from the console is necessary
     // https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_deployment#redeployment-triggers
-    redeployment = filesha1("${path.module}/api_gateway.tf")
+    redeployment = join("", [filesha1("${path.module}/api_gateway.tf"), filesha1("${path.module}/static_responses.tf")])
   }
 
   lifecycle {

--- a/terraform/stack/static_responses.tf
+++ b/terraform/stack/static_responses.tf
@@ -1,0 +1,35 @@
+locals {
+  v1_deprecation_string = "This API is now decommissioned. Please use https://api.wellcomecollection.org/catalogue/v2/works."
+  v1_gone_body = jsonencode({
+    errorType   = "http",
+    httpStatus  = 410,
+    label       = "Gone",
+    description = local.v1_deprecation_string
+    type        = "Error",
+    "@context"  = "https://api.wellcomecollection.org/catalogue/v2/context.json"
+  })
+}
+
+module "v1_root_gone" {
+  source = "../modules/static_response"
+
+  rest_api_id = aws_api_gateway_rest_api.catalogue.id
+  parent_id   = aws_api_gateway_rest_api.catalogue.root_resource_id
+  path_part   = "v1"
+
+  http_method = "GET"
+  status_code = 410
+  body        = local.v1_gone_body
+}
+
+module "v1_gone" {
+  source = "../modules/static_response"
+
+  rest_api_id = aws_api_gateway_rest_api.catalogue.id
+  parent_id   = module.v1_root_gone.resource_id
+  path_part   = "{proxy+}"
+
+  http_method = "GET"
+  status_code = 410
+  body        = local.v1_gone_body
+}


### PR DESCRIPTION
The terraform to do this is a bit verbose but I wanted to get a feel for what can be done in API gateway here - next step will be to serve `/works` and `/images` directly from the search app, then to route requests to those, then to remove `/catalogue/v2` from the search app entirely.