### PR TITLE
Fix the list of licences listed in the Swagger endpoint

### DIFF
--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/swagger/SwaggerDocs.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/swagger/SwaggerDocs.scala
@@ -228,7 +228,12 @@ trait MultipleImagesSwagger {
             "cc-by-nc-nd",
             "cc-0",
             "pdm",
-            "copyright-not-cleared"
+            "cc-by-nd",
+            "cc-by-sa",
+            "cc-by-nc-sa",
+            "ogl",
+            "opl",
+            "inc"
           )
         ),
         required = false
@@ -505,7 +510,12 @@ trait MultipleWorksSwagger {
             "cc-by-nc-nd",
             "cc-0",
             "pdm",
-            "copyright-not-cleared"
+            "cc-by-nd",
+            "cc-by-sa",
+            "cc-by-nc-sa",
+            "ogl",
+            "opl",
+            "inc"
           )
         ),
         required = false

--- a/search/src/test/scala/uk/ac/wellcome/platform/api/search/ApiSwaggerTest.scala
+++ b/search/src/test/scala/uk/ac/wellcome/platform/api/search/ApiSwaggerTest.scala
@@ -6,8 +6,17 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import uk.ac.wellcome.api.display.models.{SingleImageIncludes, WorksIncludes}
 import uk.ac.wellcome.platform.api.search.fixtures.ReflectionHelpers
-import uk.ac.wellcome.platform.api.search.models.{DisplayWorkAggregations, SearchQueryType, WorkAggregations}
-import uk.ac.wellcome.platform.api.search.rest.{MultipleImagesParams, MultipleWorksParams, SingleImageParams, SingleWorkParams}
+import uk.ac.wellcome.platform.api.search.models.{
+  DisplayWorkAggregations,
+  SearchQueryType,
+  WorkAggregations
+}
+import uk.ac.wellcome.platform.api.search.rest.{
+  MultipleImagesParams,
+  MultipleWorksParams,
+  SingleImageParams,
+  SingleWorkParams
+}
 import uk.ac.wellcome.platform.api.search.rest._
 import uk.ac.wellcome.platform.api.search.works.ApiWorksTestBase
 import weco.catalogue.internal_model.locations.{AccessStatus, License}
@@ -364,7 +373,9 @@ class ApiSwaggerTest
       // require an internal_model change.  I'll leave this test here for the
       // next person who works on AccessStatus, but I'm not going to fix it now.
       ignore("items.locations.accessConditions.status") {
-        val actualValues = getParameterEnumValues(multipleWorksEndpoint, name = "items.locations.accessConditions.status")
+        val actualValues = getParameterEnumValues(
+          multipleWorksEndpoint,
+          name = "items.locations.accessConditions.status")
         val expectedValues = AccessStatus.values.map { _.id }
 
         actualValues should contain theSameElementsAs expectedValues


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/5163; this patch got lost in the move to the new repo.