### PR TITLE
Require an API key to connect to the items API

### DIFF
--- a/terraform/catalogue_api/main.tf
+++ b/terraform/catalogue_api/main.tf
@@ -18,7 +18,8 @@ module "catalogue_api_prod" {
   cluster_arn              = aws_ecs_cluster.catalogue_api.arn
 
   providers = {
-    aws.dns = aws.dns
+    aws.dns        = aws.dns
+    aws.experience = aws.experience
   }
 }
 
@@ -42,6 +43,7 @@ module "catalogue_api_stage" {
   cluster_arn              = aws_ecs_cluster.catalogue_api.arn
 
   providers = {
-    aws.dns = aws.dns
+    aws.dns        = aws.dns
+    aws.experience = aws.experience
   }
 }

--- a/terraform/catalogue_api/provider.tf
+++ b/terraform/catalogue_api/provider.tf
@@ -20,3 +20,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update"
   }
 }
+
+provider "aws" {
+  alias = "experience"
+
+  region = var.aws_region
+
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+  }
+}

--- a/terraform/modules/api_route/main.tf
+++ b/terraform/modules/api_route/main.tf
@@ -22,7 +22,8 @@ resource "aws_api_gateway_method" "method" {
   http_method        = var.http_method
   request_parameters = var.path_param != null ? local.method_request_parameters : null
 
-  authorization = "NONE"
+  authorization    = "NONE"
+  api_key_required = var.api_key_required
 }
 
 resource "aws_api_gateway_integration" "integration" {

--- a/terraform/modules/api_route/variables.tf
+++ b/terraform/modules/api_route/variables.tf
@@ -34,3 +34,8 @@ variable "integration_path" {
 variable "external_hostname" {
   type = string
 }
+
+variable "api_key_required" {
+  type    = bool
+  default = false
+}

--- a/terraform/modules/stack/api_gateway.tf
+++ b/terraform/modules/stack/api_gateway.tf
@@ -120,6 +120,8 @@ module "items_route" {
   path_part   = "items"
   http_method = "ANY"
 
+  api_key_required = true
+
   path_param       = "workId"
   integration_path = "/works/{workId}"
   lb_port          = local.items_lb_port

--- a/terraform/modules/stack/provider.tf
+++ b/terraform/modules/stack/provider.tf
@@ -1,3 +1,7 @@
 provider "aws" {
   alias = "dns"
 }
+
+provider "aws" {
+  alias = "experience"
+}

--- a/terraform/modules/stack/usage_plans.tf
+++ b/terraform/modules/stack/usage_plans.tf
@@ -11,8 +11,20 @@ resource "aws_api_gateway_api_key" "items_api" {
   name = "Items API (${var.environment_name})"
 }
 
-resource "aws_api_gateway_usage_plan_key" "dotorg" {
+resource "aws_api_gateway_usage_plan_key" "items_api" {
   key_id        = aws_api_gateway_api_key.items_api.id
   key_type      = "API_KEY"
   usage_plan_id = aws_api_gateway_usage_plan.items_api.id
+}
+
+module "items_api_key_secret" {
+  source = "../secrets"
+
+  providers = {
+    aws = aws.experience
+  }
+
+  key_value_map = {
+    "catalogue_api/items/${var.environment_name}/api_key" = aws_api_gateway_api_key.items_api.value
+  }
 }

--- a/terraform/modules/stack/usage_plans.tf
+++ b/terraform/modules/stack/usage_plans.tf
@@ -1,0 +1,18 @@
+resource "aws_api_gateway_usage_plan" "items_api" {
+  name        = "Items API (${var.environment_name})"
+
+  api_stages {
+    api_id = aws_api_gateway_rest_api.catalogue.id
+    stage  = aws_api_gateway_stage.default.stage_name
+  }
+}
+
+resource "aws_api_gateway_api_key" "items_api" {
+  name = "Items API (${var.environment_name})"
+}
+
+resource "aws_api_gateway_usage_plan_key" "dotorg" {
+  key_id        = aws_api_gateway_api_key.items_api.id
+  key_type      = "API_KEY"
+  usage_plan_id = aws_api_gateway_usage_plan.items_api.id
+}

--- a/terraform/modules/stack/usage_plans.tf
+++ b/terraform/modules/stack/usage_plans.tf
@@ -1,5 +1,5 @@
 resource "aws_api_gateway_usage_plan" "items_api" {
-  name        = "Items API (${var.environment_name})"
+  name = "Items API (${var.environment_name})"
 
   api_stages {
     api_id = aws_api_gateway_rest_api.catalogue.id


### PR DESCRIPTION
The first part of https://github.com/wellcomecollection/platform/issues/5157

You now need an API key to make requests to the items API, and then you call the API like so:

```
curl -H 'x-api-key: [api_key]' 'https://api.wellcomecollection.org/catalogue/v2/works/fetp6ws5/items'
```

The API key is available to apps running in the experience account via Secrets Manager: `catalogue_api/items/prod/api_key` and `catalogue_api/items/stage/api_key`.