### PR TITLE
Smoke tests should expect 200 for every endpoint

### DIFF
--- a/smoke_tests/smokeTests.yml
+++ b/smoke_tests/smokeTests.yml
@@ -25,14 +25,20 @@ scenarios:
     flow:
       - get:
           url: "/works"
+          expect:
+            statusCode: 200
   - name: "/images"
     flow:
       - get:
           url: "/images"
+          expect:
+            statusCode: 200
   - name: "/works/awa6c6gm"
     flow:
       - get:
           url: "/works/awa6c6gm"
+          expect:
+            statusCode: 200
   - name: "/works/awa6c6gm/items"
     flow:
       - get:


### PR DESCRIPTION
Noticed this while looking at a broken stage API, we can get an OK from the smoke tests incorrectly.