### PR TITLE
Change how we handle HTTP requests to the Sierra API

### DIFF
--- a/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/source/SierraSource.scala
+++ b/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/source/SierraSource.scala
@@ -66,7 +66,7 @@ object SierraSource {
     display: String
   )
   case class SierraItemStub(
-    id: String,
+    id: SierraItemNumber,
     status: SierraItemStatusStub
   )
   case class SierraHoldRequestPostBody(

--- a/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/source/SierraSource.scala
+++ b/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/source/SierraSource.scala
@@ -13,6 +13,7 @@ import weco.api.stacks.http.{
   AkkaClientPost,
   AkkaClientTokenExchange
 }
+import weco.api.stacks.http.impl.AkkaHttpClient
 import weco.catalogue.source_model.sierra.identifiers.{
   SierraItemNumber,
   SierraPatronNumber
@@ -97,19 +98,18 @@ class AkkaSierraSource(
 
   override val tokenPath = Path("v5/token")
 
+  import weco.api.stacks.http
+
+  private val underlying = new http.SierraSource(
+    client = new AkkaHttpClient(
+      baseUri = baseUri,
+      credentials = credentials
+    )
+  )
+
   // See https://sandbox.iii.com/iii/sierra-api/swagger/index.html#!/items
   def getSierraItemStub(itemNumber: SierraItemNumber): Future[SierraItemStub] =
-    for {
-      token <- getToken(credentials)
-      item <- get[SierraItemStub](
-        path = Path(s"v5/items/${itemNumber.withoutCheckDigit}"),
-        headers = List(Authorization(token))
-      )
-    } yield
-      item match {
-        case SuccessResponse(Some(holds)) => holds
-        case _                            => throw new Exception(s"Failed to get item!")
-      }
+    underlying.lookupItem(itemNumber).map(_.right.get)
 
   // See https://sandbox.iii.com/iii/sierra-api/swagger/index.html#!/patrons
   def getSierraUserHoldsStub(

--- a/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/source/SierraSource.scala
+++ b/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/source/SierraSource.scala
@@ -13,6 +13,7 @@ import weco.api.stacks.http.{
   AkkaClientPost,
   AkkaClientTokenExchange
 }
+import weco.api.stacks.http.SierraAuthenticatedHttpClient
 import weco.api.stacks.http.impl.AkkaHttpClient
 import weco.catalogue.source_model.sierra.identifiers.{
   SierraItemNumber,
@@ -100,9 +101,11 @@ class AkkaSierraSource(
 
   import weco.api.stacks.http
 
+  private val httpClient = new AkkaHttpClient(baseUri = baseUri)
+
   private val underlying = new http.SierraSource(
-    client = new AkkaHttpClient(
-      baseUri = baseUri,
+    client = new SierraAuthenticatedHttpClient(
+      underlying = httpClient,
       credentials = credentials
     )
   )

--- a/common/stacks/src/main/scala/weco/api/stacks/http/HttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/HttpClient.scala
@@ -12,7 +12,7 @@ trait HttpClient {
 
   implicit val ec: ExecutionContext
 
-  protected def makeRequest(request: HttpRequest): Future[HttpResponse]
+  def makeRequest(request: HttpRequest): Future[HttpResponse]
 
   private def buildUri(
     path: Path,

--- a/common/stacks/src/main/scala/weco/api/stacks/http/HttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/HttpClient.scala
@@ -22,15 +22,10 @@ trait HttpClient {
       .withPath(baseUri.path ++ Slash(path))
       .withQuery(Query(params))
 
-  def get(
-    path: Path,
-    params: Map[String, String] = Map.empty,
-    headers: List[HttpHeader] = Nil): Future[HttpResponse] = {
-
+  def get(path: Path, params: Map[String, String] = Map.empty): Future[HttpResponse] = {
     val request = HttpRequest(
       method = HttpMethods.GET,
-      uri = buildUri(path, params),
-      headers = headers
+      uri = buildUri(path, params)
     )
 
     makeRequest(request)

--- a/common/stacks/src/main/scala/weco/api/stacks/http/HttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/HttpClient.scala
@@ -23,7 +23,8 @@ trait HttpClient {
       .withPath(baseUri.path ++ Slash(path))
       .withQuery(Query(params))
 
-  def get(path: Path, params: Map[String, String] = Map.empty): Future[HttpResponse] = {
+  def get(path: Path,
+          params: Map[String, String] = Map.empty): Future[HttpResponse] = {
     val request = HttpRequest(
       method = HttpMethods.GET,
       uri = buildUri(path, params)
@@ -32,11 +33,10 @@ trait HttpClient {
     singleRequest(request)
   }
 
-  def post[In](
-    path: Path,
-    body: Option[In] = None,
-    params: Map[String, String] = Map.empty,
-    headers: List[HttpHeader] = Nil)(
+  def post[In](path: Path,
+               body: Option[In] = None,
+               params: Map[String, String] = Map.empty,
+               headers: List[HttpHeader] = Nil)(
     implicit encoder: Encoder[In]
   ): Future[HttpResponse] = {
     implicit val um: ToEntityMarshaller[In] = CirceMarshalling.fromEncoder[In]

--- a/common/stacks/src/main/scala/weco/api/stacks/http/HttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/HttpClient.scala
@@ -1,9 +1,61 @@
 package weco.api.stacks.http
 
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.http.scaladsl.marshalling.{Marshal, Marshaller}
+import akka.http.scaladsl.model.Uri.Path.Slash
+import akka.http.scaladsl.model.Uri.{Path, Query}
+import akka.http.scaladsl.model._
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 trait HttpClient {
-  def makeRequest(request: HttpRequest): Future[HttpResponse]
+  val baseUri: Uri
+
+  implicit val ec: ExecutionContext
+
+  protected def makeRequest(request: HttpRequest): Future[HttpResponse]
+
+  private def buildUri(
+    path: Path,
+    params: Map[String, String]
+  ): Uri =
+    baseUri
+      .withPath(baseUri.path ++ Slash(path))
+      .withQuery(Query(params))
+
+  def get(
+    path: Path,
+    params: Map[String, String] = Map.empty,
+    headers: List[HttpHeader] = Nil): Future[HttpResponse] = {
+
+    val request = HttpRequest(
+      method = HttpMethods.GET,
+      uri = buildUri(path, params),
+      headers = headers
+    )
+
+    makeRequest(request)
+  }
+
+  def post[In](
+    path: Path,
+    body: Option[In] = None,
+    params: Map[String, String] = Map.empty,
+    headers: List[HttpHeader] = Nil)(
+    implicit m: Marshaller[In, RequestEntity]
+  ): Future[HttpResponse] =
+    for {
+      entity <- body match {
+        case Some(body) => Marshal(body).to[RequestEntity]
+        case None       => Future.successful(HttpEntity.Empty)
+      }
+
+      request = HttpRequest(
+        HttpMethods.POST,
+        uri = buildUri(path, params),
+        headers = headers,
+        entity = entity
+      )
+
+      response <- makeRequest(request)
+    } yield response
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/http/HttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/HttpClient.scala
@@ -5,5 +5,5 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import scala.concurrent.Future
 
 trait HttpClient {
-  protected def makeRequest(request: HttpRequest): Future[HttpResponse]
+  def makeRequest(request: HttpRequest): Future[HttpResponse]
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/http/HttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/HttpClient.scala
@@ -1,0 +1,9 @@
+package weco.api.stacks.http
+
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+
+import scala.concurrent.Future
+
+trait HttpClient {
+  protected def makeRequest(request: HttpRequest): Future[HttpResponse]
+}

--- a/common/stacks/src/main/scala/weco/api/stacks/http/SierraAuthenticatedHttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/SierraAuthenticatedHttpClient.scala
@@ -1,0 +1,65 @@
+package weco.api.stacks.http
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, HttpResponse, Uri}
+import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials, OAuth2BearerToken}
+import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
+import io.circe.generic.extras.JsonKey
+import uk.ac.wellcome.platform.api.http.TokenExchange
+
+import java.time.Instant
+import scala.concurrent.Future
+
+trait SierraAuthenticatedHttpClient
+  extends HttpClient
+    with TokenExchange[BasicHttpCredentials, OAuth2BearerToken] {
+
+  val tokenUri: Uri
+  val credentials: BasicHttpCredentials
+
+  implicit val system: ActorSystem
+  implicit val unmarshal: Unmarshaller[HttpResponse, AccessToken]
+
+  protected def makeRequest(request: HttpRequest, token: OAuth2BearerToken): Future[HttpResponse]
+
+  // This implements the Client Credentials flow, as described in the Sierra docs:
+  // https://techdocs.iii.com/sierraapi/Content/zReference/authClient.htm
+  //
+  // We make a request with a client key and secret, retrieve an access token which
+  // lasts an hour, and use that for future requests.  When the hour is up, we have
+  // to fetch a new token.
+  //
+  private case class AccessToken(
+    @JsonKey("access_token") accessToken: String,
+    @JsonKey("expires_in") expiresIn: Int
+  )
+
+  override protected def getNewToken(
+                                      credentials: BasicHttpCredentials
+                                    ): Future[(OAuth2BearerToken, Instant)] = {
+    val postRequest = HttpRequest(
+      method = HttpMethods.POST,
+      uri = tokenUri,
+      headers = List(Authorization(credentials))
+    )
+
+    for {
+      tokenResponse <- Http().singleRequest(postRequest)
+
+      accessToken <- Unmarshal(tokenResponse).to[AccessToken]
+
+      result = (
+        OAuth2BearerToken(accessToken.accessToken),
+        Instant.now().plusSeconds(accessToken.expiresIn)
+      )
+    } yield result
+  }
+
+  override protected def makeRequest(request: HttpRequest): Future[HttpResponse] =
+    for {
+      token <- getToken(credentials)
+
+      response <- makeRequest(request, token)
+    } yield response
+}

--- a/common/stacks/src/main/scala/weco/api/stacks/http/SierraAuthenticatedHttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/SierraAuthenticatedHttpClient.scala
@@ -23,15 +23,15 @@ class SierraAuthenticatedHttpClient(
   implicit
   val system: ActorSystem,
   val ec: ExecutionContext
-)
-  extends HttpClient
+) extends HttpClient
     with TokenExchange[BasicHttpCredentials, OAuth2BearerToken] {
 
   override val baseUri: Uri = underlying.baseUri
 
   import uk.ac.wellcome.json.JsonUtil._
 
-  implicit val um: FromEntityUnmarshaller[SierraAccessToken] = CirceMarshalling.fromDecoder[SierraAccessToken]
+  implicit val um: FromEntityUnmarshaller[SierraAccessToken] =
+    CirceMarshalling.fromDecoder[SierraAccessToken]
 
   // This implements the Client Credentials flow, as described in the Sierra docs:
   // https://techdocs.iii.com/sierraapi/Content/zReference/authClient.htm
@@ -70,7 +70,9 @@ class SierraAuthenticatedHttpClient(
         val existingAuthHeaders = request.headers.collect {
           case auth: Authorization => auth
         }
-        require(existingAuthHeaders.isEmpty, s"HTTP request already has auth headers: $request")
+        require(
+          existingAuthHeaders.isEmpty,
+          s"HTTP request already has auth headers: $request")
 
         request.copy(
           headers = request.headers :+ Authorization(token)

--- a/common/stacks/src/main/scala/weco/api/stacks/http/SierraAuthenticatedHttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/SierraAuthenticatedHttpClient.scala
@@ -31,7 +31,7 @@ class SierraAuthenticatedHttpClient(
 
   import uk.ac.wellcome.json.JsonUtil._
 
-  implicit val um: FromEntityUnmarshaller[SierraAccessToken] = createUnmarshaller[SierraAccessToken]
+  implicit val um: FromEntityUnmarshaller[SierraAccessToken] = CirceMarshalling.fromDecoder[SierraAccessToken]
 
   // This implements the Client Credentials flow, as described in the Sierra docs:
   // https://techdocs.iii.com/sierraapi/Content/zReference/authClient.htm
@@ -57,7 +57,7 @@ class SierraAuthenticatedHttpClient(
       )
     } yield result
 
-  override def makeRequest(request: HttpRequest): Future[HttpResponse] =
+  override def singleRequest(request: HttpRequest): Future[HttpResponse] =
     for {
       token <- getToken(credentials)
 
@@ -77,6 +77,6 @@ class SierraAuthenticatedHttpClient(
         )
       }
 
-      response <- underlying.makeRequest(authenticatedRequest)
+      response <- underlying.singleRequest(authenticatedRequest)
     } yield response
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/http/SierraSource.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/SierraSource.scala
@@ -9,19 +9,37 @@ import weco.catalogue.source_model.sierra.identifiers.SierraItemNumber
 
 import scala.concurrent.{ExecutionContext, Future}
 
+sealed trait SierraItemLookupError
+
+object SierraItemLookupError {
+  case class ItemHasNoStatus(t: Throwable) extends SierraItemLookupError
+
+  case object ItemNotFound extends SierraItemLookupError
+
+  case class UnknownError(errorCode: SierraErrorCode) extends SierraItemLookupError
+}
+
 class SierraSource(client: HttpClient)(implicit ec: ExecutionContext, mat: Materializer) {
   import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
   import io.circe.generic.auto._
 
-  def lookupItem(item: SierraItemNumber): Future[Either[SierraErrorCode, SierraItemStub]] =
+  def lookupItem(item: SierraItemNumber): Future[Either[SierraItemLookupError, SierraItemStub]] =
     for {
       resp <- client.get(
         path = Path(s"v5/items/${item.withoutCheckDigit}")
       )
 
       result <- resp.status match {
-        case StatusCodes.OK => Unmarshal(resp).to[SierraItemStub].map(Right(_))
-        case _              => Unmarshal(resp).to[SierraErrorCode].map(Left(_))
+        case StatusCodes.OK => Unmarshal(resp).to[SierraItemStub]
+          .map(Right(_))
+          .recover { case t: Throwable => Left(SierraItemLookupError.ItemHasNoStatus(t)) }
+
+        case StatusCodes.NotFound =>
+          Future.successful(Left(SierraItemLookupError.ItemNotFound))
+
+        case _                    =>
+          Unmarshal(resp).to[SierraErrorCode]
+            .map(err => Left(SierraItemLookupError.UnknownError(err)))
       }
     } yield result
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/http/SierraSource.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/SierraSource.scala
@@ -1,0 +1,27 @@
+package weco.api.stacks.http
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.Materializer
+import uk.ac.wellcome.platform.api.common.services.source.SierraSource.{SierraErrorCode, SierraItemStub}
+import weco.catalogue.source_model.sierra.identifiers.SierraItemNumber
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class SierraSource(client: HttpClient)(implicit ec: ExecutionContext, mat: Materializer) {
+  import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+  import io.circe.generic.auto._
+
+  def lookupItem(item: SierraItemNumber): Future[Either[SierraErrorCode, SierraItemStub]] =
+    for {
+      resp <- client.get(
+        path = Path(s"v5/items/${item.withoutCheckDigit}")
+      )
+
+      result <- resp.status match {
+        case StatusCodes.OK => Unmarshal(resp).to[SierraItemStub].map(Right(_))
+        case _              => Unmarshal(resp).to[SierraErrorCode].map(Left(_))
+      }
+    } yield result
+}

--- a/common/stacks/src/main/scala/weco/api/stacks/http/SierraSource.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/SierraSource.scala
@@ -4,7 +4,10 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
-import uk.ac.wellcome.platform.api.common.services.source.SierraSource.{SierraErrorCode, SierraItemStub}
+import uk.ac.wellcome.platform.api.common.services.source.SierraSource.{
+  SierraErrorCode,
+  SierraItemStub
+}
 import weco.catalogue.source_model.sierra.identifiers.SierraItemNumber
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -16,29 +19,38 @@ object SierraItemLookupError {
 
   case object ItemNotFound extends SierraItemLookupError
 
-  case class UnknownError(errorCode: SierraErrorCode) extends SierraItemLookupError
+  case class UnknownError(errorCode: SierraErrorCode)
+      extends SierraItemLookupError
 }
 
-class SierraSource(client: HttpClient)(implicit ec: ExecutionContext, mat: Materializer) {
+class SierraSource(client: HttpClient)(implicit ec: ExecutionContext,
+                                       mat: Materializer) {
   import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
   import io.circe.generic.auto._
 
-  def lookupItem(item: SierraItemNumber): Future[Either[SierraItemLookupError, SierraItemStub]] =
+  def lookupItem(item: SierraItemNumber)
+    : Future[Either[SierraItemLookupError, SierraItemStub]] =
     for {
       resp <- client.get(
         path = Path(s"v5/items/${item.withoutCheckDigit}")
       )
 
       result <- resp.status match {
-        case StatusCodes.OK => Unmarshal(resp).to[SierraItemStub]
-          .map(Right(_))
-          .recover { case t: Throwable => Left(SierraItemLookupError.ItemHasNoStatus(t)) }
+        case StatusCodes.OK =>
+          Unmarshal(resp)
+            .to[SierraItemStub]
+            .map(Right(_))
+            .recover {
+              case t: Throwable =>
+                Left(SierraItemLookupError.ItemHasNoStatus(t))
+            }
 
         case StatusCodes.NotFound =>
           Future.successful(Left(SierraItemLookupError.ItemNotFound))
 
-        case _                    =>
-          Unmarshal(resp).to[SierraErrorCode]
+        case _ =>
+          Unmarshal(resp)
+            .to[SierraErrorCode]
             .map(err => Left(SierraItemLookupError.UnknownError(err)))
       }
     } yield result

--- a/common/stacks/src/main/scala/weco/api/stacks/http/impl/AkkaHttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/impl/AkkaHttpClient.scala
@@ -8,6 +8,6 @@ import weco.api.stacks.http.HttpClient
 import scala.concurrent.{ExecutionContext, Future}
 
 class AkkaHttpClient(val baseUri: Uri)(implicit system: ActorSystem, val ec: ExecutionContext) extends HttpClient {
-  override def makeRequest(request: HttpRequest): Future[HttpResponse] =
+  override def singleRequest(request: HttpRequest): Future[HttpResponse] =
     Http().singleRequest(request)
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/http/impl/AkkaHttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/impl/AkkaHttpClient.scala
@@ -7,7 +7,9 @@ import weco.api.stacks.http.HttpClient
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class AkkaHttpClient(val baseUri: Uri)(implicit system: ActorSystem, val ec: ExecutionContext) extends HttpClient {
+class AkkaHttpClient(val baseUri: Uri)(implicit system: ActorSystem,
+                                       val ec: ExecutionContext)
+    extends HttpClient {
   override def singleRequest(request: HttpRequest): Future[HttpResponse] =
     Http().singleRequest(request)
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/http/impl/AkkaHttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/impl/AkkaHttpClient.scala
@@ -1,0 +1,25 @@
+package weco.api.stacks.http.impl
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import weco.api.stacks.http.SierraAuthenticatedHttpClient
+import weco.api.stacks.models.SierraAccessToken
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AkkaHttpClient(
+  val tokenUri: Uri,
+  val credentials: BasicHttpCredentials
+)(
+  implicit
+  val ec: ExecutionContext,
+  val system: ActorSystem,
+  val unmarshaller: Unmarshaller[HttpResponse, SierraAccessToken]
+) extends SierraAuthenticatedHttpClient {
+
+  override protected def makeSingleRequest(request: HttpRequest): Future[HttpResponse] =
+    Http().singleRequest(request)
+}

--- a/common/stacks/src/main/scala/weco/api/stacks/http/impl/AkkaHttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/impl/AkkaHttpClient.scala
@@ -2,27 +2,12 @@ package weco.api.stacks.http.impl
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.Uri.Path
-import akka.http.scaladsl.model.headers.BasicHttpCredentials
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
-import akka.http.scaladsl.unmarshalling.Unmarshaller
-import weco.api.stacks.http.SierraAuthenticatedHttpClient
-import weco.api.stacks.models.SierraAccessToken
+import weco.api.stacks.http.HttpClient
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class AkkaHttpClient(
-  val baseUri: Uri,
-  val credentials: BasicHttpCredentials
-)(
-  implicit
-  val ec: ExecutionContext,
-  val system: ActorSystem,
-  val um: Unmarshaller[HttpResponse, SierraAccessToken]
-) extends SierraAuthenticatedHttpClient {
-
-  override protected def makeSingleRequest(request: HttpRequest): Future[HttpResponse] =
+class AkkaHttpClient(val baseUri: Uri)(implicit system: ActorSystem, val ec: ExecutionContext) extends HttpClient {
+  override def makeRequest(request: HttpRequest): Future[HttpResponse] =
     Http().singleRequest(request)
-
-  override val tokenPath: Path = Path("v5/token")
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/http/impl/AkkaHttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/impl/AkkaHttpClient.scala
@@ -2,6 +2,7 @@ package weco.api.stacks.http.impl
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.model.headers.BasicHttpCredentials
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
 import akka.http.scaladsl.unmarshalling.Unmarshaller
@@ -11,15 +12,17 @@ import weco.api.stacks.models.SierraAccessToken
 import scala.concurrent.{ExecutionContext, Future}
 
 class AkkaHttpClient(
-  val tokenUri: Uri,
+  val baseUri: Uri,
   val credentials: BasicHttpCredentials
 )(
   implicit
   val ec: ExecutionContext,
   val system: ActorSystem,
-  val unmarshaller: Unmarshaller[HttpResponse, SierraAccessToken]
+  val um: Unmarshaller[HttpResponse, SierraAccessToken]
 ) extends SierraAuthenticatedHttpClient {
 
   override protected def makeSingleRequest(request: HttpRequest): Future[HttpResponse] =
     Http().singleRequest(request)
+
+  override val tokenPath: Path = Path("v5/token")
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/http/impl/MemoryHttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/impl/MemoryHttpClient.scala
@@ -1,0 +1,26 @@
+package weco.api.stacks.http.impl
+
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
+import weco.api.stacks.http.HttpClient
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class MemoryHttpClient(
+  val baseUri: Uri,
+  responses: Seq[(HttpRequest, HttpResponse)]
+)(
+  implicit val ec: ExecutionContext
+) extends HttpClient {
+
+  private val iterator = responses.toIterator
+
+  override protected def makeRequest(request: HttpRequest): Future[HttpResponse] = Future {
+    val (nextReq, nextResp) = iterator.next()
+
+    if (nextReq != request) {
+      throw new RuntimeException(s"Expected request $nextReq, but got $request")
+    }
+
+    nextResp
+  }
+}

--- a/common/stacks/src/main/scala/weco/api/stacks/http/impl/MemoryHttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/impl/MemoryHttpClient.scala
@@ -15,7 +15,7 @@ class MemoryHttpClient(
 
   private val iterator = responses.toIterator
 
-  override def makeRequest(request: HttpRequest): Future[HttpResponse] = Future {
+  override def singleRequest(request: HttpRequest): Future[HttpResponse] = Future {
     val (nextReq, nextResp) = iterator.next()
 
     if (nextReq != request) {

--- a/common/stacks/src/main/scala/weco/api/stacks/http/impl/MemoryHttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/impl/MemoryHttpClient.scala
@@ -15,7 +15,7 @@ class MemoryHttpClient(
 
   private val iterator = responses.toIterator
 
-  override protected def makeRequest(request: HttpRequest): Future[HttpResponse] = Future {
+  override def makeRequest(request: HttpRequest): Future[HttpResponse] = Future {
     val (nextReq, nextResp) = iterator.next()
 
     if (nextReq != request) {

--- a/common/stacks/src/main/scala/weco/api/stacks/http/impl/MemoryHttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/impl/MemoryHttpClient.scala
@@ -15,13 +15,15 @@ class MemoryHttpClient(
 
   private val iterator = responses.toIterator
 
-  override def singleRequest(request: HttpRequest): Future[HttpResponse] = Future {
-    val (nextReq, nextResp) = iterator.next()
+  override def singleRequest(request: HttpRequest): Future[HttpResponse] =
+    Future {
+      val (nextReq, nextResp) = iterator.next()
 
-    if (nextReq != request) {
-      throw new RuntimeException(s"Expected request $nextReq, but got $request")
+      if (nextReq != request) {
+        throw new RuntimeException(
+          s"Expected request $nextReq, but got $request")
+      }
+
+      nextResp
     }
-
-    nextResp
-  }
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/http/impl/MemoryHttpClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/impl/MemoryHttpClient.scala
@@ -6,11 +6,12 @@ import weco.api.stacks.http.HttpClient
 import scala.concurrent.{ExecutionContext, Future}
 
 class MemoryHttpClient(
-  val baseUri: Uri,
   responses: Seq[(HttpRequest, HttpResponse)]
 )(
   implicit val ec: ExecutionContext
 ) extends HttpClient {
+
+  val baseUri: Uri = Uri("http://sierra:1234")
 
   private val iterator = responses.toIterator
 

--- a/common/stacks/src/main/scala/weco/api/stacks/models/SierraAccessToken.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/SierraAccessToken.scala
@@ -1,14 +1,11 @@
 package weco.api.stacks.models
 
+import io.circe.generic.extras.JsonKey
+
 // This represents a response from the Client Credentials flow, as described
 // in the Sierra docs:
 // https://techdocs.iii.com/sierraapi/Content/zReference/authClient.htm
-//
-// Note: these use snake_case instead of camelCase field names so they can be
-// correctly decoded by the akka-http Unmarshaller when they get received from
-// the Sierra API.  I tried using the @JsonKey annotation, couldn't get it working,
-// and didn't want to spend more time debugging it.
 case class SierraAccessToken(
-  access_token: String,
-  expires_in: Int
+  @JsonKey("access_token") accessToken: String,
+  @JsonKey("expires_in") expiresIn: Int
 )

--- a/common/stacks/src/main/scala/weco/api/stacks/models/SierraAccessToken.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/SierraAccessToken.scala
@@ -1,0 +1,14 @@
+package weco.api.stacks.models
+
+// This represents a response from the Client Credentials flow, as described
+// in the Sierra docs:
+// https://techdocs.iii.com/sierraapi/Content/zReference/authClient.htm
+//
+// Note: these use snake_case instead of camelCase field names so they can be
+// correctly decoded by the akka-http Unmarshaller when they get received from
+// the Sierra API.  I tried using the @JsonKey annotation, couldn't get it working,
+// and didn't want to spend more time debugging it.
+case class SierraAccessToken(
+  access_token: String,
+  expires_in: Int
+)

--- a/common/stacks/src/test/scala/weco/api/stacks/http/SierraSourceTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/http/SierraSourceTest.scala
@@ -7,14 +7,24 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.api.common.services.source.SierraSource.{SierraItemStatusStub, SierraItemStub}
+import uk.ac.wellcome.platform.api.common.services.source.SierraSource.{
+  SierraItemStatusStub,
+  SierraItemStub
+}
 import weco.api.stacks.http.impl.MemoryHttpClient
 import weco.catalogue.source_model.sierra.identifiers.SierraItemNumber
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class SierraSourceTest extends AnyFunSpec with Matchers with EitherValues with Akka with ScalaFutures with IntegrationPatience {
-  def withSource[R](responses: Seq[(HttpRequest, HttpResponse)])(testWith: TestWith[SierraSource, R]): R =
+class SierraSourceTest
+    extends AnyFunSpec
+    with Matchers
+    with EitherValues
+    with Akka
+    with ScalaFutures
+    with IntegrationPatience {
+  def withSource[R](responses: Seq[(HttpRequest, HttpResponse)])(
+    testWith: TestWith[SierraSource, R]): R =
     withMaterializer { implicit mat =>
       val client = new MemoryHttpClient(responses = responses)
 

--- a/common/stacks/src/test/scala/weco/api/stacks/http/SierraSourceTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/http/SierraSourceTest.scala
@@ -1,0 +1,82 @@
+package weco.api.stacks.http
+
+import akka.http.scaladsl.model._
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.akka.fixtures.Akka
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.api.common.services.source.SierraSource.{SierraItemStatusStub, SierraItemStub}
+import weco.api.stacks.http.impl.MemoryHttpClient
+import weco.catalogue.source_model.sierra.identifiers.SierraItemNumber
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class SierraSourceTest extends AnyFunSpec with Matchers with Akka with ScalaFutures with IntegrationPatience {
+  def withSource[R](responses: Seq[(HttpRequest, HttpResponse)])(testWith: TestWith[SierraSource, R]): R =
+    withMaterializer { implicit mat =>
+      val client = new MemoryHttpClient(responses = responses)
+
+      val source = new SierraSource(client)
+
+      testWith(source)
+    }
+
+  describe("lookupItem") {
+    it("looks up a single item") {
+      val itemNumber = SierraItemNumber("1146055")
+
+      val responses = Seq(
+        (
+          HttpRequest(
+            uri = Uri("http://sierra:1234/v5/items/1146055")
+          ),
+          HttpResponse(
+            entity = HttpEntity(
+              contentType = ContentTypes.`application/json`,
+              """
+                |{
+                |  "id": "1146055",
+                |  "updatedDate": "2021-06-09T13:23:27Z",
+                |  "createdDate": "1999-11-15T18:56:00Z",
+                |  "deleted": false,
+                |  "bibIds": [
+                |    "1126829"
+                |  ],
+                |  "location": {
+                |    "code": "sgmed",
+                |    "name": "Closed stores Med."
+                |  },
+                |  "status": {
+                |    "code": "t",
+                |    "display": "In quarantine"
+                |  },
+                |  "volumes": [],
+                |  "barcode": "22500271327",
+                |  "callNumber": "K33043"
+                |}
+                |
+                |""".stripMargin
+            )
+          )
+        )
+      )
+
+      withSource(responses) { source =>
+        val future = source.lookupItem(itemNumber)
+
+        whenReady(future) {
+          _ shouldBe Right(
+            SierraItemStub(
+              id = itemNumber,
+              status = SierraItemStatusStub(
+                code = "t",
+                display = "In quarantine"
+              )
+            )
+          )
+        }
+      }
+    }
+  }
+}

--- a/common/stacks/src/test/scala/weco/api/stacks/http/impl/AkkaHttpClientTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/http/impl/AkkaHttpClientTest.scala
@@ -1,0 +1,68 @@
+package weco.api.stacks.http.impl
+
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, StatusCodes, Uri}
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import uk.ac.wellcome.akka.fixtures.Akka
+import uk.ac.wellcome.platform.api.common.fixtures.SierraWireMockFixture
+import weco.http.fixtures.HttpFixtures
+
+import java.net.URL
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class AkkaHttpClientTest extends AnyFunSpec with Matchers with ScalaFutures with IntegrationPatience with Akka with SierraWireMockFixture with HttpFixtures {
+  import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+  import io.circe.generic.auto._
+
+  it("requests an item, fetching a token first") {
+    withMockSierraServer {
+      case (sierraApiUrl, _) =>
+        withActorSystem { implicit actorSystem =>
+          val client = new AkkaHttpClient(
+            tokenUri = Uri(f"$sierraApiUrl/iii/sierra-api/v5/token"),
+            credentials = BasicHttpCredentials("username", "password")
+          )
+
+          val future = client.makeRequest(
+            HttpRequest(
+              method = HttpMethods.GET,
+              uri = Uri(f"$sierraApiUrl/iii/sierra-api/v5/items/1601017")
+            )
+          )
+
+          whenReady(future) { resp =>
+            resp.status shouldBe StatusCodes.OK
+
+            withStringEntity(resp.entity) {
+              assertJsonStringsAreEqual(_,
+                s"""
+                   |{
+                   |  "id": "1601017",
+                   |  "updatedDate": "2009-06-15T14:48:00Z",
+                   |  "createdDate": "2008-05-21T12:47:00Z",
+                   |  "deleted": false,
+                   |  "bibIds": [
+                   |    "1665618"
+                   |  ],
+                   |  "location": {
+                   |    "code": "sicon",
+                   |    "name": "Closed stores Iconographic"
+                   |  },
+                   |  "status": {
+                   |    "code": "-  ",
+                   |    "display": "Available"
+                   |  },
+                   |  "barcode": "D59.14 (Germany file)",
+                   |  "callNumber": "665618i"
+                   |}
+                   |""".stripMargin)
+            }
+          }
+        }
+    }
+  }
+
+  override def contextUrl: URL = new URL("http://test.example/context.json")
+}

--- a/common/stacks/src/test/scala/weco/api/stacks/http/impl/AkkaHttpClientTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/http/impl/AkkaHttpClientTest.scala
@@ -15,9 +15,6 @@ import java.net.URL
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class AkkaHttpClientTest extends AnyFunSpec with Matchers with ScalaFutures with IntegrationPatience with Akka with SierraWireMockFixture with HttpFixtures {
-  import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
-  import io.circe.generic.auto._
-
   it("requests an item, fetching a token first") {
     withMockSierraServer {
       case (sierraApiUrl, _) =>

--- a/common/stacks/src/test/scala/weco/api/stacks/http/impl/AkkaHttpClientTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/http/impl/AkkaHttpClientTest.scala
@@ -1,7 +1,8 @@
 package weco.api.stacks.http.impl
 
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.model.headers.BasicHttpCredentials
-import akka.http.scaladsl.model.{HttpMethods, HttpRequest, StatusCodes, Uri}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -21,15 +22,12 @@ class AkkaHttpClientTest extends AnyFunSpec with Matchers with ScalaFutures with
       case (sierraApiUrl, _) =>
         withActorSystem { implicit actorSystem =>
           val client = new AkkaHttpClient(
-            tokenUri = Uri(f"$sierraApiUrl/iii/sierra-api/v5/token"),
+            baseUri = Uri(s"$sierraApiUrl/iii/sierra-api"),
             credentials = BasicHttpCredentials("username", "password")
           )
 
-          val future = client.makeRequest(
-            HttpRequest(
-              method = HttpMethods.GET,
-              uri = Uri(f"$sierraApiUrl/iii/sierra-api/v5/items/1601017")
-            )
+          val future = client.get(
+            path = Path(f"v5/items/1601017")
           )
 
           whenReady(future) { resp =>

--- a/common/stacks/src/test/scala/weco/api/stacks/http/impl/AkkaHttpClientTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/http/impl/AkkaHttpClientTest.scala
@@ -14,7 +14,14 @@ import weco.http.fixtures.HttpFixtures
 import java.net.URL
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class AkkaHttpClientTest extends AnyFunSpec with Matchers with ScalaFutures with IntegrationPatience with Akka with SierraWireMockFixture with HttpFixtures {
+class AkkaHttpClientTest
+    extends AnyFunSpec
+    with Matchers
+    with ScalaFutures
+    with IntegrationPatience
+    with Akka
+    with SierraWireMockFixture
+    with HttpFixtures {
   it("requests an item, fetching a token first") {
     withMockSierraServer {
       case (sierraApiUrl, _) =>
@@ -35,7 +42,8 @@ class AkkaHttpClientTest extends AnyFunSpec with Matchers with ScalaFutures with
             resp.status shouldBe StatusCodes.OK
 
             withStringEntity(resp.entity) {
-              assertJsonStringsAreEqual(_,
+              assertJsonStringsAreEqual(
+                _,
                 s"""
                    |{
                    |  "id": "1601017",
@@ -56,7 +64,8 @@ class AkkaHttpClientTest extends AnyFunSpec with Matchers with ScalaFutures with
                    |  "barcode": "D59.14 (Germany file)",
                    |  "callNumber": "665618i"
                    |}
-                   |""".stripMargin)
+                   |""".stripMargin
+              )
             }
           }
         }

--- a/common/stacks/src/test/scala/weco/api/stacks/http/impl/AkkaHttpClientTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/http/impl/AkkaHttpClientTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.platform.api.common.fixtures.SierraWireMockFixture
+import weco.api.stacks.http.SierraAuthenticatedHttpClient
 import weco.http.fixtures.HttpFixtures
 
 import java.net.URL
@@ -21,8 +22,11 @@ class AkkaHttpClientTest extends AnyFunSpec with Matchers with ScalaFutures with
     withMockSierraServer {
       case (sierraApiUrl, _) =>
         withActorSystem { implicit actorSystem =>
-          val client = new AkkaHttpClient(
-            baseUri = Uri(s"$sierraApiUrl/iii/sierra-api"),
+          val httpClient = new AkkaHttpClient(
+            baseUri = Uri(s"$sierraApiUrl/iii/sierra-api")
+          )
+          val client = new SierraAuthenticatedHttpClient(
+            underlying = httpClient,
             credentials = BasicHttpCredentials("username", "password")
           )
 


### PR DESCRIPTION
This patch is a major change (and IMO improvement) to how we make HTTP requests to the Sierra API.

Previously we used a series of inherited traits:

```scala
trait AkkaGet {
  def get(…): Future[HttpResponse]
}

trait AkkaClient extends AkkaGet

trait SierraSource extends AkkaClient {
  def lookupItem() = get(…).map { resp => item}
}
```

If you want to test these interactions, you have to go through WireMock. This causes a couple of issues:

* I can't remember how to create WireMock stubs, because it's not something I do very often. I want to create a lot of these stubs to test various interactions with the holds API.
* Some of the Sierra API responses I'm mocking will include personal information (what holds a user has created) – I don't want to leak that inadvertently because I forgot to clean up my stubs.
* The interaction between a test and the associated JSON file is non-obvious. What are you actually testing?
* Every test goes through the access token handshake, even though we're not explicitly testing it in most cases.

tl;dr: I dislike WireMock and I wanted something better.

So: rather than inheritance, let's use injection. Now our interface looks more like this:

```scala
trait HttpGet {
  def get(…): Future[HttpResponse]
}

trait HttpClient extends HttpGet

trait SierraSource {
  val client: HttpClient

  def lookupItem() = client.get(…).map { resp => item}
}
```

Crucially, we can swap out this client implementation – I've got an Akka implementation that has a few WireMock tests, but the rest can be an in-memory client with an explicit list of requests and responses. I'm only partway through implementing this, but hopefully it's enough to get the idea across.

I'd like a sense check before I implement this everywhere – is this a good improvement, or is it deeply flawed?