### PR TITLE
Query Elasticsearch when placing holds on items

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ STACK_ROOT 	= .
 
 PROJECT_ID = catalogue_api
 
-SBT_APPS = search items
-SBT_NO_DOCKER_APPS = requests
+SBT_APPS = search items requests
+SBT_NO_DOCKER_APPS =
 
 SBT_DOCKER_LIBRARIES    = stacks
 SBT_NO_DOCKER_LIBRARIES = display  search_common

--- a/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/CatalogueService.scala
+++ b/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/CatalogueService.scala
@@ -78,30 +78,4 @@ class CatalogueService(
             s"Found multiple matching items for $identifier in: $distinctFilteredItems"
           )
       }
-
-  def getStacksItemFromItemId(
-    itemId: CanonicalId
-  ): Future[Option[StacksItemIdentifier]] =
-    for {
-      searchStub <- catalogueSource.getSearchStub(itemId)
-
-      items = searchStub.results
-        .map(_.items)
-        .flatMap(getStacksItems)
-
-      // Ensure we are only matching items that match the passed id!
-      filteredItems = items.filter(_.canonicalId == itemId)
-
-      // Items can appear on multiple works in a search result
-      distinctFilteredItems = filteredItems.distinct
-
-    } yield
-      distinctFilteredItems match {
-        case List(item) => Some(item)
-        case Nil        => None
-        case _ =>
-          throw new Exception(
-            s"Found multiple matching items for $itemId in: $distinctFilteredItems"
-          )
-      }
 }

