### PR TITLE
Add an Elasticsearch error hierarchy/tidy up type signatures

### DIFF
--- a/common/search/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ElasticsearchErrorHandler.scala
+++ b/common/search/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ElasticsearchErrorHandler.scala
@@ -34,10 +34,10 @@ object ElasticsearchErrorHandler extends Logging {
           description = s"$documentType not found for identifier $id"
         )
 
-      case IndexNotFoundError(e) =>
-        notFound(s"There is no index ${e.index}", e)
+      case e: IndexNotFoundError =>
+        notFound(s"There is no index ${e.index}", e.elasticError)
 
-      case SearchPhaseExecutionError(e) =>
+      case e: SearchPhaseExecutionError =>
         // This may occur if the user requests an overly large page of results.
         // We return this as a 400 error to the user.
         resultSizePattern.findFirstMatchIn(e.reason) match {
@@ -47,10 +47,10 @@ object ElasticsearchErrorHandler extends Logging {
               s"Only the first $size works are available in the API. " +
                 "If you want more works, you can download a snapshot of the complete catalogue: " +
                 "https://developers.wellcomecollection.org/datasets",
-              e
+              e.elasticError
             )
           case _ =>
-            serverError(s"Unknown error in search phase execution: ${e.reason}", e)
+            serverError(s"Unknown error in search phase execution: ${e.reason}", e.elasticError)
         }
 
       // Anything else should bubble up as a 500, as it's at least somewhat

