### PR TITLE
Create marshallers from Circe encoders/decoders

### DIFF
--- a/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/source/SierraSource.scala
+++ b/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/source/SierraSource.scala
@@ -89,7 +89,6 @@ class AkkaSierraSource(
     with AkkaClientPost
     with AkkaClientTokenExchange {
 
-  import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
   import io.circe.generic.auto._
   import SierraSource._
 

--- a/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/source/SierraSource.scala
+++ b/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/source/SierraSource.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials}
 import io.circe.{Encoder, Printer}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.api.http.{
+import weco.api.stacks.http.{
   AkkaClientGet,
   AkkaClientPost,
   AkkaClientTokenExchange

--- a/common/stacks/src/main/scala/weco/api/stacks/http/AkkaClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/AkkaClient.scala
@@ -11,7 +11,9 @@ import akka.http.scaladsl.model.headers.{
   OAuth2BearerToken
 }
 import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
+import io.circe.generic.extras.JsonKey
 import io.circe.{Decoder, Encoder}
+import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.api.http.TokenExchange
 
 import java.time.Instant
@@ -123,9 +125,10 @@ trait AkkaClientTokenExchange
     extends AkkaClientPost
     with TokenExchange[BasicHttpCredentials, OAuth2BearerToken] {
 
-  import io.circe.generic.auto._
-
-  case class AccessToken(access_token: String, expires_in: Int)
+  case class AccessToken(
+    @JsonKey("access_token") accessToken: String,
+    @JsonKey("expires_in") expiresIn: Int
+  )
 
   val tokenPath: Path
 

--- a/common/stacks/src/main/scala/weco/api/stacks/http/AkkaClient.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/AkkaClient.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.api.http
+package weco.api.stacks.http
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
@@ -11,6 +11,7 @@ import akka.http.scaladsl.model.headers.{
   OAuth2BearerToken
 }
 import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
+import uk.ac.wellcome.platform.api.http.TokenExchange
 
 import java.time.Instant
 import scala.concurrent.{ExecutionContextExecutor, Future}

--- a/common/stacks/src/main/scala/weco/api/stacks/http/CirceMarshalling.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/CirceMarshalling.scala
@@ -1,0 +1,36 @@
+package weco.api.stacks.http
+
+import akka.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity}
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import io.circe.{Decoder, Encoder}
+import io.circe.syntax._
+import uk.ac.wellcome.json.JsonUtil._
+
+import scala.concurrent.Future
+
+/** This class gives us helpers for using Circe to marshall/unmarshall JSON
+  * using our Circe decoders and encoders.
+  *
+  * This is helpful for a few reasons:
+  *
+  *   1.  The default [Un]marshallers aren't aware of all of Circe's features,
+  *       e.g. the @JsonKey annotation.
+  *   2.  It means that any method doing akka-http marshalling can just require
+  *       an implicit Decoder[T] or Encoder[T], which is a more common interface
+  *       in our codebase.
+  *
+  */
+object CirceMarshalling {
+  def fromDecoder[T: Decoder]: Unmarshaller[HttpEntity, T] =
+    Unmarshaller.stringUnmarshaller
+      .forContentTypes(ContentTypes.`application/json`)
+      .flatMap { _ => _ => json =>
+        Future.fromTry(fromJson[T](json))
+      }
+
+  def fromEncoder[T: Encoder]: ToEntityMarshaller[T] =
+    Marshaller.withFixedContentType(ContentTypes.`application/json`) { t =>
+      HttpEntity(ContentTypes.`application/json`, t.asJson.noSpaces)
+    }
+}


### PR DESCRIPTION
This is a piece spun out of https://github.com/wellcomecollection/catalogue-api/pull/108

It allows us to use Circe decoders/encoders for HTTP requests and responses with akka-http, rather than relying on the auto-derived `Unmarshaller/Marshaller` types.

The issue I was chasing was an inability to use `@JsonKey` annotations to decode snake-case keys from a Sierra API response; once I cracked that I figured this was just a generally nicer way to do it. The akka-http-ness is confined to the classes doing HTTP, and you can get your decoders by importing `JsonUtil._` as usual.