### PR TITLE
Use separate accounts for search and items API access to ES

### DIFF
--- a/terraform/modules/stack/services.tf
+++ b/terraform/modules/stack/services.tf
@@ -30,10 +30,10 @@ module "search_api" {
   }
   secrets = {
     es_host        = "elasticsearch/catalogue/private_host"
-    es_port        = "catalogue/api/es_port"
-    es_protocol    = "catalogue/api/es_protocol"
-    es_username    = "catalogue/api/es_username"
-    es_password    = "catalogue/api/es_password"
+    es_port        = "catalogue/search/es_port"
+    es_protocol    = "catalogue/search/es_protocol"
+    es_username    = "catalogue/search/es_username"
+    es_password    = "catalogue/search/es_password"
     apm_server_url = "catalogue/api/apm_server_url"
     apm_secret     = "catalogue/api/apm_secret"
   }
@@ -78,10 +78,10 @@ module "items_api" {
     apm_secret     = "catalogue/api/apm_secret"
 
     es_host     = "elasticsearch/catalogue/private_host"
-    es_port     = "catalogue/api/es_port"
-    es_protocol = "catalogue/api/es_protocol"
-    es_username = "catalogue/api/es_username"
-    es_password = "catalogue/api/es_password"
+    es_port     = "catalogue/items/es_port"
+    es_protocol = "catalogue/items/es_protocol"
+    es_username = "catalogue/items/es_username"
+    es_password = "catalogue/items/es_password"
   }
 
   subnets                = local.routable_private_subnets

--- a/terraform/shared/secrets.tf
+++ b/terraform/shared/secrets.tf
@@ -1,0 +1,11 @@
+locals {
+  elasticsearch_apps  = ["search", "items"]
+  elasticsearch_creds = ["es_username", "es_password", "es_protocol", "es_port"]
+}
+
+resource "aws_secretsmanager_secret" "es_credentials" {
+  for_each = toset([
+    for path in setproduct(local.elasticsearch_apps, local.elasticsearch_creds) : "${path[0]}/${path[1]}"
+  ])
+  name = "catalogue/${each.value}"
+}


### PR DESCRIPTION
It would be super cool to dynamically create the roles/users per environment and even with per-index permissions (rather than the `works-*` index pattern), but I'm not sure if this is possible with our elastic cloud account (?) and the existing providers https://registry.terraform.io/providers/phillbaker/elasticsearch/latest/docs/resources/xpack_role.

Anyway, this uses different accounts for each app, which have much more granular roles than the existing account:
![image](https://user-images.githubusercontent.com/4429247/118281970-b00b0000-b4c5-11eb-9713-bc46acdc3855.png)
![image](https://user-images.githubusercontent.com/4429247/118281991-b600e100-b4c5-11eb-9118-47f27c2e860b.png)

