### PR TITLE
Use Elasticsearch in the items API

### DIFF
--- a/common/search/docker-compose.yml
+++ b/common/search/docker-compose.yml
@@ -1,0 +1,11 @@
+elasticsearch:
+  image: "docker.elastic.co/elasticsearch/elasticsearch:7.9.0"
+  ports:
+    - "9200:9200"
+    - "9300:9300"
+  environment:
+    - "http.host=0.0.0.0"
+    - "transport.host=0.0.0.0"
+    - "cluster.name=wellcome"
+    - "logger.level=DEBUG"
+    - "discovery.type=single-node"

--- a/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticLookup.scala
+++ b/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticLookup.scala
@@ -12,9 +12,8 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 class ElasticLookup[T](
-  elasticClient: ElasticClient
-)(
   implicit
+  elasticClient: ElasticClient,
   ec: ExecutionContext,
   decoder: Decoder[T]
 ) extends Tracing {

--- a/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticLookup.scala
+++ b/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticLookup.scala
@@ -1,0 +1,46 @@
+package weco.api.search.elasticsearch
+
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.circe._
+import com.sksamuel.elastic4s.requests.get.GetResponse
+import com.sksamuel.elastic4s.{ElasticClient, ElasticError, Hit, Index}
+import io.circe.Decoder
+import uk.ac.wellcome.Tracing
+import weco.catalogue.internal_model.identifiers.CanonicalId
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+class ElasticLookup[T](
+  elasticClient: ElasticClient
+)(
+  implicit
+  ec: ExecutionContext,
+  decoder: Decoder[T]
+) extends Tracing {
+
+  def lookupById(canonicalId: CanonicalId)(index: Index): Future[Either[ElasticError, Option[T]]] =
+    executeGet(canonicalId)(index)
+      .map {
+        case Left(elasticError) => Left(elasticError)
+
+        case Right(response) if response.exists => Right(Some(deserialize(response)))
+
+        case Right(_) => Right(None)
+      }
+
+  private def executeGet(canonicalId: CanonicalId)(
+    index: Index): Future[Either[ElasticError, GetResponse]] =
+    withActiveTrace(elasticClient.execute {
+      get(index, canonicalId.underlying)
+    }).map { _.toEither }
+
+  private def deserialize(hit: Hit): T =
+    hit.safeTo[T] match {
+      case Success(work) => work
+      case Failure(e) =>
+        throw new RuntimeException(
+          s"Unable to parse JSON($e): ${hit.sourceAsString}"
+        )
+    }
+}

--- a/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticLookup.scala
+++ b/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticLookup.scala
@@ -18,12 +18,14 @@ class ElasticLookup[T](
   decoder: Decoder[T]
 ) extends Tracing {
 
-  def lookupById(canonicalId: CanonicalId)(index: Index): Future[Either[ElasticError, Option[T]]] =
+  def lookupById(canonicalId: CanonicalId)(
+    index: Index): Future[Either[ElasticError, Option[T]]] =
     executeGet(canonicalId)(index)
       .map {
         case Left(elasticError) => Left(elasticError)
 
-        case Right(response) if response.exists => Right(Some(deserialize(response)))
+        case Right(response) if response.exists =>
+          Right(Some(deserialize(response)))
 
         case Right(_) => Right(None)
       }

--- a/common/search/src/main/scala/weco/api/search/rest/SingleWorkLookup.scala
+++ b/common/search/src/main/scala/weco/api/search/rest/SingleWorkLookup.scala
@@ -13,7 +13,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait SingleWorkLookup extends CustomDirectives {
   implicit val ec: ExecutionContext
-  implicit val elasticLookup: ElasticLookup[Work[Indexed]]
+  val elasticLookup: ElasticLookup[Work[Indexed]]
 
   def lookupSingleWork(id: CanonicalId)(index: Index): Future[Either[Route, Work.Visible[Indexed]]] =
     elasticLookup

--- a/common/search/src/main/scala/weco/api/search/rest/SingleWorkLookup.scala
+++ b/common/search/src/main/scala/weco/api/search/rest/SingleWorkLookup.scala
@@ -15,7 +15,8 @@ trait SingleWorkLookup extends CustomDirectives {
   implicit val ec: ExecutionContext
   val elasticLookup: ElasticLookup[Work[Indexed]]
 
-  def lookupSingleWork(id: CanonicalId)(index: Index): Future[Either[Route, Work.Visible[Indexed]]] =
+  def lookupSingleWork(id: CanonicalId)(
+    index: Index): Future[Either[Route, Work.Visible[Indexed]]] =
     elasticLookup
       .lookupById(id)(index)
       .map {

--- a/common/search/src/main/scala/weco/api/search/rest/SingleWorkLookup.scala
+++ b/common/search/src/main/scala/weco/api/search/rest/SingleWorkLookup.scala
@@ -1,0 +1,51 @@
+package weco.api.search.rest
+
+import akka.http.scaladsl.model.StatusCodes.Found
+import akka.http.scaladsl.server.Route
+import com.sksamuel.elastic4s.Index
+import uk.ac.wellcome.platform.api.rest.CustomDirectives
+import weco.api.search.elasticsearch.ElasticLookup
+import weco.catalogue.internal_model.identifiers.CanonicalId
+import weco.catalogue.internal_model.work.Work
+import weco.catalogue.internal_model.work.WorkState.Indexed
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait SingleWorkLookup extends CustomDirectives {
+  implicit val ec: ExecutionContext
+  implicit val elasticLookup: ElasticLookup[Work[Indexed]]
+
+  def lookupSingleWork(id: CanonicalId)(index: Index): Future[Either[Route, Work.Visible[Indexed]]] =
+    elasticLookup
+      .lookupById(id)(index)
+      .map {
+        case Right(Some(work: Work.Visible[Indexed])) =>
+          Right(work)
+        case Right(Some(work: Work.Redirected[Indexed])) =>
+          Left(workRedirect(work))
+        case Right(Some(_: Work.Invisible[Indexed])) =>
+          Left(gone("This work has been deleted"))
+        case Right(Some(_: Work.Deleted[Indexed])) =>
+          Left(gone("This work has been deleted"))
+        case Right(None) =>
+          Left(notFound(s"Work not found for identifier $id"))
+        case Left(err) => Left(elasticError(err))
+      }
+
+  private def workRedirect(work: Work.Redirected[Indexed]): Route =
+    extractPublicUri { uri =>
+      val newPath =
+        (work.redirectTarget.canonicalId.underlying :: uri.path.reverse.tail).reverse
+
+      // We use a relative URL here so that redirects keep you on the same host.
+      //
+      // e.g. on https://api-stage.wc.org, we tell the API that it's running at
+      // https://api.wc.org so URLs in responses look the same, but we don't want
+      // the stage API to send redirects to the prod API.
+      //
+      // Relative URLs are explicitly supported in HTTP 302 Redirects, see
+      // https://greenbytes.de/tech/webdav/draft-ietf-httpbis-p2-semantics-17.html#rfc.section.9.5
+      // https://stackoverflow.com/q/8250259/1558022
+      redirect(uri.withPath(newPath).toRelative, Found)
+    }
+}

--- a/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticLookupTest.scala
+++ b/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticLookupTest.scala
@@ -23,7 +23,7 @@ class ElasticLookupTest
 
   case class Shape(id: CanonicalId, color: String, sides: Int)
 
-  val elasticLookup = new ElasticLookup[Shape](elasticClient)
+  val elasticLookup = new ElasticLookup[Shape]()
 
   it("looks up an object by ID") {
     val redSquare = Shape(id = createCanonicalId, color = "red", sides = 4)

--- a/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticLookupTest.scala
+++ b/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticLookupTest.scala
@@ -1,0 +1,80 @@
+package weco.api.search.elasticsearch
+
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.ElasticError
+import com.sksamuel.elastic4s.circe._
+import org.scalatest.EitherValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.elasticsearch.NoStrictMapping
+import uk.ac.wellcome.elasticsearch.test.fixtures.ElasticsearchFixtures
+import uk.ac.wellcome.json.JsonUtil._
+import weco.catalogue.internal_model.generators.IdentifiersGenerators
+import weco.catalogue.internal_model.identifiers.CanonicalId
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ElasticLookupTest
+  extends AnyFunSpec
+    with Matchers
+    with EitherValues
+    with ElasticsearchFixtures
+    with IdentifiersGenerators {
+
+  case class Shape(id: CanonicalId, color: String, sides: Int)
+
+  val elasticLookup = new ElasticLookup[Shape](elasticClient)
+
+  it("looks up an object by ID") {
+    val redSquare = Shape(id = createCanonicalId, color = "red", sides = 4)
+
+    withLocalElasticsearchIndex(NoStrictMapping) { index =>
+      elasticClient.execute(
+        indexInto(index).id(redSquare.id.toString).doc(redSquare)
+      ).await
+
+      val future = elasticLookup.lookupById(redSquare.id)(index)
+
+      whenReady(future) {
+        _ shouldBe Right(Some(redSquare))
+      }
+    }
+  }
+
+  it("returns None if the ID doesn't exist") {
+    withLocalElasticsearchIndex(NoStrictMapping) { index =>
+      val future = elasticLookup.lookupById(createCanonicalId)(index)
+
+      whenReady(future) {
+        _ shouldBe Right(None)
+      }
+    }
+  }
+
+  it("returns a failed future if it can't deserialise the object") {
+    case class BadShape(id: CanonicalId, color: String, sides: String)
+
+    val blueTriangle = BadShape(id = createCanonicalId, color = "blue", sides = "three")
+
+    withLocalElasticsearchIndex(NoStrictMapping) { index =>
+      elasticClient.execute(
+        indexInto(index).id(blueTriangle.id.toString).doc(blueTriangle)
+      ).await
+
+      val future = elasticLookup.lookupById(blueTriangle.id)(index)
+
+      whenReady(future.failed) { err =>
+        err shouldBe a[RuntimeException]
+        err.getMessage should startWith("Unable to parse JSON")
+      }
+    }
+  }
+
+  it("returns a Left[ElasticError] if it Elasticsearch returns an error") {
+    val future = elasticLookup.lookupById(createCanonicalId)(createIndex)
+
+    whenReady(future) {
+      _.left.value shouldBe a[ElasticError]
+    }
+  }
+}

--- a/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticLookupTest.scala
+++ b/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticLookupTest.scala
@@ -15,7 +15,7 @@ import weco.catalogue.internal_model.identifiers.CanonicalId
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class ElasticLookupTest
-  extends AnyFunSpec
+    extends AnyFunSpec
     with Matchers
     with EitherValues
     with ElasticsearchFixtures
@@ -29,9 +29,11 @@ class ElasticLookupTest
     val redSquare = Shape(id = createCanonicalId, color = "red", sides = 4)
 
     withLocalElasticsearchIndex(NoStrictMapping) { index =>
-      elasticClient.execute(
-        indexInto(index).id(redSquare.id.toString).doc(redSquare)
-      ).await
+      elasticClient
+        .execute(
+          indexInto(index).id(redSquare.id.toString).doc(redSquare)
+        )
+        .await
 
       val future = elasticLookup.lookupById(redSquare.id)(index)
 
@@ -54,12 +56,15 @@ class ElasticLookupTest
   it("returns a failed future if it can't deserialise the object") {
     case class BadShape(id: CanonicalId, color: String, sides: String)
 
-    val blueTriangle = BadShape(id = createCanonicalId, color = "blue", sides = "three")
+    val blueTriangle =
+      BadShape(id = createCanonicalId, color = "blue", sides = "three")
 
     withLocalElasticsearchIndex(NoStrictMapping) { index =>
-      elasticClient.execute(
-        indexInto(index).id(blueTriangle.id.toString).doc(blueTriangle)
-      ).await
+      elasticClient
+        .execute(
+          indexInto(index).id(blueTriangle.id.toString).doc(blueTriangle)
+        )
+        .await
 
       val future = elasticLookup.lookupById(blueTriangle.id)(index)
 

--- a/common/search/src/test/scala/weco/api/search/fixtures/ResponseFixtures.scala
+++ b/common/search/src/test/scala/weco/api/search/fixtures/ResponseFixtures.scala
@@ -1,0 +1,84 @@
+package weco.api.search.fixtures
+
+import akka.http.scaladsl.model.{ContentTypes, StatusCode, Uri}
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import io.circe.Json
+import io.circe.parser.parse
+import org.scalatest.Assertion
+import org.scalatest.funspec.AnyFunSpec
+import uk.ac.wellcome.models.index.IndexFixtures
+import uk.ac.wellcome.platform.api.models.ApiConfig
+
+trait ResponseFixtures extends AnyFunSpec with ScalatestRouteTest with IndexFixtures {
+  val publicRootUri: String
+
+  lazy val apiConfig = ApiConfig(
+    publicRootUri = Uri(publicRootUri),
+    defaultPageSize = 10,
+    contextSuffix = "context.json"
+  )
+
+  def assertJsonResponse(
+    routes: Route,
+    path: String,
+    unordered: Boolean = false
+  )(expectedResponse: (StatusCode, String)): Assertion =
+    eventually {
+      expectedResponse match {
+        case (expectedStatus, expectedJson) =>
+          Get(path) ~> routes ~> check {
+            contentType shouldEqual ContentTypes.`application/json`
+            parseJson(responseAs[String], unordered) shouldEqual parseJson(
+              expectedJson,
+              unordered
+            )
+            status shouldEqual expectedStatus
+          }
+      }
+    }
+
+  def assertRedirectResponse(routes: Route, path: String)(
+    expectedResponse: (StatusCode, String)
+  ): Assertion =
+    eventually {
+      expectedResponse match {
+        case (expectedStatus, expectedLocation) =>
+          Get(path) ~> routes ~> check {
+            status shouldEqual expectedStatus
+            header("Location").map(_.value) shouldEqual Some(expectedLocation)
+          }
+      }
+    }
+
+  private def parseJson(string: String, unordered: Boolean): Json =
+    parse(string) match {
+      case Right(json) => sortedJson(unordered)(json)
+      case Left(err) =>
+        throw new RuntimeException(
+          s"Asked to compare a string that wasn't JSON. Error: $err. JSON:\n$string"
+        )
+    }
+
+  private def sortedJson(unordered: Boolean)(json: Json): Json =
+    json.arrayOrObject(
+      json,
+      array => {
+        val arr = array.map(sortedJson(unordered))
+        if (unordered) {
+          Json.arr(arr.sortBy(_.toString): _*)
+        } else {
+          Json.arr(arr: _*)
+        }
+      },
+      obj =>
+        Json.obj(
+          obj.toList
+            .map {
+              case (key, value) =>
+                (key, sortedJson(unordered)(value))
+            }
+            .sortBy(tup => tup._1): _*
+        )
+    )
+}

--- a/common/search/src/test/scala/weco/api/search/fixtures/ResponseFixtures.scala
+++ b/common/search/src/test/scala/weco/api/search/fixtures/ResponseFixtures.scala
@@ -12,6 +12,7 @@ import uk.ac.wellcome.platform.api.models.ApiConfig
 
 trait ResponseFixtures extends AnyFunSpec with ScalatestRouteTest with IndexFixtures {
   val publicRootUri: String
+  val contextUrl: String
 
   lazy val apiConfig = ApiConfig(
     publicRootUri = Uri(publicRootUri),
@@ -81,4 +82,37 @@ trait ResponseFixtures extends AnyFunSpec with ScalatestRouteTest with IndexFixt
             .sortBy(tup => tup._1): _*
         )
     )
+
+  def badRequest(description: String) =
+    s"""{
+      "@context": "$contextUrl",
+      "type": "Error",
+      "errorType": "http",
+      "httpStatus": 400,
+      "label": "Bad Request",
+      "description": "$description"
+    }"""
+
+  def goneRequest(description: String) =
+    s"""{
+      "@context": "$contextUrl",
+      "type": "Error",
+      "errorType": "http",
+      "httpStatus": 410,
+      "label": "Gone",
+      "description": "$description"
+    }"""
+
+  def notFound(description: String) =
+    s"""{
+      "@context": "$contextUrl",
+      "type": "Error",
+      "errorType": "http",
+      "httpStatus": 404,
+      "label": "Not Found",
+      "description": "$description"
+    }"""
+
+  def deleted: String =
+    goneRequest("This work has been deleted")
 }

--- a/common/search/src/test/scala/weco/api/search/fixtures/ResponseFixtures.scala
+++ b/common/search/src/test/scala/weco/api/search/fixtures/ResponseFixtures.scala
@@ -83,6 +83,15 @@ trait ResponseFixtures extends AnyFunSpec with ScalatestRouteTest with IndexFixt
         )
     )
 
+  def serverError: String =
+    s"""{
+      "@context": "$contextUrl",
+      "type": "Error",
+      "errorType": "http",
+      "httpStatus": 500,
+      "label": "Internal Server Error"
+    }"""
+
   def badRequest(description: String) =
     s"""{
       "@context": "$contextUrl",

--- a/common/search/src/test/scala/weco/api/search/fixtures/ResponseFixtures.scala
+++ b/common/search/src/test/scala/weco/api/search/fixtures/ResponseFixtures.scala
@@ -10,7 +10,10 @@ import org.scalatest.funspec.AnyFunSpec
 import uk.ac.wellcome.models.index.IndexFixtures
 import uk.ac.wellcome.platform.api.models.ApiConfig
 
-trait ResponseFixtures extends AnyFunSpec with ScalatestRouteTest with IndexFixtures {
+trait ResponseFixtures
+    extends AnyFunSpec
+    with ScalatestRouteTest
+    with IndexFixtures {
   val publicRootUri: String
   val contextUrl: String
 
@@ -80,7 +83,7 @@ trait ResponseFixtures extends AnyFunSpec with ScalatestRouteTest with IndexFixt
                 (key, sortedJson(unordered)(value))
             }
             .sortBy(tup => tup._1): _*
-        )
+      )
     )
 
   def serverError: String =

--- a/common/search/src/test/scala/weco/api/search/fixtures/ResponseFixtures.scala
+++ b/common/search/src/test/scala/weco/api/search/fixtures/ResponseFixtures.scala
@@ -52,7 +52,7 @@ trait ResponseFixtures extends AnyFunSpec with ScalatestRouteTest with IndexFixt
       }
     }
 
-  private def parseJson(string: String, unordered: Boolean): Json =
+  def parseJson(string: String, unordered: Boolean = false): Json =
     parse(string) match {
       case Right(json) => sortedJson(unordered)(json)
       case Left(err) =>
@@ -61,7 +61,7 @@ trait ResponseFixtures extends AnyFunSpec with ScalatestRouteTest with IndexFixt
         )
     }
 
-  private def sortedJson(unordered: Boolean)(json: Json): Json =
+  def sortedJson(unordered: Boolean)(json: Json): Json =
     json.arrayOrObject(
       json,
       array => {

--- a/common/search/src/test/scala/weco/api/search/rest/SingleWorkLookupTest.scala
+++ b/common/search/src/test/scala/weco/api/search/rest/SingleWorkLookupTest.scala
@@ -1,16 +1,20 @@
 package weco.api.search.rest
 
 import akka.http.scaladsl.model.{StatusCodes, Uri}
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.circe._
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.elasticsearch.NoStrictMapping
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.index.IndexFixtures
 import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import weco.api.search.elasticsearch.ElasticLookup
 import weco.api.search.fixtures.ResponseFixtures
-import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState}
 import weco.catalogue.internal_model.work.{Work, WorkState}
 
 import scala.concurrent.ExecutionContext

--- a/common/search/src/test/scala/weco/api/search/rest/SingleWorkLookupTest.scala
+++ b/common/search/src/test/scala/weco/api/search/rest/SingleWorkLookupTest.scala
@@ -1,20 +1,16 @@
 package weco.api.search.rest
 
 import akka.http.scaladsl.model.{StatusCodes, Uri}
-import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.circe._
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import uk.ac.wellcome.elasticsearch.NoStrictMapping
-import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.index.IndexFixtures
 import uk.ac.wellcome.models.work.generators.WorkGenerators
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import weco.api.search.elasticsearch.ElasticLookup
 import weco.api.search.fixtures.ResponseFixtures
-import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState}
+import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.{Work, WorkState}
 
 import scala.concurrent.ExecutionContext

--- a/common/search/src/test/scala/weco/api/search/rest/SingleWorkLookupTest.scala
+++ b/common/search/src/test/scala/weco/api/search/rest/SingleWorkLookupTest.scala
@@ -1,0 +1,81 @@
+package weco.api.search.rest
+
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import org.scalatest.EitherValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.models.Implicits._
+import uk.ac.wellcome.models.index.IndexFixtures
+import uk.ac.wellcome.models.work.generators.WorkGenerators
+import uk.ac.wellcome.platform.api.models.ApiConfig
+import weco.api.search.elasticsearch.ElasticLookup
+import weco.api.search.fixtures.ResponseFixtures
+import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.work.{Work, WorkState}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class SingleWorkLookupTest
+  extends AnyFunSpec
+    with Matchers
+    with EitherValues
+    with IndexFixtures
+    with WorkGenerators
+    with ResponseFixtures {
+  val publicRootUri = "https://example.wellcomecollection.org/api/works"
+  val exampleContextUri = "https://example.wellcomecollection.org/context.json"
+
+  val lookup = new SingleWorkLookup {
+    override implicit val ec: ExecutionContext = global
+    override implicit val elasticLookup: ElasticLookup[Work[WorkState.Indexed]] =
+      new ElasticLookup()
+
+    override implicit val apiConfig: ApiConfig =
+      ApiConfig(
+        publicRootUri = Uri("http://example.com/api"),
+        defaultPageSize = 10,
+        contextSuffix = "context.json"
+      )
+
+    override def context: String = exampleContextUri
+  }
+
+  it("finds a work") {
+    val w = indexedWork()
+
+    withLocalWorksIndex { index =>
+      insertIntoElasticsearch(index, w)
+
+      val future = lookup.lookupSingleWork(w.state.canonicalId)(index)
+
+      whenReady(future) {
+        _.right.value shouldBe w
+      }
+    }
+  }
+
+  it("returns a redirect if a Work is redirected") {
+    val redirectedWork = indexedWork().redirected(
+      IdState.Identified(
+        canonicalId = createCanonicalId,
+        sourceIdentifier = createSourceIdentifier
+      )
+    )
+    val redirectId = redirectedWork.redirectTarget.canonicalId
+    println(redirectId)
+
+    withLocalWorksIndex { index =>
+      insertIntoElasticsearch(index, redirectedWork)
+
+      val future = lookup.lookupSingleWork(redirectedWork.state.canonicalId)(index)
+
+      whenReady(future) { resp =>
+        val route = resp.left.value
+        assertRedirectResponse(route, path = s"/works/$redirectId") {
+          StatusCodes.Found -> s"${apiConfig.publicRootPath}/$redirectId"
+        }
+      }
+    }
+  }
+}

--- a/common/search/src/test/scala/weco/api/search/rest/SingleWorkLookupTest.scala
+++ b/common/search/src/test/scala/weco/api/search/rest/SingleWorkLookupTest.scala
@@ -17,7 +17,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class SingleWorkLookupTest
-  extends AnyFunSpec
+    extends AnyFunSpec
     with Matchers
     with EitherValues
     with IndexFixtures
@@ -28,7 +28,8 @@ class SingleWorkLookupTest
 
   val lookup = new SingleWorkLookup {
     override implicit val ec: ExecutionContext = global
-    override implicit val elasticLookup: ElasticLookup[Work[WorkState.Indexed]] =
+    override implicit val elasticLookup
+      : ElasticLookup[Work[WorkState.Indexed]] =
       new ElasticLookup()
 
     override implicit val apiConfig: ApiConfig =
@@ -67,7 +68,8 @@ class SingleWorkLookupTest
     withLocalWorksIndex { index =>
       insertIntoElasticsearch(index, redirectedWork)
 
-      val future = lookup.lookupSingleWork(redirectedWork.state.canonicalId)(index)
+      val future =
+        lookup.lookupSingleWork(redirectedWork.state.canonicalId)(index)
 
       whenReady(future) { resp =>
         val route = resp.left.value
@@ -84,7 +86,8 @@ class SingleWorkLookupTest
     withLocalWorksIndex { index =>
       insertIntoElasticsearch(index, invisibleWork)
 
-      val future = lookup.lookupSingleWork(invisibleWork.state.canonicalId)(index)
+      val future =
+        lookup.lookupSingleWork(invisibleWork.state.canonicalId)(index)
 
       whenReady(future) { resp =>
         val route = resp.left.value

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object WellcomeDependencies {
 
-  val defaultVersion = "26.9.1"
+  val defaultVersion = "26.9.2"
 
   lazy val versions = new {
     val typesafe = defaultVersion

--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/Main.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/Main.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.api.search
 import akka.Done
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
+import com.sksamuel.elastic4s.ElasticClient
 import com.typesafe.config.Config
 import uk.ac.wellcome.api.display.ElasticConfig
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
@@ -24,7 +25,8 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildExecutionContext()
 
     Tracing.init(config)
-    val elasticClient = ElasticBuilder.buildElasticClient(config)
+    implicit val elasticClient: ElasticClient =
+      ElasticBuilder.buildElasticClient(config)
 
     val elasticConfig = ElasticConfig()
 
@@ -38,7 +40,6 @@ object Main extends WellcomeTypesafeApp {
     val swaggerDocs = new SwaggerDocs(apiConfig)
 
     val router = new Router(
-      elasticClient = elasticClient,
       elasticConfig = elasticConfig,
       queryConfig = queryConfig,
       swaggerDocs = swaggerDocs,

--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/Router.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/Router.scala
@@ -29,7 +29,6 @@ import uk.ac.wellcome.platform.api.search.rest.{
   SingleWorkParams,
   WorksController
 }
-import uk.ac.wellcome.platform.api.search.services.ElasticsearchService
 import uk.ac.wellcome.platform.api.search.swagger.SwaggerDocs
 import weco.catalogue.internal_model.identifiers.CanonicalId
 
@@ -37,12 +36,11 @@ import scala.concurrent.ExecutionContext
 import scala.util.{Success, Try}
 
 class Router(
-  elasticClient: ElasticClient,
   elasticConfig: ElasticConfig,
   queryConfig: QueryConfig,
   swaggerDocs: SwaggerDocs,
   implicit val apiConfig: ApiConfig
-)(implicit ec: ExecutionContext)
+)(implicit elasticClient: ElasticClient, ec: ExecutionContext)
     extends CustomDirectives {
 
   def searchRoutes: Route = concat(
@@ -112,21 +110,17 @@ class Router(
     }
   }
 
-  lazy val elasticsearchService = new ElasticsearchService(elasticClient)
-
   lazy val worksController =
     new WorksController(
-      elasticsearchService,
-      apiConfig,
-      worksIndex = elasticConfig.worksIndex
+      worksIndex = elasticConfig.worksIndex,
+      apiConfig = apiConfig
     )
 
   lazy val imagesController =
     new ImagesController(
-      elasticsearchService,
-      apiConfig,
       imagesIndex = elasticConfig.imagesIndex,
-      queryConfig
+      apiConfig = apiConfig,
+      queryConfig = queryConfig
     )
 
   def swagger: Route = get {

--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/rest/ImagesController.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/rest/ImagesController.scala
@@ -26,13 +26,11 @@ import weco.http.models.ContextResponse
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ImagesController(
-  imagesIndex: Index,
-  implicit val apiConfig: ApiConfig,
-  queryConfig: QueryConfig)(
-  implicit
-  elasticClient: ElasticClient,
-  ec: ExecutionContext)
+class ImagesController(imagesIndex: Index,
+                       implicit val apiConfig: ApiConfig,
+                       queryConfig: QueryConfig)(implicit
+                                                 elasticClient: ElasticClient,
+                                                 ec: ExecutionContext)
     extends CustomDirectives
     with Tracing
     with FailFastCirceSupport {

--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/services/ElasticsearchService.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/services/ElasticsearchService.scala
@@ -10,7 +10,8 @@ import uk.ac.wellcome.Tracing
 import uk.ac.wellcome.platform.api.search.models._
 
 class ElasticsearchService(
-  implicit elasticClient: ElasticClient, ec: ExecutionContext
+  implicit elasticClient: ElasticClient,
+  ec: ExecutionContext
 ) extends Logging
     with Tracing {
 

--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/services/ElasticsearchService.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/services/ElasticsearchService.scala
@@ -3,24 +3,16 @@ package uk.ac.wellcome.platform.api.search.services
 import scala.concurrent.{ExecutionContext, Future}
 import co.elastic.apm.api.Transaction
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.requests.get.GetResponse
 import com.sksamuel.elastic4s.requests.searches.{SearchRequest, SearchResponse}
 import com.sksamuel.elastic4s.{ElasticClient, ElasticError, Index}
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.Tracing
 import uk.ac.wellcome.platform.api.search.models._
-import weco.catalogue.internal_model.identifiers.CanonicalId
 
-class ElasticsearchService(elasticClient: ElasticClient)(
-  implicit ec: ExecutionContext
+class ElasticsearchService(
+  implicit elasticClient: ElasticClient, ec: ExecutionContext
 ) extends Logging
     with Tracing {
-
-  def executeGet(canonicalId: CanonicalId)(
-    index: Index): Future[Either[ElasticError, GetResponse]] =
-    withActiveTrace(elasticClient.execute {
-      get(index, canonicalId.underlying)
-    }).map { _.toEither }
 
   /** Given a set of query options, build a SearchDefinition for Elasticsearch
     * using the elastic4s query DSL, then execute the search.

--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/services/ImagesService.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/services/ImagesService.scala
@@ -9,7 +9,6 @@ import io.circe.Decoder
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.Tracing
 import uk.ac.wellcome.platform.api.search.models._
-import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.catalogue.internal_model.image.{Image, ImageState}
 
 class ImagesService(searchService: ElasticsearchService,
@@ -18,19 +17,6 @@ class ImagesService(searchService: ElasticsearchService,
 
   private val nVisuallySimilarImages = 5
   private val imagesRequestBuilder = new ImagesRequestBuilder(queryConfig)
-
-  def findImageById(id: CanonicalId)(index: Index)
-    : Future[Either[ElasticError, Option[Image[ImageState.Indexed]]]] =
-    searchService
-      .executeGet(id)(index)
-      .map {
-        _.map { response =>
-          if (response.exists)
-            Some(deserialize[Image[ImageState.Indexed]](response))
-          else
-            None
-        }
-      }
 
   def listOrSearchImages(index: Index, searchOptions: ImageSearchOptions)
     : Future[Either[ElasticError,

--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/services/WorksService.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/services/WorksService.scala
@@ -5,29 +5,15 @@ import scala.util.{Failure, Success}
 import io.circe.Decoder
 import com.sksamuel.elastic4s.{Hit, Index}
 import com.sksamuel.elastic4s.ElasticError
-import com.sksamuel.elastic4s.requests.get.GetResponse
 import com.sksamuel.elastic4s.requests.searches.SearchResponse
 import com.sksamuel.elastic4s.circe._
 import uk.ac.wellcome.platform.api.search.models._
 import uk.ac.wellcome.models.Implicits._
-import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.internal_model.work.WorkState.Indexed
 
 class WorksService(searchService: ElasticsearchService)(
   implicit ec: ExecutionContext) {
-
-  def findWorkById(canonicalId: CanonicalId)(
-    index: Index): Future[Either[ElasticError, Option[Work[Indexed]]]] =
-    searchService
-      .executeGet(canonicalId)(index)
-      .map { result: Either[ElasticError, GetResponse] =>
-        result.map { response: GetResponse =>
-          if (response.exists)
-            Some(deserialize[Work[Indexed]](response))
-          else None
-        }
-      }
 
   def listOrSearchWorks(index: Index, searchOptions: WorkSearchOptions): Future[
     Either[ElasticError, ResultList[Work.Visible[Indexed], WorkAggregations]]] =

--- a/search/src/test/scala/uk/ac/wellcome/platform/api/search/ApiTestBase.scala
+++ b/search/src/test/scala/uk/ac/wellcome/platform/api/search/ApiTestBase.scala
@@ -22,26 +22,6 @@ trait ApiTestBase extends ApiFixture with RandomGenerators {
        |  "results": []
        |}""".stripMargin
 
-  def badRequest(description: String) =
-    s"""{
-      "@context": "$contextUrl",
-      "type": "Error",
-      "errorType": "http",
-      "httpStatus": 400,
-      "label": "Bad Request",
-      "description": "$description"
-    }"""
-
-  def goneRequest(description: String) =
-    s"""{
-      "@context": "$contextUrl",
-      "type": "Error",
-      "errorType": "http",
-      "httpStatus": 410,
-      "label": "Gone",
-      "description": "$description"
-    }"""
-
   def resultList(
     pageSize: Int = 10,
     totalPages: Int = 1,
@@ -54,26 +34,6 @@ trait ApiTestBase extends ApiFixture with RandomGenerators {
       "totalPages": $totalPages,
       "totalResults": $totalResults
     """
-
-  def notFound(description: String) =
-    s"""{
-      "@context": "$contextUrl",
-      "type": "Error",
-      "errorType": "http",
-      "httpStatus": 404,
-      "label": "Not Found",
-      "description": "$description"
-    }"""
-
-  def deleted =
-    s"""{
-      "@context": "$contextUrl",
-      "type": "Error",
-      "errorType": "http",
-      "httpStatus": 410,
-      "label": "Gone",
-      "description": "This work has been deleted"
-    }"""
 
   def withEmptyIndex[R]: Fixture[Index, R] =
     fixture[Index, R](

--- a/search/src/test/scala/uk/ac/wellcome/platform/api/search/elasticsearch/WorksQueryTest.scala
+++ b/search/src/test/scala/uk/ac/wellcome/platform/api/search/elasticsearch/WorksQueryTest.scala
@@ -35,7 +35,7 @@ class WorksQueryTest
     with ImageGenerators
     with ContributorGenerators {
 
-  val searchService = new ElasticsearchService(elasticClient)
+  val searchService = new ElasticsearchService()
 
   describe("Free text query functionality") {
 

--- a/search/src/test/scala/uk/ac/wellcome/platform/api/search/fixtures/ApiFixture.scala
+++ b/search/src/test/scala/uk/ac/wellcome/platform/api/search/fixtures/ApiFixture.scala
@@ -42,7 +42,6 @@ trait ApiFixture extends AnyFunSpec with ScalatestRouteTest with IndexFixtures {
     elasticConfig: ElasticConfig
   )(testWith: TestWith[Route, R]): R = {
     val router = new Router(
-      elasticClient,
       elasticConfig,
       QueryConfig(
         paletteBinSizes = Seq(Seq(4, 6, 9), Seq(2, 4, 6), Seq(1, 3, 5)),

--- a/search/src/test/scala/uk/ac/wellcome/platform/api/search/services/AggregationsTest.scala
+++ b/search/src/test/scala/uk/ac/wellcome/platform/api/search/services/AggregationsTest.scala
@@ -33,7 +33,7 @@ class AggregationsTest
     with WorkGenerators {
 
   val worksService = new WorksService(
-    searchService = new ElasticsearchService(elasticClient)
+    searchService = new ElasticsearchService()
   )
 
   it("returns more than 10 format aggregations") {

--- a/search/src/test/scala/uk/ac/wellcome/platform/api/search/services/ElasticsearchServiceTest.scala
+++ b/search/src/test/scala/uk/ac/wellcome/platform/api/search/services/ElasticsearchServiceTest.scala
@@ -26,39 +26,10 @@ class ElasticsearchServiceTest
     with ItemsGenerators
     with WorkGenerators {
 
-  val searchService = new ElasticsearchService(elasticClient)
+  val searchService = new ElasticsearchService()
 
   val defaultSearchOptions =
     createWorksSearchOptions
-
-  describe("findResultById") {
-    it("finds a result by ID") {
-      withLocalWorksIndex { index =>
-        val work = indexedWork()
-
-        insertIntoElasticsearch(index, work)
-
-        val searchResultFuture =
-          searchService.executeGet(canonicalId = work.state.canonicalId)(index)
-
-        whenReady(searchResultFuture) { result =>
-          val returnedWork =
-            jsonToWork(result.right.get.sourceAsString)
-          returnedWork shouldBe work
-        }
-      }
-    }
-
-    it("returns a Left[ElasticError] if Elasticsearch returns an error") {
-      val future = searchService
-        .executeGet(createCanonicalId)(Index("doesnotexist"))
-
-      whenReady(future) { response =>
-        response.isLeft shouldBe true
-        response.left.get shouldBe a[ElasticError]
-      }
-    }
-  }
 
   describe("executeSearch") {
     it("returns everything if we ask for a limit > result size") {

--- a/search/src/test/scala/uk/ac/wellcome/platform/api/search/services/ImagesServiceTest.scala
+++ b/search/src/test/scala/uk/ac/wellcome/platform/api/search/services/ImagesServiceTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.api.search.services
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import com.sksamuel.elastic4s.{ElasticError, Index}
+import com.sksamuel.elastic4s.Index
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.{EitherValues, OptionValues}
@@ -18,7 +18,7 @@ class ImagesServiceTest
     with EitherValues
     with OptionValues {
 
-  val elasticsearchService = new ElasticsearchService(elasticClient)
+  val elasticsearchService = new ElasticsearchService()
 
   val imagesService = new ImagesService(
     elasticsearchService,
@@ -27,39 +27,6 @@ class ImagesServiceTest
       paletteBinMinima = Seq(0f, 10f / 256, 10f / 256)
     )
   )
-
-  describe("findImageById") {
-    it("fetches an Image by ID") {
-      withLocalImagesIndex { index =>
-        val image = createImageData.toIndexedImage
-        insertImagesIntoElasticsearch(index, image)
-
-        whenReady(
-          imagesService
-            .findImageById(id = image.state.canonicalId)(index)) {
-          _.right.value.value shouldBe image
-        }
-      }
-    }
-
-    it("returns a None if no image can be found") {
-      withLocalImagesIndex { index =>
-        whenReady(
-          imagesService
-            .findImageById(createCanonicalId)(index)) {
-          _.right.value shouldBe None
-        }
-      }
-    }
-
-    it("returns a Left[ElasticError] if Elasticsearch returns an error") {
-      whenReady(
-        imagesService
-          .findImageById(createCanonicalId)(Index("parsnips"))) {
-        _.left.value shouldBe a[ElasticError]
-      }
-    }
-  }
 
   describe("retrieveSimilarImages") {
     it("gets images using a blended similarity metric by default") {

--- a/search/src/test/scala/uk/ac/wellcome/platform/api/search/services/WorksServiceTest.scala
+++ b/search/src/test/scala/uk/ac/wellcome/platform/api/search/services/WorksServiceTest.scala
@@ -30,7 +30,7 @@ class WorksServiceTest
     with WorkGenerators
     with ProductionEventGenerators {
 
-  val elasticsearchService = new ElasticsearchService(elasticClient)
+  val elasticsearchService = new ElasticsearchService()
 
   val worksService = new WorksService(
     searchService = elasticsearchService
@@ -270,53 +270,6 @@ class WorksServiceTest
           filters = DateRangeFilter(None, Some(toDate)) :: Nil
         )
       )
-    }
-  }
-
-  describe("findWorkById") {
-    it("gets a DisplayWork by id") {
-      withLocalWorksIndex { index =>
-        val work = indexedWork()
-
-        insertIntoElasticsearch(index, work)
-
-        val future =
-          worksService.findWorkById(canonicalId = work.state.canonicalId)(index)
-
-        whenReady(future) { response =>
-          response.isRight shouldBe true
-
-          val records = response.right.get
-          records.isDefined shouldBe true
-          records.get shouldBe work
-        }
-      }
-
-    }
-
-    it("returns a future of None if it cannot get a record by id") {
-      withLocalWorksIndex { index =>
-        val recordsFuture =
-          worksService.findWorkById(canonicalId = createCanonicalId)(index)
-
-        whenReady(recordsFuture) { result =>
-          result.isRight shouldBe true
-          result.right.get shouldBe None
-        }
-      }
-    }
-
-    it("returns a Left[ElasticError] if there's an Elasticsearch error") {
-      val future = worksService.findWorkById(
-        canonicalId = createCanonicalId
-      )(
-        index = Index("doesnotexist")
-      )
-
-      whenReady(future) { result =>
-        result.isLeft shouldBe true
-        result.left.get shouldBe a[ElasticError]
-      }
     }
   }
 

--- a/search/src/test/scala/uk/ac/wellcome/platform/api/search/works/WorksErrorsTest.scala
+++ b/search/src/test/scala/uk/ac/wellcome/platform/api/search/works/WorksErrorsTest.scala
@@ -276,16 +276,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
         withEmptyIndex { index =>
           val path = s"$rootPath/works?_index=${index.name}"
           assertJsonResponse(routes, path)(
-            Status.InternalServerError ->
-              s"""
-                 |{
-                 |  "@context": "$contextUrl",
-                 |  "type": "Error",
-                 |  "errorType": "http",
-                 |  "httpStatus": 500,
-                 |  "label": "Internal Server Error"
-                 |}
-            """.stripMargin
+            Status.InternalServerError -> serverError
           )
         }
     }


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/catalogue-api/issues/8

At the core of this patch is two new classes:

```scala
// Looks up individual documents in Elasticsearch
class ElasticLookup[T] {
  def lookupById(canonicalId: CanonicalId)(index: Index): Future[Either[ElasticError, Option[T]]]
}

// Looks up works in Elasticsearch, and returns either a visible work or
// the appropriate error/redirection route
trait SingleWorkLookup {
  def lookupSingleWork(id: CanonicalId)(index: Index): Future[Either[Route, Work.Visible[Indexed]]]
}
```

The second class in particular means we get all the nice handling of work state for "free" in the items API. Next step is to plumb this class into the items API, but I'm going for lunch first.