### PR TITLE
Actually add the secrets module used by Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,6 @@ shared_infra/.releases
 .pytest_cache
 
 # Files which could contain secrets we do not want in the repo
-secrets
-secrets.zip
 id_rsa
 id_rsa.pub
 /config

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ id_rsa.pub
 /config
 credentials
 
+# These are files we used to keep for our Travis CI setup
+secrets
+secrets.zip
+
 ### Gatling ###
 /gatling/results/*
 

--- a/terraform/modules/secrets/main.tf
+++ b/terraform/modules/secrets/main.tf
@@ -1,0 +1,12 @@
+resource "aws_secretsmanager_secret" "secret" {
+  for_each = var.key_value_map
+
+  name = each.key
+}
+
+resource "aws_secretsmanager_secret_version" "secret" {
+  for_each = var.key_value_map
+
+  secret_id     = aws_secretsmanager_secret.secret[each.key].id
+  secret_string = each.value
+}

--- a/terraform/modules/secrets/variables.tf
+++ b/terraform/modules/secrets/variables.tf
@@ -1,0 +1,3 @@
+variable "key_value_map" {
+  type = map(string)
+}


### PR DESCRIPTION
We used to put secrets in a `secrets.zip` bundle that would be unpacked by Travis, but we don't do that any more. Unfortunately, it meant I forgot to check in the `secrets` module when I added it in a recent PR.