### PR TITLE
Split items/search credentials

### DIFF
--- a/terraform/shared/elastic.tf
+++ b/terraform/shared/elastic.tf
@@ -71,17 +71,33 @@ module "catalogue_api_secrets" {
   tags        = local.default_tags
 }
 
-# Catalogue API service credentials
+# Search service credentials
 
-resource "aws_secretsmanager_secret" "service-catalogue_api-username" {
-  name = "elasticsearch/catalogue_api/catalogue_api/username"
+resource "aws_secretsmanager_secret" "service-search-username" {
+  name = "elasticsearch/catalogue_api/search/username"
 
   description = "Config secret populated by Terraform"
   tags        = local.default_tags
 }
 
-resource "aws_secretsmanager_secret" "service-catalogue_api-password" {
-  name = "elasticsearch/catalogue_api/catalogue_api/password"
+resource "aws_secretsmanager_secret" "service-search-password" {
+  name = "elasticsearch/catalogue_api/search/password"
+
+  description = "Config secret populated by Terraform"
+  tags        = local.default_tags
+}
+
+# Items service credentials
+
+resource "aws_secretsmanager_secret" "service-items-username" {
+  name = "elasticsearch/catalogue_api/items/username"
+
+  description = "Config secret populated by Terraform"
+  tags        = local.default_tags
+}
+
+resource "aws_secretsmanager_secret" "service-items-password" {
+  name = "elasticsearch/catalogue_api/items/password"
 
   description = "Config secret populated by Terraform"
   tags        = local.default_tags
@@ -129,8 +145,10 @@ resource "null_resource" "elasticsearch_users" {
   depends_on = [
     ec_deployment.catalogue_api,
     module.catalogue_api_secrets,
-    aws_secretsmanager_secret.service-catalogue_api-username,
-    aws_secretsmanager_secret.service-catalogue_api-password,
+    aws_secretsmanager_secret.service-search-username,
+    aws_secretsmanager_secret.service-search-password,
+    aws_secretsmanager_secret.service-items-username,
+    aws_secretsmanager_secret.service-items-password,
     aws_secretsmanager_secret.service-diff_tool-username,
     aws_secretsmanager_secret.service-diff_tool-password,
     aws_secretsmanager_secret.service-replication_manager-username,

--- a/terraform/shared/scripts/create_elastic_users.py
+++ b/terraform/shared/scripts/create_elastic_users.py
@@ -36,7 +36,8 @@ ROLES = {
 }
 
 SERVICES = {
-    "catalogue_api": ["catalogue_read"],
+    "search": ["catalogue_read"],
+    "items": ["catalogue_read"],
     "diff_tool": ["catalogue_read"],
     "replication_manager": ["catalogue_read", "catalogue_manage_ccr"]
 }


### PR DESCRIPTION
We need separate credentials for items & search services, this change provides them.

## terraform diff
```
Terraform will perform the following actions:

  # aws_secretsmanager_secret.service-catalogue_api-password will be destroyed
  - resource "aws_secretsmanager_secret" "service-catalogue_api-password" {
      - arn                     = "arn:aws:secretsmanager:eu-west-1:756629837203:secret:elasticsearch/catalogue_api/catalogue_api/password-EYBG62" -> null
      - description             = "Config secret populated by Terraform" -> null
      - id                      = "arn:aws:secretsmanager:eu-west-1:756629837203:secret:elasticsearch/catalogue_api/catalogue_api/password-EYBG62" -> null
      - name                    = "elasticsearch/catalogue_api/catalogue_api/password" -> null
      - recovery_window_in_days = 30 -> null
      - rotation_enabled        = false -> null
      - tags                    = {
          - "Managed"                   = "terraform"
          - "TerraformConfigurationURL" = "https://github.com/wellcomecollection/catalogue-api/tree/main/terraform/shared"
        } -> null
    }

  # aws_secretsmanager_secret.service-catalogue_api-username will be destroyed
  - resource "aws_secretsmanager_secret" "service-catalogue_api-username" {
      - arn                     = "arn:aws:secretsmanager:eu-west-1:756629837203:secret:elasticsearch/catalogue_api/catalogue_api/username-hYIdZ2" -> null
      - description             = "Config secret populated by Terraform" -> null
      - id                      = "arn:aws:secretsmanager:eu-west-1:756629837203:secret:elasticsearch/catalogue_api/catalogue_api/username-hYIdZ2" -> null
      - name                    = "elasticsearch/catalogue_api/catalogue_api/username" -> null
      - recovery_window_in_days = 30 -> null
      - rotation_enabled        = false -> null
      - tags                    = {
          - "Managed"                   = "terraform"
          - "TerraformConfigurationURL" = "https://github.com/wellcomecollection/catalogue-api/tree/main/terraform/shared"
        } -> null
    }

  # aws_secretsmanager_secret.service-items-password will be created
  + resource "aws_secretsmanager_secret" "service-items-password" {
      + arn                     = (known after apply)
      + description             = "Config secret populated by Terraform"
      + id                      = (known after apply)
      + name                    = "elasticsearch/catalogue_api/items/password"
      + name_prefix             = (known after apply)
      + recovery_window_in_days = 30
      + rotation_enabled        = (known after apply)
      + rotation_lambda_arn     = (known after apply)
      + tags                    = {
          + "Managed"                   = "terraform"
          + "TerraformConfigurationURL" = "https://github.com/wellcomecollection/catalogue-api/tree/main/terraform/shared"
        }

      + rotation_rules {
          + automatically_after_days = (known after apply)
        }
    }

  # aws_secretsmanager_secret.service-items-username will be created
  + resource "aws_secretsmanager_secret" "service-items-username" {
      + arn                     = (known after apply)
      + description             = "Config secret populated by Terraform"
      + id                      = (known after apply)
      + name                    = "elasticsearch/catalogue_api/items/username"
      + name_prefix             = (known after apply)
      + recovery_window_in_days = 30
      + rotation_enabled        = (known after apply)
      + rotation_lambda_arn     = (known after apply)
      + tags                    = {
          + "Managed"                   = "terraform"
          + "TerraformConfigurationURL" = "https://github.com/wellcomecollection/catalogue-api/tree/main/terraform/shared"
        }

      + rotation_rules {
          + automatically_after_days = (known after apply)
        }
    }

  # aws_secretsmanager_secret.service-search-password will be created
  + resource "aws_secretsmanager_secret" "service-search-password" {
      + arn                     = (known after apply)
      + description             = "Config secret populated by Terraform"
      + id                      = (known after apply)
      + name                    = "elasticsearch/catalogue_api/search/password"
      + name_prefix             = (known after apply)
      + recovery_window_in_days = 30
      + rotation_enabled        = (known after apply)
      + rotation_lambda_arn     = (known after apply)
      + tags                    = {
          + "Managed"                   = "terraform"
          + "TerraformConfigurationURL" = "https://github.com/wellcomecollection/catalogue-api/tree/main/terraform/shared"
        }

      + rotation_rules {
          + automatically_after_days = (known after apply)
        }
    }

  # aws_secretsmanager_secret.service-search-username will be created
  + resource "aws_secretsmanager_secret" "service-search-username" {
      + arn                     = (known after apply)
      + description             = "Config secret populated by Terraform"
      + id                      = (known after apply)
      + name                    = "elasticsearch/catalogue_api/search/username"
      + name_prefix             = (known after apply)
      + recovery_window_in_days = 30
      + rotation_enabled        = (known after apply)
      + rotation_lambda_arn     = (known after apply)
      + tags                    = {
          + "Managed"                   = "terraform"
          + "TerraformConfigurationURL" = "https://github.com/wellcomecollection/catalogue-api/tree/main/terraform/shared"
        }

      + rotation_rules {
          + automatically_after_days = (known after apply)
        }
    }

Plan: 4 to add, 0 to change, 2 to destroy.
```

For https://github.com/wellcomecollection/platform/issues/5185