### PR TITLE
Allow diff_tool to run in CI

### DIFF
--- a/.buildkite/pipeline.deploy-prod.yml
+++ b/.buildkite/pipeline.deploy-prod.yml
@@ -1,6 +1,22 @@
 steps:
+  - label: "Diff tool: Compare stage & prod"
+    #TODO: Remove before merge
+    #branches: "main"
+    plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::130871440101:role/experience-ci"
+      - docker-compose#v3.5.0:
+          run: diff_tool
+          env:
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+            - AWS_SESSION_TOKEN
+            - AWS_REGION=eu-west-1
+
+  - wait
+
   - block: ":rocket: Deploy to prod?"
-    prompt: "Deploying ref.$BUILDKITE_COMMIT: Have you checked staging?"
+    prompt: "Deploying ref.$BUILDKITE_COMMIT: Have you checked staging & diff-tool?"
 
   - label: "Deploy (prod)"
     branches: "main"

--- a/.buildkite/pipeline.deploy-stage.yml
+++ b/.buildkite/pipeline.deploy-stage.yml
@@ -42,7 +42,8 @@ steps:
   - wait
 
   - label: trigger prod deploy
-    branches: "main"
+    #TODO: Remove before merge
+    #branches: "main"
     trigger: "catalogue-api-deploy-prod"
     build:
       message: "${BUILDKITE_MESSAGE}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,7 +24,8 @@ steps:
   - wait
 
   - label: trigger stage deploy
-    branches: "main"
+    #TODO: Remove before merge
+    #branches: "main"
     trigger: "catalogue-api-deploy-stage"
     build:
       message: "${BUILDKITE_MESSAGE}"

--- a/diff_tool/Dockerfile
+++ b/diff_tool/Dockerfile
@@ -1,0 +1,16 @@
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/python:3.7-alpine
+
+LABEL maintainer = "Wellcome Collection <dev@wellcomecollection.org>"
+LABEL description = "A Docker image for deploying our Docker images to AWS"
+
+WORKDIR /usr/src/app
+
+ADD requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+ADD routes.json routes.json
+ADD template.html template.html
+ADD api_stats.py api_stats.py
+ADD diff_tool.py diff_tool.py
+
+CMD ["/usr/local/bin/python3", "/usr/src/app/diff_tool.py", "--console"]

--- a/diff_tool/diff_tool.py
+++ b/diff_tool/diff_tool.py
@@ -101,37 +101,43 @@ class ApiDiffer:
         response = httpx.get(url, params=self.params)
         return (response.status_code, response.json())
 
+
 def _display_in_console(stats, diffs):
     time_now = datetime.datetime.now().strftime("%A %-d %B %Y @ %H:%M:%S")
     click.echo()
-    click.echo(click.style(f"API diff for {time_now}", fg="white", bold=True, underline=True))
+    click.echo(
+        click.style(f"API diff for {time_now}", fg="white", bold=True, underline=True)
+    )
     click.echo()
     click.echo(click.style("Index statistics", underline=True))
     click.echo()
-    click.echo(tabulate(
-        [
-            ["Production"] + list(stats['prod']['work_types'].values()),
-            ["Staging"] + list(stats['staging']['work_types'].values())
-        ],
-        headers=stats['prod']['work_types'].keys()
-    ))
+    click.echo(
+        tabulate(
+            [
+                ["Production"] + list(stats["prod"]["work_types"].values()),
+                ["Staging"] + list(stats["staging"]["work_types"].values()),
+            ],
+            headers=stats["prod"]["work_types"].keys(),
+        )
+    )
 
     click.echo()
     click.echo(click.style("Index tests", underline=True))
     click.echo()
 
     for diff_line in diffs:
-        if 'comment' in diff_line['route']:
-            display_diff_line = diff_line['route']['comment']
+        if "comment" in diff_line["route"]:
+            display_diff_line = diff_line["route"]["comment"]
         else:
-            display_diff_line = diff_line['display_url']
+            display_diff_line = diff_line["display_url"]
 
-        if diff_line['status'] == 'match':
+        if diff_line["status"] == "match":
             click.echo(click.style(f"✓ {display_diff_line}", fg="green"))
         else:
             click.echo(click.style(f"✖ {display_diff_line}", fg="red"))
 
     click.echo()
+
 
 @click.command()
 @click.option(
@@ -139,7 +145,7 @@ def _display_in_console(stats, diffs):
     default="routes.json",
     help="What routes file to use (default=routes.json)",
 )
-@click.option('--console', is_flag=True, help="Print results in console")
+@click.option("--console", is_flag=True, help="Print results in console")
 def main(routes_file, console):
     session = api_stats.get_session_with_role(
         role_arn="arn:aws:iam::760097843905:role/platform-developer"

--- a/diff_tool/requirements.in
+++ b/diff_tool/requirements.in
@@ -1,6 +1,7 @@
 boto3
 click
 elasticsearch
+tabulate
 httpx
 humanize
 jinja2

--- a/diff_tool/requirements.txt
+++ b/diff_tool/requirements.txt
@@ -48,6 +48,8 @@ sniffio==1.2.0
     # via
     #   httpcore
     #   httpx
+tabulate==0.8.9
+    # via -r requirements.in
 tqdm==4.59.0
     # via -r requirements.in
 urllib3==1.25.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,7 @@ services:
     image: smoke_test_catalogue_api_stage
     build:
       context: ./smoke_tests
+  diff_tool:
+    image: diff_tool
+    build:
+      context: ./diff_tool


### PR DESCRIPTION
This change runs the diff_tool in CI before a prod deploy can occur, giving the opportunity to quickly see a disparity / issue before a deployment. This further automates part of the deployment workflow for catalogue-api.

Instead of pushing a generated HTML artifact somewhere for review, this change prints a summary to the console for review - sidestepping the requirement to provision and maintain external storage.