### PR TITLE
Allow catalogue-api service secrets to vary by env

### DIFF
--- a/terraform/catalogue_api/locals.tf
+++ b/terraform/catalogue_api/locals.tf
@@ -8,4 +8,30 @@ locals {
 
   search_repository = data.terraform_remote_state.catalogue_api_shared.outputs["ecr_search_repository_url"]
   items_repository  = data.terraform_remote_state.catalogue_api_shared.outputs["ecr_items_repository_url"]
+
+  apm_secret_config = {
+    apm_server_url = "catalogue/api/apm_server_url"
+    apm_secret     = "catalogue/api/apm_secret"
+  }
+
+  es_items_secret_config = {
+    es_host = "elasticsearch/catalogue/private_host"
+    es_port = "catalogue/items/es_port"
+    es_protocol = "catalogue/items/es_protocol"
+    es_username = "catalogue/items/es_username"
+    es_password = "catalogue/items/es_password"
+  }
+
+  es_search_secret_config = {
+    es_host = "elasticsearch/catalogue/private_host"
+    es_port = "catalogue/search/es_port"
+    es_protocol = "catalogue/search/es_protocol"
+    es_username = "catalogue/search/es_username"
+    es_password = "catalogue/search/es_password"
+  }
+
+  sierra_secret_config = {
+    sierra_api_key    = "stacks/prod/sierra_api_key"
+    sierra_api_secret = "stacks/prod/sierra_api_secret"
+  }
 }

--- a/terraform/catalogue_api/locals.tf
+++ b/terraform/catalogue_api/locals.tf
@@ -30,6 +30,9 @@ locals {
     es_password = "catalogue/search/es_password"
   }
 
