### PR TITLE
Use a single level of indentation in the scenario test

### DIFF
--- a/common/stacks/src/main/scala/weco/api/stacks/http/SierraItemLookupError.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/SierraItemLookupError.scala
@@ -10,5 +10,5 @@ object SierraItemLookupError {
   case object ItemNotFound extends SierraItemLookupError
 
   case class UnknownError(errorCode: SierraErrorCode)
-    extends SierraItemLookupError
+      extends SierraItemLookupError
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/http/SierraItemLookupError.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/SierraItemLookupError.scala
@@ -1,0 +1,14 @@
+package weco.api.stacks.http
+
+import weco.api.stacks.models.SierraErrorCode
+
+sealed trait SierraItemLookupError
+
+object SierraItemLookupError {
+  case class ItemHasNoStatus(t: Throwable) extends SierraItemLookupError
+
+  case object ItemNotFound extends SierraItemLookupError
+
+  case class UnknownError(errorCode: SierraErrorCode)
+    extends SierraItemLookupError
+}

--- a/common/stacks/src/main/scala/weco/api/stacks/http/SierraSource.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/SierraSource.scala
@@ -23,17 +23,6 @@ import java.time.{Instant, ZoneId}
 import java.time.format.DateTimeFormatter
 import scala.concurrent.{ExecutionContext, Future}
 
-sealed trait SierraItemLookupError
-
-object SierraItemLookupError {
-  case class ItemHasNoStatus(t: Throwable) extends SierraItemLookupError
-
-  case object ItemNotFound extends SierraItemLookupError
-
-  case class UnknownError(errorCode: SierraErrorCode)
-      extends SierraItemLookupError
-}
-
 class SierraSource(client: HttpClient with HttpGet with HttpPost)(
   implicit
   ec: ExecutionContext,

--- a/items/src/main/scala/uk/ac/wellcome/platform/api/items/ItemsApi.scala
+++ b/items/src/main/scala/uk/ac/wellcome/platform/api/items/ItemsApi.scala
@@ -1,13 +1,26 @@
 package uk.ac.wellcome.platform.api.items
 
 import akka.http.scaladsl.server.Route
+import com.sksamuel.elastic4s.Index
 import uk.ac.wellcome.Tracing
+import uk.ac.wellcome.platform.api.common.services.SierraService
+import uk.ac.wellcome.platform.api.models.ApiConfig
 import weco.api.items.responses.LookupItemStatus
+import weco.api.stacks.services.WorkLookup
 import weco.catalogue.internal_model.identifiers.CanonicalId
 
+import scala.concurrent.ExecutionContext
 import scala.util.{Success, Try}
 
-trait ItemsApi extends LookupItemStatus with Tracing {
+class ItemsApi(
+  val sierraService: SierraService,
+  val workLookup: WorkLookup,
+  val index: Index
+)(
+  implicit
+  val ec: ExecutionContext,
+  val apiConfig: ApiConfig
+) extends LookupItemStatus with Tracing {
   val routes: Route = concat(
     pathPrefix("works") {
       path(Segment) { id: String =>

--- a/items/src/main/scala/uk/ac/wellcome/platform/api/items/ItemsApi.scala
+++ b/items/src/main/scala/uk/ac/wellcome/platform/api/items/ItemsApi.scala
@@ -20,7 +20,8 @@ class ItemsApi(
   implicit
   val ec: ExecutionContext,
   val apiConfig: ApiConfig
-) extends LookupItemStatus with Tracing {
+) extends LookupItemStatus
+    with Tracing {
   val routes: Route = concat(
     pathPrefix("works") {
       path(Segment) { id: String =>

--- a/items/src/test/scala/uk/ac/wellcome/platform/api/items/fixtures/ItemsApiFixture.scala
+++ b/items/src/test/scala/uk/ac/wellcome/platform/api/items/fixtures/ItemsApiFixture.scala
@@ -1,19 +1,17 @@
 package uk.ac.wellcome.platform.api.items.fixtures
 
-import java.net.URL
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.sksamuel.elastic4s.Index
 import org.scalatest.Suite
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.models.index.IndexFixtures
 import uk.ac.wellcome.platform.api.common.fixtures.ServicesFixture
-import uk.ac.wellcome.platform.api.common.services.SierraService
 import uk.ac.wellcome.platform.api.items.ItemsApi
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import weco.api.stacks.services.WorkLookup
 import weco.http.fixtures.HttpFixtures
 
-import scala.concurrent.ExecutionContext
+import java.net.URL
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait ItemsApiFixture
@@ -26,7 +24,7 @@ trait ItemsApiFixture
   override def contextUrl =
     new URL("https://localhost/catalogue/v2/context.json")
 
-  val apiConf =
+  implicit val apiConfig: ApiConfig =
     ApiConfig(
       publicHost = "localhost",
       publicScheme = "https",
@@ -38,20 +36,15 @@ trait ItemsApiFixture
   def withItemsApi[R](index: Index)(
     testWith: TestWith[(URL, WireMockServer), R]): R =
     withSierraService {
-      case (sierraServiceTest, sierraWiremockServer) =>
-        val indexTest = index
+      case (sierraService, sierraWiremockServer) =>
+        val api: ItemsApi = new ItemsApi(
+          sierraService = sierraService,
+          workLookup = WorkLookup(elasticClient),
+          index = index
+        )
 
-        val router: ItemsApi = new ItemsApi {
-          override implicit val ec: ExecutionContext = global
-          override implicit val apiConfig: ApiConfig = apiConf
-          override val workLookup: WorkLookup =
-            WorkLookup(elasticClient)(global)
-          override val sierraService: SierraService = sierraServiceTest
-          override val index: Index = indexTest
-        }
-
-        withApp(router.routes) { _ =>
-          testWith((router.contextUrl, sierraWiremockServer))
+        withApp(api.routes) { _ =>
+          testWith((api.contextUrl, sierraWiremockServer))
         }
     }
 }

--- a/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/Main.scala
+++ b/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/Main.scala
@@ -6,12 +6,10 @@ import uk.ac.wellcome.api.display.ElasticConfig
 import uk.ac.wellcome.elasticsearch.typesafe.ElasticBuilder
 import uk.ac.wellcome.http.typesafe.HTTPServerBuilder
 import uk.ac.wellcome.monitoring.typesafe.CloudWatchBuilder
-import uk.ac.wellcome.platform.api.common.services.SierraService
 import uk.ac.wellcome.platform.api.common.services.config.builders.SierraServiceBuilder
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
-import weco.api.stacks.services.ItemLookup
 import weco.api.stacks.services.elastic.ElasticItemLookup
 import weco.http.WellcomeHttpApp
 import weco.http.monitoring.HttpMetrics
@@ -22,24 +20,20 @@ object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
     implicit val asMain: ActorSystem =
       AkkaBuilder.buildActorSystem()
+    implicit val ec: ExecutionContext =
+      AkkaBuilder.buildExecutionContext()
 
-    val apiConf = ApiConfig.build(config)
+    implicit val apiConfig: ApiConfig = ApiConfig.build(config)
 
     val elasticClient = ElasticBuilder.buildElasticClient(config)
 
-    val router: RequestsApi = new RequestsApi {
-      override implicit val ec: ExecutionContext =
-        AkkaBuilder.buildExecutionContext()
-      override implicit val apiConfig: ApiConfig = apiConf
-      override val sierraService: SierraService =
-        SierraServiceBuilder.build(config)
-      override val itemLookup: ItemLookup = ElasticItemLookup(
+    val router: RequestsApi = new RequestsApi(
+      sierraService = SierraServiceBuilder.build(config),
+      itemLookup = ElasticItemLookup(
         elasticClient,
         index = ElasticConfig.apply().worksIndex
       )
-    }
-
-    implicit val ec: ExecutionContext = router.ec
+    )
 
     val appName = "RequestsApi"
 

--- a/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/RequestsApi.scala
+++ b/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/RequestsApi.scala
@@ -19,7 +19,8 @@ class RequestsApi(
   implicit
   val ec: ExecutionContext,
   val apiConfig: ApiConfig
-) extends CreateRequest with LookupPendingRequests {
+) extends CreateRequest
+    with LookupPendingRequests {
   val routes: Route = concat(
     pathPrefix("users" / Segment / "item-requests") { userId: String =>
       val userIdentifier = SierraPatronNumber(userId)

--- a/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/RequestsApi.scala
+++ b/requests/src/main/scala/uk/ac/wellcome/platform/api/requests/RequestsApi.scala
@@ -1,14 +1,25 @@
 package uk.ac.wellcome.platform.api.requests
 
 import akka.http.scaladsl.server.Route
+import uk.ac.wellcome.platform.api.common.services.SierraService
+import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.platform.api.requests.models.ItemRequest
 import weco.api.requests.responses.{CreateRequest, LookupPendingRequests}
+import weco.api.stacks.services.ItemLookup
 import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.catalogue.source_model.sierra.identifiers.SierraPatronNumber
 
+import scala.concurrent.ExecutionContext
 import scala.util.{Success, Try}
 
-trait RequestsApi extends CreateRequest with LookupPendingRequests {
+class RequestsApi(
+  val sierraService: SierraService,
+  val itemLookup: ItemLookup
+)(
+  implicit
+  val ec: ExecutionContext,
+  val apiConfig: ApiConfig
+) extends CreateRequest with LookupPendingRequests {
   val routes: Route = concat(
     pathPrefix("users" / Segment / "item-requests") { userId: String =>
       val userIdentifier = SierraPatronNumber(userId)

--- a/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/RequestingScenarioTest.scala
+++ b/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/RequestingScenarioTest.scala
@@ -1,15 +1,27 @@
 package uk.ac.wellcome.platform.api.requests
 
-import akka.http.scaladsl.model.{HttpResponse, RequestEntity, StatusCodes}
+import akka.http.scaladsl.model.HttpMethods.POST
+import akka.http.scaladsl.model.{
+  HttpRequest,
+  HttpResponse,
+  RequestEntity,
+  StatusCodes,
+  Uri
+}
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.GivenWhenThen
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.models.work.generators.ItemsGenerators
+import uk.ac.wellcome.platform.api.common.services.SierraService
 import uk.ac.wellcome.platform.api.requests.fixtures.RequestsApiFixture
+import weco.api.stacks.services.ItemLookup
 import weco.api.stacks.services.memory.MemoryItemLookup
 import weco.catalogue.internal_model.identifiers.{IdState, IdentifierType}
 import weco.catalogue.internal_model.work.Item
+import weco.http.client.{HttpGet, HttpPost, MemoryHttpClient}
 
 class RequestingScenarioTest
     extends AnyFeatureSpec
@@ -17,7 +29,8 @@ class RequestingScenarioTest
     with Matchers
     with ItemsGenerators
     with RequestsApiFixture
-    with IntegrationPatience {
+    with IntegrationPatience
+    with ScalatestRouteTest {
 
   Feature("requesting an item") {
     Scenario("An item which is not from Sierra") {
@@ -25,13 +38,12 @@ class RequestingScenarioTest
       val item = createIdentifiedCalmItem
 
       val lookup = new MemoryItemLookup(items = Seq(item))
+      implicit val route: Route = createRoute(lookup)
 
-      withRequestsApi(lookup) { _ =>
-        When("the user requests the item")
-
-        val path = "/users/1234567/item-requests"
-
-        val entity = createJsonHttpEntityWith(
+      When("the user requests the item")
+      val response = makePostRequest(
+        path = "/users/1234567/item-requests",
+        entity = createJsonHttpEntityWith(
           s"""
              |{
              |  "itemId": "${item.id.canonicalId}",
@@ -40,43 +52,40 @@ class RequestingScenarioTest
              |}
              |""".stripMargin
         )
+      )
 
-        val response = waitForPostRequest(path, entity)
+      Then("the hold is rejected")
+      response.status shouldBe StatusCodes.BadRequest
 
-        Then("the hold is rejected")
-        response.status shouldBe StatusCodes.BadRequest
-
-        And("the error explains why the hold is rejected")
-        withStringEntity(response.entity) {
-          assertJsonStringsAreEqual(
-            _,
-            s"""
-              |{
-              |  "@context": "$contextUrl",
-              |  "type": "Error",
-              |  "errorType": "http",
-              |  "httpStatus": 400,
-              |  "label": "Bad Request",
-              |  "description": "You cannot request ${item.id.canonicalId}"
-              |}
-              |""".stripMargin
-          )
-        }
+      And("the error explains why the hold is rejected")
+      withStringEntity(response.entity) {
+        assertJsonStringsAreEqual(
+          _,
+          s"""
+             |{
+             |  "@context": "$contextUrl",
+             |  "type": "Error",
+             |  "errorType": "http",
+             |  "httpStatus": 400,
+             |  "label": "Bad Request",
+             |  "description": "You cannot request ${item.id.canonicalId}"
+             |}
+             |""".stripMargin
+        )
       }
     }
 
     Scenario("An item which does not exist") {
       val lookup = new MemoryItemLookup(items = Seq.empty)
+      implicit val route: Route = createRoute(lookup)
 
       Given("an item ID that doesn't exist")
       val itemId = createCanonicalId
 
-      withRequestsApi(lookup) { _ =>
-        When("the user requests a non-existent item")
-
-        val path = "/users/1234567/item-requests"
-
-        val entity = createJsonHttpEntityWith(
+      When("the user requests a non-existent item")
+      val response = makePostRequest(
+        path = "/users/1234567/item-requests",
+        entity = createJsonHttpEntityWith(
           s"""
              |{
              |  "itemId": "$itemId",
@@ -85,36 +94,41 @@ class RequestingScenarioTest
              |}
              |""".stripMargin
         )
+      )
 
-        val response = waitForPostRequest(path, entity)
+      Then("the API returns a 404 error")
+      response.status shouldBe StatusCodes.NotFound
 
-        Then("the API returns a 404 error")
-        response.status shouldBe StatusCodes.NotFound
-
-        And("the error explains why the hold is rejected")
-        withStringEntity(response.entity) {
-          assertJsonStringsAreEqual(
-            _,
-            s"""
-               |{
-               |  "@context": "$contextUrl",
-               |  "type": "Error",
-               |  "errorType": "http",
-               |  "httpStatus": 404,
-               |  "label": "Not Found",
-               |  "description": "Item not found for identifier $itemId"
-               |}
-               |""".stripMargin
-          )
-        }
+      And("the error explains why the hold is rejected")
+      withStringEntity(response.entity) {
+        assertJsonStringsAreEqual(
+          _,
+          s"""
+             |{
+             |  "@context": "$contextUrl",
+             |  "type": "Error",
+             |  "errorType": "http",
+             |  "httpStatus": 404,
+             |  "label": "Not Found",
+             |  "description": "Item not found for identifier $itemId"
+             |}
+             |""".stripMargin
+        )
       }
     }
   }
 
-  def waitForPostRequest(path: String, entity: RequestEntity): HttpResponse =
-    whenPostRequestReady(path, entity) { resp =>
-      resp
+  def makePostRequest(path: String, entity: RequestEntity)(implicit route: Route): HttpResponse = {
+    val request = HttpRequest(
+      method = POST,
+      uri = s"https://localhost$path",
+      entity = entity
+    )
+
+    request ~> route ~> check {
+      response
     }
+  }
 
   def createIdentifiedCalmItem: Item[IdState.Identified] =
     createIdentifiedItemWith(
@@ -124,4 +138,19 @@ class RequestingScenarioTest
       ),
       locations = List(createPhysicalLocation)
     )
+
+  def createRoute(
+    itemLookup: ItemLookup,
+    responses: Seq[(HttpRequest, HttpResponse)] = Seq()): Route = {
+    val client = new MemoryHttpClient(responses) with HttpGet with HttpPost {
+      override val baseUri: Uri = Uri("http://localhost:1234")
+    }
+
+    val api: RequestsApi = new RequestsApi(
+      sierraService = SierraService(client),
+      itemLookup = itemLookup
+    )
+
+    api.routes
+  }
 }

--- a/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/RequestingScenarioTest.scala
+++ b/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/RequestingScenarioTest.scala
@@ -118,7 +118,8 @@ class RequestingScenarioTest
     }
   }
 
-  def makePostRequest(path: String, entity: RequestEntity)(implicit route: Route): HttpResponse = {
+  def makePostRequest(path: String, entity: RequestEntity)(
+    implicit route: Route): HttpResponse = {
     val request = HttpRequest(
       method = POST,
       uri = s"https://localhost$path",

--- a/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/fixtures/RequestsApiFixture.scala
+++ b/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/fixtures/RequestsApiFixture.scala
@@ -3,14 +3,12 @@ package uk.ac.wellcome.platform.api.requests.fixtures
 import com.github.tomakehurst.wiremock.WireMockServer
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.api.common.fixtures.ServicesFixture
-import uk.ac.wellcome.platform.api.common.services.SierraService
 import uk.ac.wellcome.platform.api.models.ApiConfig
 import uk.ac.wellcome.platform.api.requests.RequestsApi
 import weco.api.stacks.services.ItemLookup
 import weco.http.fixtures.HttpFixtures
 
 import java.net.URL
-import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait RequestsApiFixture extends ServicesFixture with HttpFixtures {
@@ -20,7 +18,7 @@ trait RequestsApiFixture extends ServicesFixture with HttpFixtures {
   override def contextUrl =
     new URL("https://localhost/catalogue/context.json")
 
-  val apiConf =
+  implicit val apiConfig: ApiConfig =
     ApiConfig(
       publicHost = "localhost/",
       publicScheme = "https",
@@ -32,18 +30,14 @@ trait RequestsApiFixture extends ServicesFixture with HttpFixtures {
   def withRequestsApi[R](itemLookup: ItemLookup)(
     testWith: TestWith[(URL, WireMockServer), R]): R =
     withSierraService {
-      case (sierraServiceTest, server) =>
-        val lookup = itemLookup
+      case (sierraService, server) =>
+        val api: RequestsApi = new RequestsApi(
+          sierraService = sierraService,
+          itemLookup = itemLookup
+        )
 
-        val router: RequestsApi = new RequestsApi {
-          override implicit val ec: ExecutionContext = global
-          override implicit val apiConfig: ApiConfig = apiConf
-          override val sierraService: SierraService = sierraServiceTest
-          override val itemLookup: ItemLookup = lookup
-        }
-
-        withApp(router.routes) { _ =>
-          testWith((router.contextUrl, server))
+        withApp(api.routes) { _ =>
+          testWith((api.contextUrl, server))
         }
     }
 }


### PR DESCRIPTION
A step towards https://github.com/wellcomecollection/platform/issues/5195

This makes the scenario tests a bit nicer – they're all indented to one level now, and we don't bother starting an app that we need to tear down – instead, I'm using [route testing](https://developer.lightbend.com/guides/akka-http-quickstart-scala/testing-routes.html).

I've also added a scenario for the case when an item doesn't exist.