### PR TITLE
Remove an unused method for executing multi-searches

### DIFF
--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/services/ElasticsearchService.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/services/ElasticsearchService.scala
@@ -4,10 +4,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import co.elastic.apm.api.Transaction
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.requests.get.GetResponse
-import com.sksamuel.elastic4s.requests.searches.{
-  SearchRequest,
-  SearchResponse
-}
+import com.sksamuel.elastic4s.requests.searches.{SearchRequest, SearchResponse}
 import com.sksamuel.elastic4s.{ElasticClient, ElasticError, Index}
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.Tracing


### PR DESCRIPTION
This was added by Nick last year for some relations work -- I'm guessing when relations were being added in the API requests. Now we add relations in the pipeline, this method is unused.