### PR TITLE
Trigger API gateway deployments as per the docs

### DIFF
--- a/terraform/modules/api_route/outputs.tf
+++ b/terraform/modules/api_route/outputs.tf
@@ -1,3 +1,11 @@
 output "resource_id" {
   value = aws_api_gateway_resource.resource.id
 }
+
+output "all_ids" {
+  value = [
+    aws_api_gateway_resource.resource.id,
+    aws_api_gateway_method.method.id,
+    aws_api_gateway_integration.integration.id
+  ]
+}

--- a/terraform/modules/static_response/output.tf
+++ b/terraform/modules/static_response/output.tf
@@ -1,3 +1,13 @@
 output "resource_id" {
   value = aws_api_gateway_resource.static.id
 }
+
+output "all_ids" {
+  value = [
+    aws_api_gateway_resource.static.id,
+    aws_api_gateway_method.static.id,
+    aws_api_gateway_integration.static.id,
+    aws_api_gateway_method_response.static.id,
+    aws_api_gateway_integration_response.static.id
+  ]
+}


### PR DESCRIPTION
The way that I initially did this seemed to occasionally require manual redeploys but otherwise appeared fine - however this was not the case, as @harrisonpim just noticed a regression which I think would've been caused by an innocuous terraform application creating an API Gateway deployment before resources were updated.

As such, I've changed the deployment triggers to work as [specified in the docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_deployment#terraform-resources) (even though this is very verbose). There's a lot more context and worthwhile-ish reading here: https://github.com/hashicorp/terraform-provider-aws/issues/11344, and I've linked to that issue in a comment as well.