### PR TITLE
Use logging cluster id from shared state

### DIFF
--- a/terraform/shared/elastic.tf
+++ b/terraform/shared/elastic.tf
@@ -1,5 +1,5 @@
 data "ec_deployment" "logging" {
-  id = "f4c9aca09347dad4c05f35cfbec04cdb"
+  id = local.logging_cluster_id
 }
 
 resource "ec_deployment" "catalogue_api" {

--- a/terraform/shared/locals.tf
+++ b/terraform/shared/locals.tf
@@ -13,4 +13,6 @@ locals {
     Managed                   = "terraform"
     TerraformConfigurationURL = "https://github.com/wellcomecollection/catalogue-api/tree/main/terraform/shared"
   }
+
+  logging_cluster_id = data.terraform_remote_state.infra_critical.outputs.logging_cluster_id
 }


### PR DESCRIPTION
This change follows the good practise of using the logging cluster ID from remote state, rather than hard coding where it can get out of date.

Dependent on: https://github.com/wellcomecollection/platform-infrastructure/pull/189