### PR TITLE
use default query when fetching index JSON

### DIFF
--- a/rank/pages/api/json.ts
+++ b/rank/pages/api/json.ts
@@ -16,8 +16,8 @@ export default async (
     notFound(res, req)
   } else {
     const [index, query] = await Promise.all([
-      await import(`../../data/indices/${namespace}`),
-      await import(`../../data/queries/${namespace}`),
+      await import(`../../data/indices/${namespace}`).then((m) => m.default),
+      await import(`../../data/queries/${namespace}`).then((m) => m.default),
     ])
 
     ok(res, { index, query })


### PR DESCRIPTION
Avoids the JSON being
```JSONC
{ "default": { "mappings": { /*...*/ } } }
```

And rather 
```JSONC
{ "mappings": { /*...*/ } }
```

[See here for example](https://rank.wellcomecollection.org/api/json?namespace=works)