+  // TODO: Requests & Items APIs have different security profile
+  // TODO: Requests will access PII - and must have a different set of credentials!
+  // See: https://github.com/wellcomecollection/catalogue-api/issues/95
   sierra_secret_config = {
     sierra_api_key    = "stacks/prod/sierra_api_key"
     sierra_api_secret = "stacks/prod/sierra_api_secret"

--- a/terraform/catalogue_api/locals.tf
+++ b/terraform/catalogue_api/locals.tf
@@ -15,16 +15,16 @@ locals {
   }
 
   es_items_secret_config = {
-    es_host = "elasticsearch/catalogue/private_host"
-    es_port = "catalogue/items/es_port"
+    es_host     = "elasticsearch/catalogue/private_host"
+    es_port     = "catalogue/items/es_port"
     es_protocol = "catalogue/items/es_protocol"
     es_username = "catalogue/items/es_username"
     es_password = "catalogue/items/es_password"
   }
 
   es_search_secret_config = {
-    es_host = "elasticsearch/catalogue/private_host"
-    es_port = "catalogue/search/es_port"
+    es_host     = "elasticsearch/catalogue/private_host"
+    es_port     = "catalogue/search/es_port"
     es_protocol = "catalogue/search/es_protocol"
     es_username = "catalogue/search/es_username"
     es_password = "catalogue/search/es_password"

--- a/terraform/catalogue_api/main.tf
+++ b/terraform/catalogue_api/main.tf
@@ -3,10 +3,12 @@ module "catalogue_api_prod" {
 
   environment_name  = "prod"
   external_hostname = "api.wellcomecollection.org"
+
   container_images = {
     search = "${local.search_repository}:env.prod"
     items  = "${local.items_repository}:env.prod"
   }
+
   desired_task_counts = {
     search = 3
     items  = 3
@@ -16,6 +18,11 @@ module "catalogue_api_prod" {
   private_subnets          = local.private_subnets
   elastic_cloud_vpce_sg_id = local.elastic_cloud_vpce_sg_id
   cluster_arn              = aws_ecs_cluster.catalogue_api.arn
+
+  apm_secret_config       = local.apm_secret_config
+  es_items_secret_config  = local.es_items_secret_config
+  es_search_secret_config = local.es_search_secret_config
+  sierra_secret_config    = local.sierra_secret_config
 
   providers = {
     aws.dns        = aws.dns
@@ -28,10 +35,12 @@ module "catalogue_api_stage" {
 
   environment_name  = "stage"
   external_hostname = "api-stage.wellcomecollection.org"
+
   container_images = {
     search = "${local.search_repository}:env.stage"
     items  = "${local.items_repository}:env.stage"
   }
+
   desired_task_counts = {
     search = 1
     items  = 1
@@ -41,6 +50,11 @@ module "catalogue_api_stage" {
   private_subnets          = local.private_subnets
   elastic_cloud_vpce_sg_id = local.elastic_cloud_vpce_sg_id
   cluster_arn              = aws_ecs_cluster.catalogue_api.arn
+
+  apm_secret_config       = local.apm_secret_config
+  es_items_secret_config  = local.es_items_secret_config
+  es_search_secret_config = local.es_search_secret_config
+  sierra_secret_config    = local.sierra_secret_config
 
   providers = {
     aws.dns        = aws.dns

--- a/terraform/modules/stack/services.tf
+++ b/terraform/modules/stack/services.tf
@@ -28,15 +28,8 @@ module "search_api" {
     apm_service_name = "search-api"
     apm_environment  = var.environment_name
   }
-  secrets = {
-    es_host        = "elasticsearch/catalogue/private_host"
-    es_port        = "catalogue/search/es_port"
-    es_protocol    = "catalogue/search/es_protocol"
-    es_username    = "catalogue/search/es_username"
-    es_password    = "catalogue/search/es_password"
-    apm_server_url = "catalogue/api/apm_server_url"
-    apm_secret     = "catalogue/api/apm_secret"
-  }
+
+  secrets = merge(var.es_search_secret_config, var.apm_secret_config)
 
   subnets                = local.routable_private_subnets
   cluster_arn            = var.cluster_arn
@@ -70,19 +63,8 @@ module "items_api" {
     log_level         = "INFO"
     metrics_namespace = "items-api"
   }
-  secrets = {
-    sierra_api_key    = "stacks/prod/sierra_api_key"
-    sierra_api_secret = "stacks/prod/sierra_api_secret"
 
-    apm_server_url = "catalogue/api/apm_server_url"
-    apm_secret     = "catalogue/api/apm_secret"
-
-    es_host     = "elasticsearch/catalogue/private_host"
-    es_port     = "catalogue/items/es_port"
-    es_protocol = "catalogue/items/es_protocol"
-    es_username = "catalogue/items/es_username"
-    es_password = "catalogue/items/es_password"
-  }
+  secrets = merge(var.es_items_secret_config, var.apm_secret_config, var.sierra_secret_config)
 
   subnets                = local.routable_private_subnets
   cluster_arn            = var.cluster_arn

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -35,3 +35,37 @@ variable "container_images" {
     items  = string
   })
 }
+
+variable "es_items_secret_config" {
+  type=object({
+    es_host     = string
+    es_port     = string
+    es_protocol = string
+    es_username = string
+    es_password = string
+  })
+}
+
+variable "es_search_secret_config" {
+  type=object({
+    es_host     = string
+    es_port     = string
+    es_protocol = string
+    es_username = string
+    es_password = string
+  })
+}
+
+variable "apm_secret_config" {
+  type=object({
+    apm_server_url = string
+    apm_secret     = string
+  })
+}
+
+variable "sierra_secret_config" {
+  type=object({
+    sierra_api_key    = string
+    sierra_api_secret = string
+  })
+}

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -37,7 +37,7 @@ variable "container_images" {
 }
 
 variable "es_items_secret_config" {
-  type=object({
+  type = object({
     es_host     = string
     es_port     = string
     es_protocol = string
@@ -47,7 +47,7 @@ variable "es_items_secret_config" {
 }
 
 variable "es_search_secret_config" {
-  type=object({
+  type = object({
     es_host     = string
     es_port     = string
     es_protocol = string
@@ -57,14 +57,14 @@ variable "es_search_secret_config" {
 }
 
 variable "apm_secret_config" {
-  type=object({
+  type = object({
     apm_server_url = string
     apm_secret     = string
   })
 }
 
 variable "sierra_secret_config" {
-  type=object({
+  type = object({
     sierra_api_key    = string
     sierra_api_secret = string
   })


### PR DESCRIPTION
We will want to vary the secrets we hand to each env in order to move to a new ES cluster in stage before prod. 

This is a no-op change in terraform.

For https://github.com/wellcomecollection/platform/issues/5185