--- a/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/SierraService.scala
+++ b/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/SierraService.scala
@@ -31,7 +31,8 @@ class SierraService(
     (sourceIdentifier.identifierType == IdentifierType.SierraSystemNumber) &&
       (sourceIdentifier.ontologyType == "Item")
 
-  def getItemStatus(sourceIdentifier: SourceIdentifier): Future[StacksItemStatus] = {
+  def getItemStatus(
+    sourceIdentifier: SourceIdentifier): Future[StacksItemStatus] = {
     require(isSierraItemId(sourceIdentifier))
 
     val itemNumber = SierraItemNumber(sourceIdentifier.value)

--- a/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/SierraService.scala
+++ b/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/SierraService.scala
@@ -27,10 +27,14 @@ class SierraService(
 
   import SierraSource._
 
-  def getItemStatus(sierraId: SourceIdentifier): Future[StacksItemStatus] = {
-    require(sierraId.identifierType == IdentifierType.SierraSystemNumber)
+  private def isSierraItemId(sourceIdentifier: SourceIdentifier): Boolean =
+    (sourceIdentifier.identifierType == IdentifierType.SierraSystemNumber) &&
+      (sourceIdentifier.ontologyType == "Item")
 
-    val itemNumber = SierraItemNumber(sierraId.value)
+  def getItemStatus(sourceIdentifier: SourceIdentifier): Future[StacksItemStatus] = {
+    require(isSierraItemId(sourceIdentifier))
+
+    val itemNumber = SierraItemNumber(sourceIdentifier.value)
 
     sierraSource
       .getSierraItemStub(itemNumber)
@@ -39,15 +43,13 @@ class SierraService(
 
   def placeHold(
     userIdentifier: StacksUserIdentifier,
-    sierraItemIdentifier: SierraItemIdentifier,
-    neededBy: Option[Instant]
-  ): Future[HoldResponse] =
-    sierraSource
-      .postHold(
-        userIdentifier,
-        sierraItemIdentifier,
-        neededBy
-      ) map {
+    sourceIdentifier: SourceIdentifier
+  ): Future[HoldResponse] = {
+    require(isSierraItemId(sourceIdentifier))
+
+    val itemNumber = SierraItemNumber(sourceIdentifier.value)
+
+    sierraSource.postHold(userIdentifier, itemNumber) map {
       // This is an "XCirc/Record not available" error
       // See https://techdocs.iii.com/sierraapi/Content/zReference/errorHandling.htm
       case Left(SierraErrorCode(132, 2, 500, _, _)) => HoldRejected()
@@ -58,6 +60,7 @@ class SierraService(
 
       case Right(_) => HoldAccepted()
     }
+  }
 
   protected def buildStacksHold(
     entry: SierraUserHoldsEntryStub

--- a/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/StacksService.scala
+++ b/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/StacksService.scala
@@ -1,12 +1,10 @@
 package uk.ac.wellcome.platform.api.common.services
 
-import java.time.Instant
 import cats.instances.future._
 import cats.instances.list._
 import cats.syntax.traverse._
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.api.common.models._
-import weco.catalogue.internal_model.identifiers.CanonicalId
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -16,30 +14,6 @@ class StacksService(
 )(
   implicit ec: ExecutionContext
 ) extends Logging {
-
-  def requestHoldOnItem(
-    userIdentifier: StacksUserIdentifier,
-    itemId: CanonicalId,
-    neededBy: Option[Instant]
-  ): Future[HoldResponse] =
-    for {
-      stacksItem <- catalogueService.getStacksItemFromItemId(itemId)
-
-      response <- stacksItem match {
-        case Some(id) =>
-          sierraService.placeHold(
-            userIdentifier = userIdentifier,
-            sierraItemIdentifier = id.sierraId,
-            neededBy = neededBy
-          )
-        case None =>
-          Future.failed(
-            new Exception(f"Could not locate item $itemId!")
-          )
-      }
-
-    } yield response
-
   def getStacksUserHolds(
     userId: StacksUserIdentifier
   ): Future[StacksUserHolds] =

--- a/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/source/CatalogueSource.scala
+++ b/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/source/CatalogueSource.scala
@@ -5,14 +5,12 @@ import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.Uri.Path
 import uk.ac.wellcome.platform.api.common.models.Identifier
 import uk.ac.wellcome.platform.api.http.AkkaClientGet
-import weco.catalogue.internal_model.identifiers.CanonicalId
 
 import scala.concurrent.Future
 
 trait CatalogueSource {
   import CatalogueSource._
 
-  def getSearchStub(canonicalId: CanonicalId): Future[SearchStub]
   def getSearchStub(identifier: Identifier[_]): Future[SearchStub]
 }
 
@@ -64,19 +62,6 @@ class AkkaCatalogueSource(
       params = Map(
         ("include", "items,identifiers"),
         ("query", identifier.value.toString)
-      )
-    ) map {
-      case SuccessResponse(Some(workStub)) => workStub
-      case _                               => throw new Exception("Failed to make catalogue search!")
-    }
-
-  // See https://developers.wellcomecollection.org/catalogue/v2/works/getworks
-  def getSearchStub(canonicalId: CanonicalId): Future[SearchStub] =
-    get[SearchStub](
-      path = Path("works"),
-      params = Map(
-        ("include", "items,identifiers"),
-        ("query", canonicalId.toString)
       )
     ) map {
       case SuccessResponse(Some(workStub)) => workStub

--- a/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
@@ -3,8 +3,16 @@ package weco.api.stacks.services
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.{ElasticClient, Index}
 import uk.ac.wellcome.models.Implicits._
-import weco.api.search.elasticsearch.{DocumentNotFoundError, ElasticsearchError, ElasticsearchService}
-import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState, SourceIdentifier}
+import weco.api.search.elasticsearch.{
+  DocumentNotFoundError,
+  ElasticsearchError,
+  ElasticsearchService
+}
+import weco.catalogue.internal_model.identifiers.{
+  CanonicalId,
+  IdState,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.work.{Item, Work}
 import weco.catalogue.internal_model.work.WorkState.Indexed
 

--- a/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
@@ -1,18 +1,10 @@
 package weco.api.stacks.services
 
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.Index
+import com.sksamuel.elastic4s.{ElasticClient, Index}
 import uk.ac.wellcome.models.Implicits._
-import weco.api.search.elasticsearch.{
-  DocumentNotFoundError,
-  ElasticsearchError,
-  ElasticsearchService
-}
-import weco.catalogue.internal_model.identifiers.{
-  CanonicalId,
-  IdState,
-  SourceIdentifier
-}
+import weco.api.search.elasticsearch.{DocumentNotFoundError, ElasticsearchError, ElasticsearchService}
+import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState, SourceIdentifier}
 import weco.catalogue.internal_model.work.{Item, Work}
 import weco.catalogue.internal_model.work.WorkState.Indexed
 
@@ -95,4 +87,12 @@ class ItemLookup(elasticsearchService: ElasticsearchService)(
         }
     }
   }
+}
+
+object ItemLookup {
+  def apply(elasticClient: ElasticClient)(
+    implicit ec: ExecutionContext): ItemLookup =
+    new ItemLookup(
+      elasticsearchService = new ElasticsearchService(elasticClient)
+    )
 }

--- a/common/stacks/src/test/scala/uk/ac/wellcome/platform/api/common/fixtures/ServicesFixture.scala
+++ b/common/stacks/src/test/scala/uk/ac/wellcome/platform/api/common/fixtures/ServicesFixture.scala
@@ -51,7 +51,7 @@ trait ServicesFixture
   }
 
   def withStacksService[R](
-    testWith: TestWith[(StacksService, WireMockServer), R]
+    testWith: TestWith[(StacksService, SierraService, WireMockServer), R]
   ): R = {
     withCatalogueService { catalogueService =>
       withSierraService {
@@ -63,7 +63,7 @@ trait ServicesFixture
               new StacksService(catalogueService, sierraService)
 
             testWith(
-              (stacksService, sierraWiremockServer)
+              (stacksService, sierraService, sierraWiremockServer)
             )
           }
       }

--- a/common/stacks/src/test/scala/uk/ac/wellcome/platform/api/common/services/CatalogueServiceTest.scala
+++ b/common/stacks/src/test/scala/uk/ac/wellcome/platform/api/common/services/CatalogueServiceTest.scala
@@ -25,13 +25,6 @@ class CatalogueServiceTest
         Future.successful(
           SearchStub(totalResults = works.size, results = works.toList)
         )
-
-      override def getSearchStub(
-        canonicalId: CanonicalId
-      ): Future[SearchStub] =
-        Future.successful(
-          SearchStub(totalResults = works.size, results = works.toList)
-        )
     }
 
     it("returns an empty list if there are no matching works") {
@@ -40,55 +33,6 @@ class CatalogueServiceTest
 
       whenReady(service.getStacksItem(createStacksItemIdentifier)) {
         _ shouldBe None
-      }
-    }
-
-    it("gets an item from a work") {
-      val item = ItemStub(
-        id = Some(createStacksItemIdentifier.value),
-        identifiers = Some(List(createSierraIdentifier("1234567")))
-      )
-
-      val work = createWorkStubWith(items = List(item))
-
-      val catalogueSource = new MockCatalogueSource(work)
-      val service = new CatalogueService(catalogueSource)
-
-      whenReady(service.getStacksItemFromItemId(CanonicalId(item.id.get))) {
-        _ shouldBe Some(
-          StacksItemIdentifier(
-            canonicalId = CanonicalId(item.id.get),
-            sierraId = SierraItemIdentifier(1234567)
-          )
-        )
-      }
-    }
-
-    it("filters results by catalogue item identifier") {
-      val item1 = ItemStub(
-        id = Some(createStacksItemIdentifier.value),
-        identifiers = Some(List(createSierraIdentifier("1111111")))
-      )
-
-      val work1 = createWorkStubWith(items = List(item1))
-
-      val item2 = ItemStub(
-        id = Some(createStacksItemIdentifier.value),
-        identifiers = Some(List(createSierraIdentifier("2222222")))
-      )
-
-      val work2 = createWorkStubWith(items = List(item2))
-
-      val catalogueSource = new MockCatalogueSource(work1, work2)
-      val service = new CatalogueService(catalogueSource)
-
-      whenReady(service.getStacksItemFromItemId(CanonicalId(item1.id.get))) {
-        _ shouldBe Some(
-          StacksItemIdentifier(
-            canonicalId = CanonicalId(item1.id.get),
-            sierraId = SierraItemIdentifier(1111111)
-          )
-        )
       }
     }
 
@@ -174,11 +118,6 @@ class CatalogueServiceTest
     class BrokenCatalogueSource extends CatalogueSource {
       override def getSearchStub(
         identifier: Identifier[_]
-      ): Future[SearchStub] =
-        Future.failed(searchException)
-
-      override def getSearchStub(
-        canonicalId: CanonicalId
       ): Future[SearchStub] =
         Future.failed(searchException)
     }

--- a/common/stacks/src/test/scala/uk/ac/wellcome/platform/api/common/services/SierraServiceTest.scala
+++ b/common/stacks/src/test/scala/uk/ac/wellcome/platform/api/common/services/SierraServiceTest.scala
@@ -76,17 +76,17 @@ class SierraServiceTest
       it("requests a hold from the Sierra API") {
         withSierraService {
           case (sierraService, wireMockServer) =>
-            val sierraItemIdentifier = SierraItemIdentifier(1601017)
-            val stacksUserIdentifier = StacksUserIdentifier("1234567")
-            val neededBy = Some(
-              Instant.parse("2020-01-01T00:00:00.00Z")
+            val userIdentifier = StacksUserIdentifier(value = "1234567")
+            val sourceIdentifier = SourceIdentifier(
+              identifierType = SierraSystemNumber,
+              ontologyType = "Item",
+              value = "i16010176"
             )
 
             whenReady(
               sierraService.placeHold(
-                userIdentifier = stacksUserIdentifier,
-                sierraItemIdentifier = sierraItemIdentifier,
-                neededBy = neededBy
+                userIdentifier = userIdentifier,
+                sourceIdentifier = sourceIdentifier
               )
             ) { _ =>
               wireMockServer.verify(
@@ -100,8 +100,7 @@ class SierraServiceTest
                 |{
                 |  "recordType" : "i",
                 |  "recordNumber" : 1601017,
-                |  "pickupLocation" : "unspecified",
-                |  "neededBy" : "2020-01-01"
+                |  "pickupLocation" : "unspecified"
                 |}
                 |""".stripMargin)
                 )
@@ -113,14 +112,17 @@ class SierraServiceTest
       it("rejects a hold when the Sierra API errors indicating such") {
         withSierraService {
           case (sierraService, wireMockServer) =>
-            val sierraItemIdentifier = SierraItemIdentifier(1601018)
-            val stacksUserIdentifier = StacksUserIdentifier("1234567")
+            val userIdentifier = StacksUserIdentifier(value = "1234567")
+            val sourceIdentifier = SourceIdentifier(
+              identifierType = SierraSystemNumber,
+              ontologyType = "Item",
+              value = "i16010188"
+            )
 
             whenReady(
               sierraService.placeHold(
-                userIdentifier = stacksUserIdentifier,
-                sierraItemIdentifier = sierraItemIdentifier,
-                neededBy = None
+                userIdentifier = userIdentifier,
+                sourceIdentifier = sourceIdentifier,
               )
             ) { response =>
               wireMockServer.verify(

--- a/common/stacks/src/test/scala/uk/ac/wellcome/platform/api/common/services/StacksServiceTest.scala
+++ b/common/stacks/src/test/scala/uk/ac/wellcome/platform/api/common/services/StacksServiceTest.scala
@@ -2,11 +2,6 @@ package uk.ac.wellcome.platform.api.common.services
 
 import java.time.Instant
 
-import com.github.tomakehurst.wiremock.client.WireMock.{
-  equalToJson,
-  postRequestedFor,
-  urlEqualTo
-}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -22,86 +17,10 @@ class StacksServiceTest
     with Matchers {
 
   describe("StacksService") {
-    describe("requestHoldOnItem") {
-      it("requests a hold from the Sierra API") {
-        withStacksService {
-          case (stacksService, wireMockServer) =>
-            val stacksUserIdentifier = StacksUserIdentifier("1234567")
-            val canonicalId = CanonicalId("ys3ern6x")
-            val neededBy = Some(
-              Instant.parse("2020-01-01T00:00:00.00Z")
-            )
-
-            whenReady(
-              stacksService.requestHoldOnItem(
-                userIdentifier = stacksUserIdentifier,
-                itemId = canonicalId,
-                neededBy = neededBy
-              )
-            ) { response =>
-              response shouldBe a[HoldAccepted]
-
-              wireMockServer.verify(
-                1,
-                postRequestedFor(
-                  urlEqualTo(
-                    "/iii/sierra-api/v5/patrons/1234567/holds/requests"
-                  )
-                ).withRequestBody(
-                  equalToJson("""
-                      |{
-                      |  "recordType" : "i",
-                      |  "recordNumber" : 1601017,
-                      |  "pickupLocation" : "unspecified",
-                      |  "neededBy" : "2020-01-01"
-                      |}
-                      |""".stripMargin)
-                )
-              )
-            }
-        }
-      }
-
-      it("returns a rejected hold if Sierra does the same") {
-        withStacksService {
-          case (stacksService, wireMockServer) =>
-            val stacksUserIdentifier = StacksUserIdentifier("1234567")
-            val canonicalId = CanonicalId("ys3ern6y")
-
-            whenReady(
-              stacksService.requestHoldOnItem(
-                userIdentifier = stacksUserIdentifier,
-                itemId = canonicalId,
-                neededBy = None
-              )
-            ) { response =>
-              response shouldBe a[HoldRejected]
-
-              wireMockServer.verify(
-                1,
-                postRequestedFor(
-                  urlEqualTo(
-                    "/iii/sierra-api/v5/patrons/1234567/holds/requests"
-                  )
-                ).withRequestBody(
-                  equalToJson("""
-                                |{
-                                |  "recordType" : "i",
-                                |  "recordNumber" : 1601018,
-                                |  "pickupLocation" : "unspecified"
-                                |}
-                                |""".stripMargin)
-                )
-              )
-            }
-        }
-      }
-    }
-
     describe("getStacksUserHoldsWithStacksItemIdentifier") {
       it("gets a StacksUserHolds[StacksItemIdentifier]") {
         withStacksService {
-          case (stacksService, _) =>
+          case (stacksService, _, _) =>
             val stacksUserIdentifier = StacksUserIdentifier("1234567")
 
             whenReady(

--- a/common/stacks/src/test/scala/weco/api/stacks/services/ItemLookupTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/services/ItemLookupTest.scala
@@ -10,10 +10,7 @@ import weco.catalogue.internal_model.identifiers.IdentifierType.{
   MiroImageNumber,
   SierraSystemNumber
 }
-import weco.api.search.elasticsearch.{
-  DocumentNotFoundError,
-  IndexNotFoundError
-}
+import weco.api.search.elasticsearch.{DocumentNotFoundError, IndexNotFoundError}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 

--- a/common/stacks/src/test/scala/weco/api/stacks/services/ItemLookupTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/services/ItemLookupTest.scala
@@ -12,7 +12,6 @@ import weco.catalogue.internal_model.identifiers.IdentifierType.{
 }
 import weco.api.search.elasticsearch.{
   DocumentNotFoundError,
-  ElasticsearchService,
   IndexNotFoundError
 }
 
@@ -25,9 +24,7 @@ class ItemLookupTest
     with IndexFixtures
     with ItemsGenerators
     with WorkGenerators {
-  val lookup = new ItemLookup(
-    elasticsearchService = new ElasticsearchService(elasticClient)
-  )
+  val lookup: ItemLookup = ItemLookup(elasticClient)
 
   describe("byCanonicalId") {
     it("finds a work with the same item ID") {

--- a/items/src/main/scala/uk/ac/wellcome/platform/api/items/ItemsApi.scala
+++ b/items/src/main/scala/uk/ac/wellcome/platform/api/items/ItemsApi.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.api.items
 
 import akka.http.scaladsl.server.Route
 import uk.ac.wellcome.Tracing
-import weco.api.stacks.items.responses.LookupItemStatus
+import weco.api.items.responses.LookupItemStatus
 import weco.catalogue.internal_model.identifiers.CanonicalId
 
 import scala.util.{Success, Try}

--- a/items/src/main/scala/weco/api/items/responses/LookupItemStatus.scala
+++ b/items/src/main/scala/weco/api/items/responses/LookupItemStatus.scala
@@ -1,4 +1,4 @@
-package weco.api.stacks.items.responses
+package weco.api.items.responses
 
 import akka.http.scaladsl.server.Route
 import com.sksamuel.elastic4s.Index

--- a/items/src/test/scala/uk/ac/wellcome/platform/api/items/ItemsApiFeatureTest.scala
+++ b/items/src/test/scala/uk/ac/wellcome/platform/api/items/ItemsApiFeatureTest.scala
@@ -147,11 +147,12 @@ class ItemsApiFeatureTest
       val id = createCanonicalId
 
       withLocalWorksIndex { index =>
-        withItemsApi(index) { case (contextUrl, _) =>
-          val path = s"/works/$id"
+        withItemsApi(index) {
+          case (contextUrl, _) =>
+            val path = s"/works/$id"
 
-          val expectedError =
-            s"""
+            val expectedError =
+              s"""
                |{
                |  "errorType": "http",
                |  "httpStatus": 404,
@@ -161,13 +162,13 @@ class ItemsApiFeatureTest
                |  "@context": "$contextUrl"
                |}""".stripMargin
 
-          whenGetRequestReady(path) { response =>
-            response.status shouldBe StatusCodes.NotFound
+            whenGetRequestReady(path) { response =>
+              response.status shouldBe StatusCodes.NotFound
 
-            withStringEntity(response.entity) {
-              assertJsonStringsAreEqual(_, expectedError)
+              withStringEntity(response.entity) {
+                assertJsonStringsAreEqual(_, expectedError)
+              }
             }
-          }
         }
       }
     }
@@ -179,11 +180,12 @@ class ItemsApiFeatureTest
       } shouldBe a[Failure[_]]
 
       withLocalWorksIndex { index =>
-        withItemsApi(index) { case (contextUrl, _) =>
-          val path = s"/works/$id"
+        withItemsApi(index) {
+          case (contextUrl, _) =>
+            val path = s"/works/$id"
 
-          val expectedError =
-            s"""
+            val expectedError =
+              s"""
                |{
                |  "errorType": "http",
                |  "httpStatus": 404,
@@ -193,13 +195,13 @@ class ItemsApiFeatureTest
                |  "@context": "$contextUrl"
                |}""".stripMargin
 
-          whenGetRequestReady(path) { response =>
-            response.status shouldBe StatusCodes.NotFound
+            whenGetRequestReady(path) { response =>
+              response.status shouldBe StatusCodes.NotFound
 
-            withStringEntity(response.entity) {
-              assertJsonStringsAreEqual(_, expectedError)
+              withStringEntity(response.entity) {
+                assertJsonStringsAreEqual(_, expectedError)
+              }
             }
-          }
         }
       }
     }
@@ -231,7 +233,12 @@ class ItemsApiFeatureTest
           whenGetRequestReady(path) { response =>
             response.status shouldBe StatusCodes.Found
 
-            response.headers.filter { h => h.name() == "Location" }.head.value() shouldBe s"/catalogue/works/${targetWork.state.canonicalId}"
+            response.headers
+              .filter { h =>
+                h.name() == "Location"
+              }
+              .head
+              .value() shouldBe s"/catalogue/works/${targetWork.state.canonicalId}"
           }
         }
       }
@@ -251,11 +258,12 @@ class ItemsApiFeatureTest
       withLocalWorksIndex { index =>
         insertIntoElasticsearch(index, invisibleWork)
 
-        withItemsApi(index) { case (contextUrl, _) =>
-          val path = s"/works/${invisibleWork.state.canonicalId}"
+        withItemsApi(index) {
+          case (contextUrl, _) =>
+            val path = s"/works/${invisibleWork.state.canonicalId}"
 
-          val expectedError =
-            s"""
+            val expectedError =
+              s"""
                |{
                |  "errorType": "http",
                |  "httpStatus": 410,
@@ -265,13 +273,13 @@ class ItemsApiFeatureTest
                |  "@context": "$contextUrl"
                |}""".stripMargin
 
-          whenGetRequestReady(path) { response =>
-            response.status shouldBe StatusCodes.Gone
+            whenGetRequestReady(path) { response =>
+              response.status shouldBe StatusCodes.Gone
 
-            withStringEntity(response.entity) {
-              assertJsonStringsAreEqual(_, expectedError)
+              withStringEntity(response.entity) {
+                assertJsonStringsAreEqual(_, expectedError)
+              }
             }
-          }
         }
       }
     }
@@ -290,11 +298,12 @@ class ItemsApiFeatureTest
       withLocalWorksIndex { index =>
         insertIntoElasticsearch(index, deletedWork)
 
-        withItemsApi(index) { case (contextUrl, _) =>
-          val path = s"/works/${deletedWork.state.canonicalId}"
+        withItemsApi(index) {
+          case (contextUrl, _) =>
+            val path = s"/works/${deletedWork.state.canonicalId}"
 
-          val expectedError =
-            s"""
+            val expectedError =
+              s"""
                |{
                |  "errorType": "http",
                |  "httpStatus": 410,
@@ -304,13 +313,13 @@ class ItemsApiFeatureTest
                |  "@context": "$contextUrl"
                |}""".stripMargin
 
-          whenGetRequestReady(path) { response =>
-            response.status shouldBe StatusCodes.Gone
+            whenGetRequestReady(path) { response =>
+              response.status shouldBe StatusCodes.Gone
 
-            withStringEntity(response.entity) {
-              assertJsonStringsAreEqual(_, expectedError)
+              withStringEntity(response.entity) {
+                assertJsonStringsAreEqual(_, expectedError)
+              }
             }
-          }
         }
       }
     }

--- a/requests/docker-compose.yml
+++ b/requests/docker-compose.yml
@@ -1,0 +1,11 @@
+elasticsearch:
+  image: "docker.elastic.co/elasticsearch/elasticsearch:7.9.0"
+  ports:
+    - "9200:9200"
+    - "9300:9300"
+  environment:
+    - "http.host=0.0.0.0"
+    - "transport.host=0.0.0.0"
+    - "cluster.name=wellcome"
+    - "logger.level=DEBUG"
+    - "discovery.type=single-node"

--- a/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/Main.scala
+++ b/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/Main.scala
@@ -7,8 +7,14 @@ import uk.ac.wellcome.api.display.ElasticConfig
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.http.typesafe.HTTPServerBuilder
 import uk.ac.wellcome.monitoring.typesafe.CloudWatchBuilder
-import uk.ac.wellcome.platform.api.common.services.{SierraService, StacksService}
-import uk.ac.wellcome.platform.api.common.services.config.builders.{SierraServiceBuilder, StacksServiceBuilder}
+import uk.ac.wellcome.platform.api.common.services.{
+  SierraService,
+  StacksService
+}
+import uk.ac.wellcome.platform.api.common.services.config.builders.{
+  SierraServiceBuilder,
+  StacksServiceBuilder
+}
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
@@ -43,7 +49,8 @@ object Main extends WellcomeTypesafeApp {
     val elasticClient = ElasticBuilder.buildElasticClient(config)
 
     val router: RequestsApi = new RequestsApi {
-      override implicit val ec: ExecutionContext = AkkaBuilder.buildExecutionContext()
+      override implicit val ec: ExecutionContext =
+        AkkaBuilder.buildExecutionContext()
       override implicit val stacksWorkService: StacksService =
         StacksServiceBuilder.build(config)
       override implicit val apiConfig: ApiConfig = apiConf

--- a/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/Main.scala
+++ b/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/Main.scala
@@ -1,15 +1,19 @@
 package uk.ac.wellcome.platform.api.requests
 
 import akka.actor.ActorSystem
+import com.sksamuel.elastic4s.Index
 import com.typesafe.config.Config
+import uk.ac.wellcome.api.display.ElasticConfig
+import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.http.typesafe.HTTPServerBuilder
 import uk.ac.wellcome.monitoring.typesafe.CloudWatchBuilder
-import uk.ac.wellcome.platform.api.common.services.StacksService
-import uk.ac.wellcome.platform.api.common.services.config.builders.StacksServiceBuilder
+import uk.ac.wellcome.platform.api.common.services.{SierraService, StacksService}
+import uk.ac.wellcome.platform.api.common.services.config.builders.{SierraServiceBuilder, StacksServiceBuilder}
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
+import weco.api.stacks.services.ItemLookup
 import weco.http.WellcomeHttpApp
 import weco.http.monitoring.HttpMetrics
 
@@ -19,11 +23,6 @@ object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
     implicit val asMain: ActorSystem =
       AkkaBuilder.buildActorSystem()
-
-    implicit val ecMain: ExecutionContext =
-      AkkaBuilder.buildExecutionContext()
-
-    val workService: StacksService = StacksServiceBuilder.build(config)
 
     val apiConf =
       ApiConfig(
@@ -41,11 +40,20 @@ object Main extends WellcomeTypesafeApp {
           .getOrElse("context.json")
       )
 
+    val elasticClient = ElasticBuilder.buildElasticClient(config)
+
     val router: RequestsApi = new RequestsApi {
-      override implicit val ec: ExecutionContext = ecMain
-      override implicit val stacksWorkService: StacksService = workService
+      override implicit val ec: ExecutionContext = AkkaBuilder.buildExecutionContext()
+      override implicit val stacksWorkService: StacksService =
+        StacksServiceBuilder.build(config)
       override implicit val apiConfig: ApiConfig = apiConf
+      override val sierraService: SierraService =
+        SierraServiceBuilder.build(config)
+      override val itemLookup: ItemLookup = ItemLookup(elasticClient)
+      override val index: Index = ElasticConfig.apply().worksIndex
     }
+
+    implicit val ec: ExecutionContext = router.ec
 
     val appName = "RequestsApi"
 

--- a/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/RequestsApi.scala
+++ b/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/RequestsApi.scala
@@ -22,6 +22,9 @@ trait RequestsApi extends CreateHold {
       post {
         entity(as[ItemRequest]) {
           itemRequest: ItemRequest =>
+            // TODO: We get the work ID as part of the item request, although right now
+            // it's only for future-proofing, in case it's useful later.
+            // Should we query based on the work ID?
             Try { CanonicalId(itemRequest.itemId) } match {
               case Success(itemId) =>
                 withFuture {

--- a/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/RequestsApi.scala
+++ b/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/RequestsApi.scala
@@ -5,13 +5,13 @@ import uk.ac.wellcome.platform.api.common.models.display.DisplayResultsList
 import uk.ac.wellcome.platform.api.common.models.StacksUserIdentifier
 import uk.ac.wellcome.platform.api.common.services.StacksService
 import uk.ac.wellcome.platform.api.requests.models.ItemRequest
-import weco.api.requests.responses.CreateHold
+import weco.api.requests.responses.CreateRequest
 import weco.catalogue.internal_model.identifiers.CanonicalId
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
 
-trait RequestsApi extends CreateHold {
+trait RequestsApi extends CreateRequest {
   implicit val ec: ExecutionContext
   implicit val stacksWorkService: StacksService
 
@@ -28,7 +28,7 @@ trait RequestsApi extends CreateHold {
             Try { CanonicalId(itemRequest.itemId) } match {
               case Success(itemId) =>
                 withFuture {
-                  createHold(itemId = itemId, userIdentifier = userIdentifier)
+                  createRequest(itemId = itemId, userIdentifier = userIdentifier)
                 }
 
               case _ => notFound(s"Item not found for identifier ${itemRequest.itemId}")

--- a/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/RequestsApi.scala
+++ b/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/RequestsApi.scala
@@ -28,10 +28,13 @@ trait RequestsApi extends CreateRequest {
             Try { CanonicalId(itemRequest.itemId) } match {
               case Success(itemId) =>
                 withFuture {
-                  createRequest(itemId = itemId, userIdentifier = userIdentifier)
+                  createRequest(
+                    itemId = itemId,
+                    userIdentifier = userIdentifier)
                 }
 
-              case _ => notFound(s"Item not found for identifier ${itemRequest.itemId}")
+              case _ =>
+                notFound(s"Item not found for identifier ${itemRequest.itemId}")
             }
         }
       } ~ get {

--- a/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/RequestsApi.scala
+++ b/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/RequestsApi.scala
@@ -1,22 +1,17 @@
 package uk.ac.wellcome.platform.api.requests
 
-import akka.http.scaladsl.model.{HttpEntity, StatusCodes}
 import akka.http.scaladsl.server.Route
 import uk.ac.wellcome.platform.api.common.models.display.DisplayResultsList
 import uk.ac.wellcome.platform.api.common.models.StacksUserIdentifier
-import uk.ac.wellcome.platform.api.common.services.{
-  HoldAccepted,
-  HoldRejected,
-  StacksService
-}
+import uk.ac.wellcome.platform.api.common.services.StacksService
 import uk.ac.wellcome.platform.api.requests.models.ItemRequest
-import uk.ac.wellcome.platform.api.rest.CustomDirectives
+import weco.api.requests.responses.CreateHold
 import weco.catalogue.internal_model.identifiers.CanonicalId
 
 import scala.concurrent.ExecutionContext
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
-trait RequestsApi extends CustomDirectives {
+trait RequestsApi extends CreateHold {
   implicit val ec: ExecutionContext
   implicit val stacksWorkService: StacksService
 
@@ -27,22 +22,13 @@ trait RequestsApi extends CustomDirectives {
       post {
         entity(as[ItemRequest]) {
           itemRequest: ItemRequest =>
-            val canonicalId =
-              CanonicalId(itemRequest.itemId)
+            Try { CanonicalId(itemRequest.itemId) } match {
+              case Success(itemId) =>
+                withFuture {
+                  createHold(itemId = itemId, userIdentifier = userIdentifier)
+                }
 
-            val result = stacksWorkService.requestHoldOnItem(
-              userIdentifier = userIdentifier,
-              itemId = canonicalId,
-              neededBy = None
-            )
-
-            val accepted = (StatusCodes.Accepted, HttpEntity.Empty)
-            val conflict = (StatusCodes.Conflict, HttpEntity.Empty)
-
-            onComplete(result) {
-              case Success(HoldAccepted(_)) => complete(accepted)
-              case Success(HoldRejected(_)) => complete(conflict)
-              case Failure(err)             => failWith(err)
+              case _ => notFound(s"Item not found for identifier ${itemRequest.itemId}")
             }
         }
       } ~ get {

--- a/requests/src/main/scala/weco/api/requests/responses/CreateHold.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/CreateHold.scala
@@ -39,8 +39,8 @@ trait CreateHold extends CustomDirectives with Logging {
         }
 
       case Right(sourceIdentifier) =>
-        warn(s"Somebody tried to place a hold on $itemId / $sourceIdentifier")
-        invalidRequest("You cannot place a hold on " + itemId)
+        warn(s"Somebody tried to request non-Sierra item $itemId / $sourceIdentifier")
+        invalidRequest("You cannot request " + itemId)
 
       case Left(err) => elasticError("Item", err)
     }

--- a/requests/src/main/scala/weco/api/requests/responses/CreateHold.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/CreateHold.scala
@@ -1,0 +1,47 @@
+package weco.api.requests.responses
+
+import akka.http.scaladsl.model.{HttpEntity, StatusCodes}
+import akka.http.scaladsl.server.Route
+import com.sksamuel.elastic4s.Index
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.platform.api.common.models.StacksUserIdentifier
+import uk.ac.wellcome.platform.api.common.services.{HoldAccepted, HoldRejected, SierraService}
+import uk.ac.wellcome.platform.api.rest.CustomDirectives
+import weco.api.stacks.services.ItemLookup
+import weco.catalogue.internal_model.identifiers.CanonicalId
+import weco.catalogue.internal_model.identifiers.IdentifierType.SierraSystemNumber
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+trait CreateHold extends CustomDirectives with Logging {
+  implicit val ec: ExecutionContext
+
+  val sierraService: SierraService
+  val itemLookup: ItemLookup
+  val index: Index
+
+  def createHold(itemId: CanonicalId, userIdentifier: StacksUserIdentifier): Future[Route] =
+    itemLookup.byCanonicalId(itemId)(index).map {
+      case Right(sourceIdentifier) if sourceIdentifier.identifierType == SierraSystemNumber =>
+        val result = sierraService.placeHold(
+          userIdentifier = userIdentifier,
+          sourceIdentifier = sourceIdentifier
+        )
+
+        val accepted = (StatusCodes.Accepted, HttpEntity.Empty)
+        val conflict = (StatusCodes.Conflict, HttpEntity.Empty)
+
+        onComplete(result) {
+          case Success(HoldAccepted(_)) => complete(accepted)
+          case Success(HoldRejected(_)) => complete(conflict)
+          case Failure(err)             => failWith(err)
+        }
+
+      case Right(sourceIdentifier) =>
+        warn(s"Somebody tried to place a hold on $itemId / $sourceIdentifier")
+        invalidRequest("You cannot place a hold on " + itemId)
+
+      case Left(err) => elasticError("Item", err)
+    }
+}

--- a/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
@@ -14,14 +14,14 @@ import weco.catalogue.internal_model.identifiers.IdentifierType.SierraSystemNumb
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
-trait CreateHold extends CustomDirectives with Logging {
+trait CreateRequest extends CustomDirectives with Logging {
   implicit val ec: ExecutionContext
 
   val sierraService: SierraService
   val itemLookup: ItemLookup
   val index: Index
 
-  def createHold(itemId: CanonicalId, userIdentifier: StacksUserIdentifier): Future[Route] =
+  def createRequest(itemId: CanonicalId, userIdentifier: StacksUserIdentifier): Future[Route] =
     itemLookup.byCanonicalId(itemId)(index).map {
       case Right(sourceIdentifier) if sourceIdentifier.identifierType == SierraSystemNumber =>
         val result = sierraService.placeHold(

--- a/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
@@ -5,7 +5,11 @@ import akka.http.scaladsl.server.Route
 import com.sksamuel.elastic4s.Index
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.api.common.models.StacksUserIdentifier
-import uk.ac.wellcome.platform.api.common.services.{HoldAccepted, HoldRejected, SierraService}
+import uk.ac.wellcome.platform.api.common.services.{
+  HoldAccepted,
+  HoldRejected,
+  SierraService
+}
 import uk.ac.wellcome.platform.api.rest.CustomDirectives
 import weco.api.stacks.services.ItemLookup
 import weco.catalogue.internal_model.identifiers.CanonicalId
@@ -21,9 +25,11 @@ trait CreateRequest extends CustomDirectives with Logging {
   val itemLookup: ItemLookup
   val index: Index
 
-  def createRequest(itemId: CanonicalId, userIdentifier: StacksUserIdentifier): Future[Route] =
+  def createRequest(itemId: CanonicalId,
+                    userIdentifier: StacksUserIdentifier): Future[Route] =
     itemLookup.byCanonicalId(itemId)(index).map {
-      case Right(sourceIdentifier) if sourceIdentifier.identifierType == SierraSystemNumber =>
+      case Right(sourceIdentifier)
+          if sourceIdentifier.identifierType == SierraSystemNumber =>
         val result = sierraService.placeHold(
           userIdentifier = userIdentifier,
           sourceIdentifier = sourceIdentifier
@@ -39,7 +45,8 @@ trait CreateRequest extends CustomDirectives with Logging {
         }
 
       case Right(sourceIdentifier) =>
-        warn(s"Somebody tried to request non-Sierra item $itemId / $sourceIdentifier")
+        warn(
+          s"Somebody tried to request non-Sierra item $itemId / $sourceIdentifier")
         invalidRequest("You cannot request " + itemId)
 
       case Left(err) => elasticError("Item", err)

--- a/requests/src/test/resources/logback-test.xml
+++ b/requests/src/test/resources/logback-test.xml
@@ -9,5 +9,6 @@
     <appender-ref ref="STDOUT" />
   </root>
 
+  <logger name="com.sksamuel" level="INFO"/>
   <logger name="org.eclipse.jetty" level="INFO"/>
 </configuration>

--- a/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/RequestsApiFeatureTest.scala
+++ b/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/RequestsApiFeatureTest.scala
@@ -1,7 +1,11 @@
 package uk.ac.wellcome.platform.api.requests
 
 import akka.http.scaladsl.model.StatusCodes
-import com.github.tomakehurst.wiremock.client.WireMock.{equalToJson, postRequestedFor, urlEqualTo}
+import com.github.tomakehurst.wiremock.client.WireMock.{
+  equalToJson,
+  postRequestedFor,
+  urlEqualTo
+}
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -9,7 +13,10 @@ import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.models.Implicits._
 import uk.ac.wellcome.models.work.generators.{ItemsGenerators, WorkGenerators}
 import uk.ac.wellcome.platform.api.requests.fixtures.RequestsApiFixture
-import weco.catalogue.internal_model.identifiers.IdentifierType.{MiroImageNumber, SierraSystemNumber}
+import weco.catalogue.internal_model.identifiers.IdentifierType.{
+  MiroImageNumber,
+  SierraSystemNumber
+}
 import weco.catalogue.internal_model.identifiers.{CanonicalId, SourceIdentifier}
 
 import scala.util.{Failure, Try}
@@ -49,42 +56,42 @@ class RequestsApiFeatureTest
       withLocalWorksIndex { index =>
         insertIntoElasticsearch(index, work)
 
-        withRequestsApi(index) { case (_, wireMockServer) =>
-          val path = "/users/1234567/item-requests"
+        withRequestsApi(index) {
+          case (_, wireMockServer) =>
+            val path = "/users/1234567/item-requests"
 
-          val entity = createJsonHttpEntityWith(
-            s"""
+            val entity = createJsonHttpEntityWith(
+              s"""
                |{
                |  "itemId": "${item.id.canonicalId}",
                |  "workId": "${work.state.canonicalId}",
                |  "type": "ItemRequest"
                |}
                |""".stripMargin
-          )
+            )
 
-          whenPostRequestReady(path, entity) { response =>
-            response.status shouldBe StatusCodes.Accepted
+            whenPostRequestReady(path, entity) { response =>
+              response.status shouldBe StatusCodes.Accepted
 
-            wireMockServer.verify(
-              1,
-              postRequestedFor(
-                urlEqualTo(
-                  "/iii/sierra-api/v5/patrons/1234567/holds/requests"
-                )
-              ).withRequestBody(
-                equalToJson(
-                  """
+              wireMockServer.verify(
+                1,
+                postRequestedFor(
+                  urlEqualTo(
+                    "/iii/sierra-api/v5/patrons/1234567/holds/requests"
+                  )
+                ).withRequestBody(
+                  equalToJson("""
                     |{
                     |  "recordType" : "i",
                     |  "recordNumber" : 1601017,
                     |  "pickupLocation" : "unspecified"
                     |}
                     |""".stripMargin)
+                )
               )
-            )
 
-            response.entity.isKnownEmpty() shouldBe true
-          }
+              response.entity.isKnownEmpty() shouldBe true
+            }
         }
       }
     }
@@ -103,40 +110,40 @@ class RequestsApiFeatureTest
       withLocalWorksIndex { index =>
         insertIntoElasticsearch(index, work)
 
-        withRequestsApi(index) { case (_, wireMockServer) =>
-          val path = "/users/1234567/item-requests"
+        withRequestsApi(index) {
+          case (_, wireMockServer) =>
+            val path = "/users/1234567/item-requests"
 
-          val entity = createJsonHttpEntityWith(
-            s"""
+            val entity = createJsonHttpEntityWith(
+              s"""
                |{
                |  "itemId": "${item.id.canonicalId}",
                |  "workId": "${work.state.canonicalId}",
                |  "type": "ItemRequest"
                |}
                |""".stripMargin
-          )
+            )
 
-          whenPostRequestReady(path, entity) { response =>
-            response.status shouldBe StatusCodes.Conflict
+            whenPostRequestReady(path, entity) { response =>
+              response.status shouldBe StatusCodes.Conflict
 
-            wireMockServer.verify(
-              1,
-              postRequestedFor(
-                urlEqualTo(
-                  "/iii/sierra-api/v5/patrons/1234567/holds/requests"
-                )
-              ).withRequestBody(
-                equalToJson(
-                  """
+              wireMockServer.verify(
+                1,
+                postRequestedFor(
+                  urlEqualTo(
+                    "/iii/sierra-api/v5/patrons/1234567/holds/requests"
+                  )
+                ).withRequestBody(
+                  equalToJson("""
                     |{
                     |  "recordType" : "i",
                     |  "recordNumber" : 1601018,
                     |  "pickupLocation" : "unspecified"
                     |}
                     |""".stripMargin)
+                )
               )
-            )
-          }
+            }
         }
       }
     }
@@ -190,27 +197,28 @@ class RequestsApiFeatureTest
   describe("placing a hold") {
     it("returns a 404 if the item ID isn't a canonical ID") {
       withLocalWorksIndex { index =>
-        withRequestsApi(index) { case (contextUrl, _) =>
-          val path = "/users/1234567/item-requests"
+        withRequestsApi(index) {
+          case (contextUrl, _) =>
+            val path = "/users/1234567/item-requests"
 
-          val itemId = randomAlphanumeric(length = 10)
-          Try { CanonicalId(itemId) } shouldBe a[Failure[_]]
+            val itemId = randomAlphanumeric(length = 10)
+            Try { CanonicalId(itemId) } shouldBe a[Failure[_]]
 
-          val entity = createJsonHttpEntityWith(
-            s"""
+            val entity = createJsonHttpEntityWith(
+              s"""
                |{
                |  "itemId": "$itemId",
                |  "workId": "$createCanonicalId",
                |  "type": "ItemRequest"
                |}
                |""".stripMargin
-          )
+            )
 
-          whenPostRequestReady(path, entity) { response =>
-            response.status shouldBe StatusCodes.NotFound
+            whenPostRequestReady(path, entity) { response =>
+              response.status shouldBe StatusCodes.NotFound
 
-            val expectedError =
-              s"""
+              val expectedError =
+                s"""
                  |{
                  |  "errorType": "http",
                  |  "httpStatus": 404,
@@ -220,36 +228,37 @@ class RequestsApiFeatureTest
                  |  "@context": "$contextUrl"
                  |}""".stripMargin
 
-            withStringEntity(response.entity) {
-              assertJsonStringsAreEqual(_, expectedError)
+              withStringEntity(response.entity) {
+                assertJsonStringsAreEqual(_, expectedError)
+              }
             }
-          }
         }
       }
     }
 
     it("returns a 404 if there is no item with this ID") {
       withLocalWorksIndex { index =>
-        withRequestsApi(index) { case (contextUrl, _) =>
-          val path = "/users/1234567/item-requests"
+        withRequestsApi(index) {
+          case (contextUrl, _) =>
+            val path = "/users/1234567/item-requests"
 
-          val itemId = createCanonicalId
+            val itemId = createCanonicalId
 
-          val entity = createJsonHttpEntityWith(
-            s"""
+            val entity = createJsonHttpEntityWith(
+              s"""
                |{
                |  "itemId": "$itemId",
                |  "workId": "$createCanonicalId",
                |  "type": "ItemRequest"
                |}
                |""".stripMargin
-          )
+            )
 
-          whenPostRequestReady(path, entity) { response =>
-            response.status shouldBe StatusCodes.NotFound
+            whenPostRequestReady(path, entity) { response =>
+              response.status shouldBe StatusCodes.NotFound
 
-            val expectedError =
-              s"""
+              val expectedError =
+                s"""
                  |{
                  |  "errorType": "http",
                  |  "httpStatus": 404,
@@ -259,10 +268,10 @@ class RequestsApiFeatureTest
                  |  "@context": "$contextUrl"
                  |}""".stripMargin
 
-            withStringEntity(response.entity) {
-              assertJsonStringsAreEqual(_, expectedError)
+              withStringEntity(response.entity) {
+                assertJsonStringsAreEqual(_, expectedError)
+              }
             }
-          }
         }
       }
     }
@@ -281,24 +290,25 @@ class RequestsApiFeatureTest
       withLocalWorksIndex { index =>
         insertIntoElasticsearch(index, work)
 
-        withRequestsApi(index) { case (contextUrl, _) =>
-          val path = "/users/1234567/item-requests"
+        withRequestsApi(index) {
+          case (contextUrl, _) =>
+            val path = "/users/1234567/item-requests"
 
-          val entity = createJsonHttpEntityWith(
-            s"""
+            val entity = createJsonHttpEntityWith(
+              s"""
                |{
                |  "itemId": "${item.id.canonicalId}",
                |  "workId": "${work.state.canonicalId}",
                |  "type": "ItemRequest"
                |}
                |""".stripMargin
-          )
+            )
 
-          whenPostRequestReady(path, entity) { response =>
-            response.status shouldBe StatusCodes.BadRequest
+            whenPostRequestReady(path, entity) { response =>
+              response.status shouldBe StatusCodes.BadRequest
 
-            val expectedError =
-              s"""
+              val expectedError =
+                s"""
                  |{
                  |  "errorType": "http",
                  |  "httpStatus": 400,
@@ -308,10 +318,10 @@ class RequestsApiFeatureTest
                  |  "@context": "$contextUrl"
                  |}""".stripMargin
 
-            withStringEntity(response.entity) {
-              assertJsonStringsAreEqual(_, expectedError)
+              withStringEntity(response.entity) {
+                assertJsonStringsAreEqual(_, expectedError)
+              }
             }
-          }
         }
       }
     }

--- a/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/RequestsApiFeatureTest.scala
+++ b/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/RequestsApiFeatureTest.scala
@@ -1,153 +1,184 @@
 package uk.ac.wellcome.platform.api.requests
 
 import akka.http.scaladsl.model.StatusCodes
-import com.github.tomakehurst.wiremock.client.WireMock.{
-  equalToJson,
-  postRequestedFor,
-  urlEqualTo
-}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalToJson, postRequestedFor, urlEqualTo}
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.json.utils.JsonAssertions
+import uk.ac.wellcome.models.Implicits._
+import uk.ac.wellcome.models.work.generators.{ItemsGenerators, WorkGenerators}
 import uk.ac.wellcome.platform.api.requests.fixtures.RequestsApiFixture
+import weco.catalogue.internal_model.identifiers.IdentifierType.SierraSystemNumber
+import weco.catalogue.internal_model.identifiers.SourceIdentifier
 
 class RequestsApiFeatureTest
     extends AnyFunSpec
     with Matchers
     with RequestsApiFixture
     with JsonAssertions
-    with IntegrationPatience {
+    with IntegrationPatience
+    with WorkGenerators
+    with ItemsGenerators {
 
   describe("requests") {
     it("responds to a GET request") {
-      withRequestsApi { _ =>
-        val path = "/users/1234567/item-requests"
-        whenGetRequestReady(path) {
-          _.status shouldBe StatusCodes.OK
+      withLocalWorksIndex { index =>
+        withRequestsApi(index) { _ =>
+          val path = "/users/1234567/item-requests"
+          whenGetRequestReady(path) {
+            _.status shouldBe StatusCodes.OK
+          }
         }
       }
     }
 
     it("accepts requests to place a hold on an item") {
-      withRequestsApi { wireMockServer =>
-        val path = "/users/1234567/item-requests"
-
-        val entity = createJsonHttpEntityWith(
-          """
-            |{
-            |  "itemId": "ys3ern6x",
-            |  "workId": "cnkv77md",
-            |  "type": "ItemRequest"
-            |}
-            |""".stripMargin
+      val item = createIdentifiedItemWith(
+        sourceIdentifier = SourceIdentifier(
+          identifierType = SierraSystemNumber,
+          value = "i16010176",
+          ontologyType = "Item"
         )
+      )
 
-        whenPostRequestReady(path, entity) { response =>
-          withStringEntity(response.entity) { actualJson =>
-            println(actualJson)
-          }
+      val work = indexedWork().items(List(item))
 
-          response.status shouldBe StatusCodes.Accepted
+      withLocalWorksIndex { index =>
+        insertIntoElasticsearch(index, work)
 
-          wireMockServer.verify(
-            1,
-            postRequestedFor(
-              urlEqualTo(
-                "/iii/sierra-api/v5/patrons/1234567/holds/requests"
-              )
-            ).withRequestBody(
-              equalToJson("""
-                  |{
-                  |  "recordType" : "i",
-                  |  "recordNumber" : 1601017,
-                  |  "pickupLocation" : "unspecified"
-                  |}
-                  |""".stripMargin)
-            )
+        withRequestsApi(index) { wireMockServer =>
+          val path = "/users/1234567/item-requests"
+
+          val entity = createJsonHttpEntityWith(
+            s"""
+               |{
+               |  "itemId": "${item.id.canonicalId}",
+               |  "workId": "${work.state.canonicalId}",
+               |  "type": "ItemRequest"
+               |}
+               |""".stripMargin
           )
 
-          response.entity.isKnownEmpty() shouldBe true
+          whenPostRequestReady(path, entity) { response =>
+            response.status shouldBe StatusCodes.Accepted
+
+            wireMockServer.verify(
+              1,
+              postRequestedFor(
+                urlEqualTo(
+                  "/iii/sierra-api/v5/patrons/1234567/holds/requests"
+                )
+              ).withRequestBody(
+                equalToJson(
+                  """
+                    |{
+                    |  "recordType" : "i",
+                    |  "recordNumber" : 1601017,
+                    |  "pickupLocation" : "unspecified"
+                    |}
+                    |""".stripMargin)
+              )
+            )
+
+            response.entity.isKnownEmpty() shouldBe true
+          }
         }
       }
     }
 
     it("responds with a 409 Conflict when a hold is rejected") {
-      withRequestsApi { wireMockServer =>
-        val path = "/users/1234567/item-requests"
-
-        val entity = createJsonHttpEntityWith(
-          """
-            |{
-            |  "itemId": "ys3ern6y",
-            |  "workId": "cnkv77md",
-            |  "type": "ItemRequest"
-            |}
-            |""".stripMargin
+      val item = createIdentifiedItemWith(
+        sourceIdentifier = SourceIdentifier(
+          identifierType = SierraSystemNumber,
+          value = "i16010188",
+          ontologyType = "Item"
         )
+      )
 
-        whenPostRequestReady(path, entity) { response =>
-          response.status shouldBe StatusCodes.Conflict
+      val work = indexedWork().items(List(item))
 
-          wireMockServer.verify(
-            1,
-            postRequestedFor(
-              urlEqualTo(
-                "/iii/sierra-api/v5/patrons/1234567/holds/requests"
-              )
-            ).withRequestBody(
-              equalToJson("""
+      withLocalWorksIndex { index =>
+        insertIntoElasticsearch(index, work)
+
+        withRequestsApi(index) { wireMockServer =>
+          val path = "/users/1234567/item-requests"
+
+          val entity = createJsonHttpEntityWith(
+            s"""
+               |{
+               |  "itemId": "${item.id.canonicalId}",
+               |  "workId": "${work.state.canonicalId}",
+               |  "type": "ItemRequest"
+               |}
+               |""".stripMargin
+          )
+
+          whenPostRequestReady(path, entity) { response =>
+            response.status shouldBe StatusCodes.Conflict
+
+            wireMockServer.verify(
+              1,
+              postRequestedFor(
+                urlEqualTo(
+                  "/iii/sierra-api/v5/patrons/1234567/holds/requests"
+                )
+              ).withRequestBody(
+                equalToJson(
+                  """
                     |{
                     |  "recordType" : "i",
                     |  "recordNumber" : 1601018,
                     |  "pickupLocation" : "unspecified"
                     |}
                     |""".stripMargin)
+              )
             )
-          )
-
+          }
         }
       }
     }
 
     it("provides information about a users' holds") {
-      withRequestsApi { _ =>
-        val path = "/users/1234567/item-requests"
+      withLocalWorksIndex { index =>
+        withRequestsApi(index) { _ =>
+          val path = "/users/1234567/item-requests"
 
-        val expectedJson =
-          s"""
-             |{
-             |  "results" : [
-             |    {
-             |      "item" : {
-             |        "id" : "n5v7b4md",
-             |        "locations" : [
-             |        ],
-             |        "type" : "Item"
-             |      },
-             |      "pickupDate" : "2019-12-03T04:00:00Z",
-             |      "pickupLocation" : {
-             |        "id" : "sepbb",
-             |        "label" : "Rare Materials Room",
-             |        "type" : "LocationDescription"
-             |      },
-             |      "status" : {
-             |        "id" : "i",
-             |        "label" : "item hold ready for pickup.",
-             |        "type" : "RequestStatus"
-             |      },
-             |      "type" : "Request"
-             |    }
-             |  ],
-             |  "totalResults" : 1,
-             |  "type" : "ResultList"
-             |}""".stripMargin
+          val expectedJson =
+            s"""
+               |{
+               |  "results" : [
+               |    {
+               |      "item" : {
+               |        "id" : "n5v7b4md",
+               |        "locations" : [
+               |        ],
+               |        "type" : "Item"
+               |      },
+               |      "pickupDate" : "2019-12-03T04:00:00Z",
+               |      "pickupLocation" : {
+               |        "id" : "sepbb",
+               |        "label" : "Rare Materials Room",
+               |        "type" : "LocationDescription"
+               |      },
+               |      "status" : {
+               |        "id" : "i",
+               |        "label" : "item hold ready for pickup.",
+               |        "type" : "RequestStatus"
+               |      },
+               |      "type" : "Request"
+               |    }
+               |  ],
+               |  "totalResults" : 1,
+               |  "type" : "ResultList"
+               |}""".stripMargin
 
-        whenGetRequestReady(path) { response =>
-          response.status shouldBe StatusCodes.OK
+          whenGetRequestReady(path) { response =>
+            response.status shouldBe StatusCodes.OK
 
-          withStringEntity(response.entity) { actualJson =>
-            assertJsonStringsAreEqual(actualJson, expectedJson)
+            withStringEntity(response.entity) {
+              assertJsonStringsAreEqual(_, expectedJson)
+            }
           }
         }
       }

--- a/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/fixtures/RequestsApiFixture.scala
+++ b/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/fixtures/RequestsApiFixture.scala
@@ -1,18 +1,20 @@
 package uk.ac.wellcome.platform.api.requests.fixtures
 
 import com.github.tomakehurst.wiremock.WireMockServer
-
+import com.sksamuel.elastic4s.Index
 import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.models.index.IndexFixtures
 import uk.ac.wellcome.platform.api.common.fixtures.ServicesFixture
 import weco.http.fixtures.HttpFixtures
-import uk.ac.wellcome.platform.api.common.services.StacksService
+import uk.ac.wellcome.platform.api.common.services.{SierraService, StacksService}
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.platform.api.requests.RequestsApi
+import weco.api.stacks.services.ItemLookup
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait RequestsApiFixture extends ServicesFixture with HttpFixtures {
+trait RequestsApiFixture extends ServicesFixture with HttpFixtures with IndexFixtures {
 
   val metricsName = "RequestsApiFixture"
 
@@ -25,14 +27,19 @@ trait RequestsApiFixture extends ServicesFixture with HttpFixtures {
       contextPath = "context.json"
     )
 
-  def withRequestsApi[R](testWith: TestWith[WireMockServer, R]): R =
+  def withRequestsApi[R](index: Index)(testWith: TestWith[WireMockServer, R]): R =
     withStacksService {
-      case (stacksService, server) =>
+      case (stacksService, sierraServiceTest, server) =>
+        val indexTest = index
+
         val router: RequestsApi = new RequestsApi {
           override implicit val ec: ExecutionContext = global
           override implicit val stacksWorkService: StacksService =
             stacksService
           override implicit val apiConfig: ApiConfig = apiConf
+          override val sierraService: SierraService = sierraServiceTest
+          override val itemLookup: ItemLookup = ItemLookup(elasticClient)(global)
+          override val index: Index = indexTest
         }
 
         withApp(router.routes) { _ =>

--- a/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/fixtures/RequestsApiFixture.scala
+++ b/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/fixtures/RequestsApiFixture.scala
@@ -6,7 +6,10 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.index.IndexFixtures
 import uk.ac.wellcome.platform.api.common.fixtures.ServicesFixture
 import weco.http.fixtures.HttpFixtures
-import uk.ac.wellcome.platform.api.common.services.{SierraService, StacksService}
+import uk.ac.wellcome.platform.api.common.services.{
+  SierraService,
+  StacksService
+}
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.platform.api.requests.RequestsApi
 import weco.api.stacks.services.ItemLookup
@@ -15,7 +18,10 @@ import java.net.URL
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait RequestsApiFixture extends ServicesFixture with HttpFixtures with IndexFixtures {
+trait RequestsApiFixture
+    extends ServicesFixture
+    with HttpFixtures
+    with IndexFixtures {
 
   val metricsName = "RequestsApiFixture"
 
@@ -28,7 +34,8 @@ trait RequestsApiFixture extends ServicesFixture with HttpFixtures with IndexFix
       contextPath = "context.json"
     )
 
-  def withRequestsApi[R](index: Index)(testWith: TestWith[(URL, WireMockServer), R]): R =
+  def withRequestsApi[R](index: Index)(
+    testWith: TestWith[(URL, WireMockServer), R]): R =
     withStacksService {
       case (stacksService, sierraServiceTest, server) =>
         val indexTest = index
@@ -39,7 +46,8 @@ trait RequestsApiFixture extends ServicesFixture with HttpFixtures with IndexFix
             stacksService
           override implicit val apiConfig: ApiConfig = apiConf
           override val sierraService: SierraService = sierraServiceTest
-          override val itemLookup: ItemLookup = ItemLookup(elasticClient)(global)
+          override val itemLookup: ItemLookup =
+            ItemLookup(elasticClient)(global)
           override val index: Index = indexTest
         }
 

--- a/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/fixtures/RequestsApiFixture.scala
+++ b/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/fixtures/RequestsApiFixture.scala
@@ -11,6 +11,7 @@ import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.platform.api.requests.RequestsApi
 import weco.api.stacks.services.ItemLookup
 
+import java.net.URL
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -27,7 +28,7 @@ trait RequestsApiFixture extends ServicesFixture with HttpFixtures with IndexFix
       contextPath = "context.json"
     )
 
-  def withRequestsApi[R](index: Index)(testWith: TestWith[WireMockServer, R]): R =
+  def withRequestsApi[R](index: Index)(testWith: TestWith[(URL, WireMockServer), R]): R =
     withStacksService {
       case (stacksService, sierraServiceTest, server) =>
         val indexTest = index
@@ -43,7 +44,7 @@ trait RequestsApiFixture extends ServicesFixture with HttpFixtures with IndexFix
         }
 
         withApp(router.routes) { _ =>
-          testWith(server)
+          testWith((router.contextUrl, server))
         }
     }
 }


### PR DESCRIPTION
For #8

This follows a similar pattern to #57 – there's a new trait `CreateRequest` that looks up an item from Elasticsearch, and delegates to the Sierra services as necessary. A few comments inline.