--- a/common/search/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ElasticsearchErrorHandler.scala
+++ b/common/search/src/main/scala/uk/ac/wellcome/platform/api/elasticsearch/ElasticsearchErrorHandler.scala
@@ -26,7 +26,8 @@ object ElasticsearchErrorHandler extends Logging {
   private val resultSizePattern =
     """Result window is too large, from \+ size must be less than or equal to: \[([0-9]+)\]""".r.unanchored
 
-  def buildDisplayError(documentType: String, e: ElasticsearchError): DisplayError =
+  def buildDisplayError(documentType: String,
+                        e: ElasticsearchError): DisplayError =
     e match {
       case DocumentNotFoundError(id) =>
         DisplayError(
@@ -50,7 +51,9 @@ object ElasticsearchErrorHandler extends Logging {
               e.elasticError
             )
           case _ =>
-            serverError(s"Unknown error in search phase execution: ${e.reason}", e.elasticError)
+            serverError(
+              s"Unknown error in search phase execution: ${e.reason}",
+              e.elasticError)
         }
 
       // Anything else should bubble up as a 500, as it's at least somewhat

--- a/common/search/src/main/scala/uk/ac/wellcome/platform/api/rest/CustomDirectives.scala
+++ b/common/search/src/main/scala/uk/ac/wellcome/platform/api/rest/CustomDirectives.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.api.rest
 
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.server.{Directive, Route}
-import com.sksamuel.elastic4s.ElasticError
 import uk.ac.wellcome.platform.api.elasticsearch.ElasticsearchErrorHandler
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import weco.api.search.elasticsearch.ElasticsearchError
@@ -43,11 +42,6 @@ trait CustomDirectives extends FutureDirectives {
       case ApiConfig(scheme, host, rootPath, contextPath, _) =>
         s"$scheme://$host$rootPath/$contextPath"
     }
-
-  def elasticError(err: ElasticError): Route =
-    error(
-      ElasticsearchErrorHandler.buildDisplayError(err)
-    )
 
   def elasticError(documentType: String, err: ElasticsearchError): Route =
     error(

--- a/common/search/src/main/scala/uk/ac/wellcome/platform/api/rest/CustomDirectives.scala
+++ b/common/search/src/main/scala/uk/ac/wellcome/platform/api/rest/CustomDirectives.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.server.{Directive, Route}
 import com.sksamuel.elastic4s.ElasticError
 import uk.ac.wellcome.platform.api.elasticsearch.ElasticsearchErrorHandler
 import uk.ac.wellcome.platform.api.models.ApiConfig
+import weco.api.search.elasticsearch.ElasticsearchError
 import weco.http.FutureDirectives
 import weco.http.models.{ContextResponse, DisplayError}
 
@@ -46,6 +47,11 @@ trait CustomDirectives extends FutureDirectives {
   def elasticError(err: ElasticError): Route =
     error(
       ElasticsearchErrorHandler.buildDisplayError(err)
+    )
+
+  def elasticError(documentType: String, err: ElasticsearchError): Route =
+    error(
+      ElasticsearchErrorHandler.buildDisplayError(documentType, err)
     )
 
   private def error(err: DisplayError): Route = {

--- a/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchError.scala
+++ b/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchError.scala
@@ -1,0 +1,28 @@
+package weco.api.search.elasticsearch
+
+import com.sksamuel.elastic4s.ElasticError
+
+sealed trait ElasticsearchError
+
+case object ElasticsearchError {
+  def apply(e: ElasticError): ElasticsearchError =
+    e.`type` match {
+      case "index_not_found_exception" => IndexNotFoundError(e)
+
+      case "search_phase_execution_exception" => SearchPhaseExecutionError(e)
+
+      case _ => UnknownError(e)
+    }
+}
+
+case class DocumentNotFoundError[Id](id: Id) extends ElasticsearchError
+
+case class IndexNotFoundError(e: ElasticError) extends ElasticsearchError {
+  def index: String = e.index.get
+}
+
+case class SearchPhaseExecutionError(e: ElasticError) extends ElasticsearchError {
+  def reason: String = e.rootCause.mkString("; ")
+}
+
+case class UnknownError(e: ElasticError) extends ElasticsearchError

--- a/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchError.scala
+++ b/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchError.scala
@@ -17,11 +17,13 @@ case object ElasticsearchError {
 
 case class DocumentNotFoundError[Id](id: Id) extends ElasticsearchError
 
-case class IndexNotFoundError(elasticError: ElasticError) extends ElasticsearchError {
+case class IndexNotFoundError(elasticError: ElasticError)
+    extends ElasticsearchError {
   def index: String = elasticError.index.get
 }
 
-case class SearchPhaseExecutionError(elasticError: ElasticError) extends ElasticsearchError {
+case class SearchPhaseExecutionError(elasticError: ElasticError)
+    extends ElasticsearchError {
   def reason: String = elasticError.rootCause.mkString("; ")
 }
 

--- a/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchError.scala
+++ b/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchError.scala
@@ -17,12 +17,12 @@ case object ElasticsearchError {
 
 case class DocumentNotFoundError[Id](id: Id) extends ElasticsearchError
 
-case class IndexNotFoundError(e: ElasticError) extends ElasticsearchError {
-  def index: String = e.index.get
+case class IndexNotFoundError(elasticError: ElasticError) extends ElasticsearchError {
+  def index: String = elasticError.index.get
 }
 
-case class SearchPhaseExecutionError(e: ElasticError) extends ElasticsearchError {
-  def reason: String = e.rootCause.mkString("; ")
+case class SearchPhaseExecutionError(elasticError: ElasticError) extends ElasticsearchError {
+  def reason: String = elasticError.rootCause.mkString("; ")
 }
 
 case class UnknownError(e: ElasticError) extends ElasticsearchError

--- a/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala
+++ b/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala
@@ -24,7 +24,7 @@ class ElasticsearchService(elasticClient: ElasticClient)(
     with Tracing {
 
   def findById[T](id: CanonicalId)(index: Index)(
-    implicit decoder: Decoder[T]): Future[Either[ElasticsearchError, Option[T]]] =
+    implicit decoder: Decoder[T]): Future[Either[ElasticsearchError, T]] =
     for {
       response: Response[GetResponse] <- withActiveTrace(elasticClient.execute {
         get(index, id.underlying)

--- a/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala
+++ b/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala
@@ -4,12 +4,7 @@ import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.circe._
 import com.sksamuel.elastic4s.requests.get.GetResponse
 import com.sksamuel.elastic4s.requests.searches.{SearchRequest, SearchResponse}
-import com.sksamuel.elastic4s.{
-  ElasticClient,
-  Hit,
-  Index,
-  Response
-}
+import com.sksamuel.elastic4s.{ElasticClient, Hit, Index, Response}
 import grizzled.slf4j.Logging
 import io.circe.Decoder
 import uk.ac.wellcome.Tracing
@@ -52,8 +47,8 @@ class ElasticsearchService(elasticClient: ElasticClient)(
       }
     } yield results
 
-  def executeSearchRequest(
-    request: SearchRequest): Future[Either[ElasticsearchError, SearchResponse]] =
+  def executeSearchRequest(request: SearchRequest)
+    : Future[Either[ElasticsearchError, SearchResponse]] =
     spanFuture(
       name = "ElasticSearch#executeSearchRequest",
       spanType = "request",

--- a/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
@@ -52,7 +52,7 @@ class ItemLookup(elasticsearchService: ElasticsearchService)(
 
         item match {
           case Some(it) => Right(it)
-          case None => Left(DocumentNotFoundError(itemId))
+          case None     => Left(DocumentNotFoundError(itemId))
         }
     }
   }
@@ -91,7 +91,7 @@ class ItemLookup(elasticsearchService: ElasticsearchService)(
 
         item match {
           case Some(it) => Right(it)
-          case None => Left(DocumentNotFoundError(sourceIdentifier))
+          case None     => Left(DocumentNotFoundError(sourceIdentifier))
         }
     }
   }

--- a/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
@@ -1,9 +1,13 @@
 package weco.api.stacks.services
 
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.{ElasticError, Index}
+import com.sksamuel.elastic4s.Index
 import uk.ac.wellcome.models.Implicits._
-import weco.api.search.elasticsearch.ElasticsearchService
+import weco.api.search.elasticsearch.{
+  DocumentNotFoundError,
+  ElasticsearchError,
+  ElasticsearchService
+}
 import weco.catalogue.internal_model.identifiers.{
   CanonicalId,
   IdState,
@@ -23,7 +27,7 @@ class ItemLookup(elasticsearchService: ElasticsearchService)(
     *
     */
   def byCanonicalId(itemId: CanonicalId)(
-    index: Index): Future[Either[ElasticError, Option[SourceIdentifier]]] = {
+    index: Index): Future[Either[ElasticsearchError, SourceIdentifier]] = {
     val searchRequest =
       search(index)
         .query(
@@ -37,7 +41,7 @@ class ItemLookup(elasticsearchService: ElasticsearchService)(
     elasticsearchService.findBySearch[Work[Indexed]](searchRequest).map {
       case Left(err) => Left(err)
       case Right(works) =>
-        Right(
+        val item =
           works
             .flatMap { _.data.items }
             .collectFirst {
@@ -45,7 +49,11 @@ class ItemLookup(elasticsearchService: ElasticsearchService)(
                   if id == itemId =>
                 sourceIdentifier
             }
-        )
+
+        item match {
+          case Some(it) => Right(it)
+          case None => Left(DocumentNotFoundError(itemId))
+        }
     }
   }
 
@@ -53,7 +61,7 @@ class ItemLookup(elasticsearchService: ElasticsearchService)(
     *
     */
   def bySourceIdentifier(sourceIdentifier: SourceIdentifier)(
-    index: Index): Future[Either[ElasticError, Option[CanonicalId]]] = {
+    index: Index): Future[Either[ElasticsearchError, CanonicalId]] = {
     // TODO: What if we get something with the right value but wrong type?
     // We should be able to filter by ontologyType and IdentifierType.
     val searchRequest =
@@ -72,7 +80,7 @@ class ItemLookup(elasticsearchService: ElasticsearchService)(
     elasticsearchService.findBySearch[Work[Indexed]](searchRequest).map {
       case Left(err) => Left(err)
       case Right(works) =>
-        Right(
+        val item =
           works
             .flatMap { _.data.items }
             .collectFirst {
@@ -80,7 +88,11 @@ class ItemLookup(elasticsearchService: ElasticsearchService)(
                   if id.sourceIdentifier == sourceIdentifier =>
                 id.canonicalId
             }
-        )
+
+        item match {
+          case Some(it) => Right(it)
+          case None => Left(DocumentNotFoundError(sourceIdentifier))
+        }
     }
   }
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/services/WorkLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/WorkLookup.scala
@@ -1,8 +1,8 @@
 package weco.api.stacks.services
 
-import com.sksamuel.elastic4s.{ElasticError, Index}
+import com.sksamuel.elastic4s.Index
 import uk.ac.wellcome.models.Implicits._
-import weco.api.search.elasticsearch.ElasticsearchService
+import weco.api.search.elasticsearch.{ElasticsearchError, ElasticsearchService}
 import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.internal_model.work.WorkState.Indexed
@@ -15,6 +15,6 @@ class WorkLookup(elasticsearchService: ElasticsearchService) {
     *
     */
   def byCanonicalId(id: CanonicalId)(
-    index: Index): Future[Either[ElasticError, Option[Work[Indexed]]]] =
+    index: Index): Future[Either[ElasticsearchError, Option[Work[Indexed]]]] =
     elasticsearchService.findById[Work[Indexed]](id)(index)
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/services/WorkLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/WorkLookup.scala
@@ -15,6 +15,6 @@ class WorkLookup(elasticsearchService: ElasticsearchService) {
     *
     */
   def byCanonicalId(id: CanonicalId)(
-    index: Index): Future[Either[ElasticsearchError, Option[Work[Indexed]]]] =
+    index: Index): Future[Either[ElasticsearchError, Work[Indexed]]] =
     elasticsearchService.findById[Work[Indexed]](id)(index)
 }

--- a/common/stacks/src/test/scala/weco/api/stacks/services/ItemLookupTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/services/ItemLookupTest.scala
@@ -197,7 +197,8 @@ class ItemLookupTest
       }
     }
 
-    it("returns a DocumentNotFoundError if there is no visible work with this item") {
+    it(
+      "returns a DocumentNotFoundError if there is no visible work with this item") {
       val item = createIdentifiedItem
 
       val workInvisible = indexedWork().items(List(item)).invisible()

--- a/common/stacks/src/test/scala/weco/api/stacks/services/ItemLookupTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/services/ItemLookupTest.scala
@@ -1,16 +1,19 @@
 package weco.api.stacks.services
 
-import com.sksamuel.elastic4s.ElasticError
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.index.IndexFixtures
 import uk.ac.wellcome.models.work.generators.{ItemsGenerators, WorkGenerators}
-import weco.api.search.elasticsearch.ElasticsearchService
 import weco.catalogue.internal_model.identifiers.IdentifierType.{
   MiroImageNumber,
   SierraSystemNumber
+}
+import weco.api.search.elasticsearch.{
+  DocumentNotFoundError,
+  ElasticsearchService,
+  IndexNotFoundError
 }
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -38,32 +41,24 @@ class ItemLookupTest
       withLocalWorksIndex { index =>
         insertIntoElasticsearch(index, workA, workB)
 
-        val future1 = lookup.byCanonicalId(item1.id.canonicalId)(index)
+        Seq(item1, item2, item3).foreach { it =>
+          val future =
+            lookup.bySourceIdentifier(it.id.sourceIdentifier)(index)
 
-        whenReady(future1) {
-          _ shouldBe Right(Some(item1.id.sourceIdentifier))
-        }
-
-        val future2 = lookup.byCanonicalId(item2.id.canonicalId)(index)
-
-        whenReady(future2) {
-          _ shouldBe Right(Some(item2.id.sourceIdentifier))
-        }
-
-        val future3 = lookup.byCanonicalId(item3.id.canonicalId)(index)
-
-        whenReady(future3) {
-          _ shouldBe Right(Some(item3.id.sourceIdentifier))
+          whenReady(future) {
+            _ shouldBe Right(it.id.canonicalId)
+          }
         }
       }
     }
 
-    it("returns None if there is no such work") {
+    it("returns a DocumentNotFoundError if there is no such work") {
       withLocalWorksIndex { index =>
-        val future = lookup.byCanonicalId(createCanonicalId)(index)
+        val id = createCanonicalId
+        val future = lookup.byCanonicalId(id)(index)
 
         whenReady(future) {
-          _ shouldBe Right(None)
+          _ shouldBe Left(DocumentNotFoundError(id))
         }
       }
     }
@@ -82,7 +77,7 @@ class ItemLookupTest
         val future1 = lookup.byCanonicalId(item.id.canonicalId)(index)
 
         whenReady(future1) {
-          _ shouldBe Right(None)
+          _ shouldBe Left(DocumentNotFoundError(item.id.canonicalId))
         }
 
         // Then we index both works and run the same query, so we know the
@@ -92,7 +87,7 @@ class ItemLookupTest
         val future2 = lookup.byCanonicalId(item.id.canonicalId)(index)
 
         whenReady(future2) {
-          _ shouldBe Right(Some(item.id.sourceIdentifier))
+          _ shouldBe Right(item.id.sourceIdentifier)
         }
       }
     }
@@ -101,7 +96,7 @@ class ItemLookupTest
       val future = lookup.byCanonicalId(createCanonicalId)(createIndex)
 
       whenReady(future) {
-        _.left.value shouldBe a[ElasticError]
+        _.left.value shouldBe a[IndexNotFoundError]
       }
     }
   }
@@ -118,25 +113,13 @@ class ItemLookupTest
       withLocalWorksIndex { index =>
         insertIntoElasticsearch(index, workA, workB)
 
-        val future1 =
-          lookup.bySourceIdentifier(item1.id.sourceIdentifier)(index)
+        Seq(item1, item2, item3).foreach { it =>
+          val future =
+            lookup.bySourceIdentifier(it.id.sourceIdentifier)(index)
 
-        whenReady(future1) {
-          _ shouldBe Right(Some(item1.id.canonicalId))
-        }
-
-        val future2 =
-          lookup.bySourceIdentifier(item2.id.sourceIdentifier)(index)
-
-        whenReady(future2) {
-          _ shouldBe Right(Some(item2.id.canonicalId))
-        }
-
-        val future3 =
-          lookup.bySourceIdentifier(item3.id.sourceIdentifier)(index)
-
-        whenReady(future3) {
-          _ shouldBe Right(Some(item3.id.canonicalId))
+          whenReady(future) {
+            _ shouldBe Right(it.id.canonicalId)
+          }
         }
       }
     }
@@ -192,28 +175,29 @@ class ItemLookupTest
 
         List(item1, item2, item3).foreach { it =>
           whenReady(lookup.bySourceIdentifier(it.id.sourceIdentifier)(index)) {
-            _ shouldBe Right(Some(it.id.canonicalId))
+            _ shouldBe Right(it.id.canonicalId)
           }
 
           whenReady(
             lookup.bySourceIdentifier(it.id.otherIdentifiers.head)(index)) {
-            _ shouldBe Right(None)
+            _.left.value shouldBe a[DocumentNotFoundError[_]]
           }
         }
       }
     }
 
-    it("returns None if there is no such item") {
+    it("returns a DocumentNotFoundError if there is no such item") {
       withLocalWorksIndex { index =>
-        val future = lookup.bySourceIdentifier(createSourceIdentifier)(index)
+        val id = createSourceIdentifier
+        val future = lookup.bySourceIdentifier(id)(index)
 
         whenReady(future) {
-          _ shouldBe Right(None)
+          _ shouldBe Left(DocumentNotFoundError(id))
         }
       }
     }
 
-    it("returns None if there is no visible work with this item") {
+    it("returns a DocumentNotFoundError if there is no visible work with this item") {
       val item = createIdentifiedItem
 
       val workInvisible = indexedWork().items(List(item)).invisible()
@@ -227,7 +211,7 @@ class ItemLookupTest
         val future1 = lookup.bySourceIdentifier(item.id.sourceIdentifier)(index)
 
         whenReady(future1) {
-          _ shouldBe Right(None)
+          _ shouldBe Left(DocumentNotFoundError(item.id.sourceIdentifier))
         }
 
         // Then we index both works and run the same query, so we know the
@@ -237,7 +221,7 @@ class ItemLookupTest
         val future2 = lookup.bySourceIdentifier(item.id.sourceIdentifier)(index)
 
         whenReady(future2) {
-          _ shouldBe Right(Some(item.id.canonicalId))
+          _ shouldBe Right(item.id.canonicalId)
         }
       }
     }
@@ -247,7 +231,7 @@ class ItemLookupTest
         lookup.bySourceIdentifier(createSourceIdentifier)(createIndex)
 
       whenReady(future) {
-        _.left.value shouldBe a[ElasticError]
+        _.left.value shouldBe a[IndexNotFoundError]
       }
     }
   }

--- a/common/stacks/src/test/scala/weco/api/stacks/services/ItemLookupTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/services/ItemLookupTest.scala
@@ -150,7 +150,7 @@ class ItemLookupTest
           val future = lookup.bySourceIdentifier(it.id.sourceIdentifier)(index)
 
           whenReady(future) {
-            _ shouldBe Right(Some(it.id.canonicalId))
+            _ shouldBe Right(it.id.canonicalId)
           }
         }
       }

--- a/common/stacks/src/test/scala/weco/api/stacks/services/WorkLookupTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/services/WorkLookupTest.scala
@@ -1,13 +1,16 @@
 package weco.api.stacks.services
 
-import com.sksamuel.elastic4s.ElasticError
 import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.index.IndexFixtures
 import uk.ac.wellcome.models.work.generators.WorkGenerators
-import weco.api.search.elasticsearch.{DocumentNotFoundError, ElasticsearchService, IndexNotFoundError}
+import weco.api.search.elasticsearch.{
+  DocumentNotFoundError,
+  ElasticsearchService,
+  IndexNotFoundError
+}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 

--- a/common/stacks/src/test/scala/weco/api/stacks/services/WorkLookupTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/services/WorkLookupTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.index.IndexFixtures
 import uk.ac.wellcome.models.work.generators.WorkGenerators
-import weco.api.search.elasticsearch.ElasticsearchService
+import weco.api.search.elasticsearch.{DocumentNotFoundError, ElasticsearchService, IndexNotFoundError}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -30,26 +30,29 @@ class WorkLookupTest
       val future = lookup.byCanonicalId(work.state.canonicalId)(index)
 
       whenReady(future) {
-        _ shouldBe Right(Some(work))
+        _ shouldBe Right(work)
       }
     }
   }
 
   it("returns None if there is no such work") {
     withLocalWorksIndex { index =>
-      val future = lookup.byCanonicalId(createCanonicalId)(index)
+      val id = createCanonicalId
+      val future = lookup.byCanonicalId(id)(index)
 
       whenReady(future) {
-        _ shouldBe Right(None)
+        _ shouldBe Left(DocumentNotFoundError(id))
       }
     }
   }
 
   it("returns Left[ElasticError] if Elasticsearch has an error") {
-    val future = lookup.byCanonicalId(createCanonicalId)(createIndex)
+    val index = createIndex
+    val future = lookup.byCanonicalId(createCanonicalId)(index)
 
-    whenReady(future) {
-      _.left.value shouldBe a[ElasticError]
+    whenReady(future) { err =>
+      err.left.value shouldBe a[IndexNotFoundError]
+      err.left.value.asInstanceOf[IndexNotFoundError].index shouldBe index.name
     }
   }
 }

--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/rest/ImagesController.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/rest/ImagesController.scala
@@ -82,7 +82,7 @@ class ImagesController(elasticsearchService: ElasticsearchService,
           imagesService
             .listOrSearch(index, searchOptions)
             .map {
-              case Left(err) => elasticError(err)
+              case Left(err) => elasticError("Image", err)
               case Right(resultList) =>
                 extractPublicUri { uri =>
                   complete(

--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/rest/ImagesController.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/rest/ImagesController.scala
@@ -39,7 +39,7 @@ class ImagesController(elasticsearchService: ElasticsearchService,
           imagesService
             .findById(id)(index)
             .flatMap {
-              case Right(Some(image)) =>
+              case Right(image) =>
                 getSimilarityMetrics(params.include)
                   .traverse { metric =>
                     imagesService
@@ -65,10 +65,8 @@ class ImagesController(elasticsearchService: ElasticsearchService,
                       )
                     )
                   }
-              case Right(None) =>
-                Future.successful(
-                  notFound(s"Image not found for identifier $id"))
-              case Left(err) => Future.successful(elasticError(err))
+
+              case Left(err) => Future.successful(elasticError("Image", err))
             }
         }
       }

--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/rest/WorksController.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/rest/WorksController.scala
@@ -66,17 +66,15 @@ class WorksController(
           worksService
             .findById(id)(index)
             .map {
-              case Right(Some(work: Work.Visible[Indexed])) =>
+              case Right(work: Work.Visible[Indexed]) =>
                 workFound(work, includes)
-              case Right(Some(work: Work.Redirected[Indexed])) =>
+              case Right(work: Work.Redirected[Indexed]) =>
                 workRedirect(work)
-              case Right(Some(_: Work.Invisible[Indexed])) =>
+              case Right(_: Work.Invisible[Indexed]) =>
                 gone("This work has been deleted")
-              case Right(Some(_: Work.Deleted[Indexed])) =>
+              case Right(_: Work.Deleted[Indexed]) =>
                 gone("This work has been deleted")
-              case Right(None) =>
-                notFound(s"Work not found for identifier $id")
-              case Left(err) => elasticError(err)
+              case Left(err) => elasticError("Work", err)
             }
         }
       }

--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/rest/WorksController.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/rest/WorksController.scala
@@ -36,7 +36,7 @@ class WorksController(
           worksService
             .listOrSearch(index, searchOptions)
             .map {
-              case Left(err) => elasticError(err)
+              case Left(err) => elasticError("Image", err)
               case Right(resultList) =>
                 extractPublicUri { requestUri =>
                   complete(

--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/services/SearchService.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/services/SearchService.scala
@@ -7,7 +7,7 @@ import com.sksamuel.elastic4s.requests.searches.SearchResponse
 import io.circe.Decoder
 import uk.ac.wellcome.Tracing
 import uk.ac.wellcome.platform.api.search.models.{ResultList, SearchOptions}
-import weco.api.search.elasticsearch.ElasticsearchService
+import weco.api.search.elasticsearch.{ElasticsearchError, ElasticsearchService}
 import weco.catalogue.internal_model.identifiers.CanonicalId
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -24,7 +24,7 @@ trait SearchService[T, VisibleT, Aggs, S <: SearchOptions[_, _, _]] {
   protected def createAggregations(searchResponse: SearchResponse): Option[Aggs]
 
   def findById(id: CanonicalId)(
-    index: Index): Future[Either[ElasticError, Option[T]]] =
+    index: Index): Future[Either[ElasticsearchError, T]] =
     elasticsearchService.findById[T](id)(index)
 
   def listOrSearch(index: Index, searchOptions: S)

--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/services/SearchService.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/services/SearchService.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.api.search.services
 
 import co.elastic.apm.api.Transaction
-import com.sksamuel.elastic4s.{ElasticError, Hit, Index}
+import com.sksamuel.elastic4s.{Hit, Index}
 import com.sksamuel.elastic4s.circe._
 import com.sksamuel.elastic4s.requests.searches.SearchResponse
 import io.circe.Decoder
@@ -28,7 +28,7 @@ trait SearchService[T, VisibleT, Aggs, S <: SearchOptions[_, _, _]] {
     elasticsearchService.findById[T](id)(index)
 
   def listOrSearch(index: Index, searchOptions: S)
-    : Future[Either[ElasticError, ResultList[VisibleT, Aggs]]] =
+    : Future[Either[ElasticsearchError, ResultList[VisibleT, Aggs]]] =
     executeSearch(searchOptions, index)
       .map { _.map(createResultList) }
 
@@ -56,7 +56,7 @@ trait SearchService[T, VisibleT, Aggs, S <: SearchOptions[_, _, _]] {
     */
   private def executeSearch(
     searchOptions: S,
-    index: Index): Future[Either[ElasticError, SearchResponse]] = {
+    index: Index): Future[Either[ElasticsearchError, SearchResponse]] = {
     val searchRequest = requestBuilder
       .request(searchOptions, index)
       .trackTotalHits(true)

--- a/search/src/test/scala/uk/ac/wellcome/platform/api/search/services/ImagesServiceTest.scala
+++ b/search/src/test/scala/uk/ac/wellcome/platform/api/search/services/ImagesServiceTest.scala
@@ -64,7 +64,9 @@ class ImagesServiceTest
 
       whenReady(future) { err =>
         err.left.value shouldBe a[IndexNotFoundError]
-        err.left.value.asInstanceOf[IndexNotFoundError].index shouldBe index.name
+        err.left.value
+          .asInstanceOf[IndexNotFoundError]
+          .index shouldBe index.name
       }
     }
   }

--- a/search/src/test/scala/uk/ac/wellcome/platform/api/search/services/ImagesServiceTest.scala
+++ b/search/src/test/scala/uk/ac/wellcome/platform/api/search/services/ImagesServiceTest.scala
@@ -47,7 +47,7 @@ class ImagesServiceTest
       }
     }
 
-    it("returns a None if no image can be found") {
+    it("returns a DocumentNotFoundError if no image can be found") {
       withLocalImagesIndex { index =>
         val id = createCanonicalId
         val future = imagesService.findById(id)(index)
@@ -58,7 +58,7 @@ class ImagesServiceTest
       }
     }
 
-    it("returns a Left[ElasticError] if Elasticsearch returns an error") {
+    it("returns an ElasticsearchError if Elasticsearch returns an error") {
       val index = createIndex
       val future = imagesService.findById(createCanonicalId)(index)
 

--- a/search/src/test/scala/uk/ac/wellcome/platform/api/search/services/WorksServiceTest.scala
+++ b/search/src/test/scala/uk/ac/wellcome/platform/api/search/services/WorksServiceTest.scala
@@ -493,7 +493,7 @@ class WorksServiceTest
 
     }
 
-    it("returns a future of None if it cannot get a record by id") {
+    it("returns a DocumentNotFoundError if there is no work") {
       withLocalWorksIndex { index =>
         val id = createCanonicalId
         val future = worksService.findById(id = id)(index)
@@ -504,7 +504,7 @@ class WorksServiceTest
       }
     }
 
-    it("returns a Left[ElasticError] if there's an Elasticsearch error") {
+    it("returns an ElasticsearchError if there's an Elasticsearch error") {
       val index = createIndex
       val future = worksService.findById(id = createCanonicalId)(index)
 

--- a/search/src/test/scala/uk/ac/wellcome/platform/api/search/services/WorksServiceTest.scala
+++ b/search/src/test/scala/uk/ac/wellcome/platform/api/search/services/WorksServiceTest.scala
@@ -132,7 +132,9 @@ class WorksServiceTest
 
       whenReady(future) { err =>
         err.left.value shouldBe a[IndexNotFoundError]
-        err.left.value.asInstanceOf[IndexNotFoundError].index shouldBe index.name
+        err.left.value
+          .asInstanceOf[IndexNotFoundError]
+          .index shouldBe index.name
       }
     }
 
@@ -510,7 +512,9 @@ class WorksServiceTest
 
       whenReady(future) { err =>
         err.left.value shouldBe a[IndexNotFoundError]
-        err.left.value.asInstanceOf[IndexNotFoundError].index shouldBe index.name
+        err.left.value
+          .asInstanceOf[IndexNotFoundError]
+          .index shouldBe index.name
       }
     }
   }


### PR DESCRIPTION
Follows #51, something I noticed while working on #50

The type signatures for methods that query Elasticsearch are… unwieldy. We hit all three of the classic monads:

```
def f(in: In): Future[Either[ElasticError, Option[T]]]
```

The `Option[T]` is there to distinguish "did we look up a thing that exists" – because elastic4s will return a "successful" GetResponse even if there isn't a document behind it.

This patch introduces our own hierarchy of error types for the Left, so we get the slightly nicer signature:

```
def f(in: In): Future[Either[ElasticsearchError, T]]
```

and that left can be carried all the way through the stack, rather than having to be handled separately at each stage.

I suspect this will be particularly nicer in the stacks-related code, where we'll get an Elasticsearch response and then do additional processing, not just return it straight to the user.