### PR TITLE
Enable logs/metrics export to logging cluster

### DIFF
--- a/terraform/shared/elastic.tf
+++ b/terraform/shared/elastic.tf
@@ -1,3 +1,7 @@
+data "ec_deployment" "logging" {
+  id = "f4c9aca09347dad4c05f35cfbec04cdb"
+}
+
 resource "ec_deployment" "catalogue_api" {
   name = "catalogue-api"
 
@@ -19,6 +23,8 @@ resource "ec_deployment" "catalogue_api" {
       alias         = local.catalogue_ec_cluster_name
       ref_id        = local.catalogue_ec_cluster_ref_id
     }
+
+
   }
 
   kibana {
@@ -26,6 +32,10 @@ resource "ec_deployment" "catalogue_api" {
       zone_count = 1
       size       = "1g"
     }
+  }
+
+  observability {
+    deployment_id = data.ec_deployment.logging.id
   }
 }
 


### PR DESCRIPTION
This change enables export of Elasticsearch logs & metrics to the logging cluster (for the new catalogue-api cluster).

This change addresses the actions in https://github.com/wellcomecollection/docs/blob/main/incident_retros/2021-05-20_ingestors.md#actions