### PR TITLE
Bump scala-libs to v26.14.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object WellcomeDependencies {
 
-  val defaultVersion = "26.12.0"
+  val defaultVersion = "26.14.0"
 
   lazy val versions = new {
     val typesafe = defaultVersion


### PR DESCRIPTION
I don't think this affects this repo, but it's good to run the same version everywhere.