### PR TITLE
Add three more scenario tests

### DIFF
--- a/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/SierraService.scala
+++ b/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/SierraService.scala
@@ -53,7 +53,10 @@ class SierraService(
       // See https://techdocs.iii.com/sierraapi/Content/zReference/errorHandling.htm
       case Left(SierraErrorCode(132, 2, 500, _, _)) =>
         getStacksUserHolds(patron).map {
-          case Right(holds) if holds.holds.map(_.sourceIdentifier).contains(sourceIdentifier) =>
+          case Right(holds)
+              if holds.holds
+                .map(_.sourceIdentifier)
+                .contains(sourceIdentifier) =>
             HoldAccepted()
 
           case Right(holds) if holds.holds.size >= holdLimit =>

--- a/common/stacks/src/main/scala/weco/api/stacks/models/HoldResponse.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/HoldResponse.scala
@@ -9,3 +9,5 @@ case class HoldAccepted(lastModified: Instant = Instant.now())
     extends HoldResponse
 case class HoldRejected(lastModified: Instant = Instant.now())
     extends HoldResponse
+case class UserAtHoldLimit(lastModified: Instant = Instant.now())
+    extends HoldResponse

--- a/common/stacks/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-token-YvUkU.json
+++ b/common/stacks/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-token-YvUkU.json
@@ -1,7 +1,7 @@
 {
   "id" : "49eea99a-bb25-3dec-a95b-4bcda5517729",
   "request" : {
-    "url" : "/iii/sierra-api/v5/token",
+    "url" : "/iii/sierra-api/token",
     "method" : "POST",
     "headers" : {
       "Authorization" : {

--- a/common/stacks/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-token-mIRgi.json
+++ b/common/stacks/src/test/resources/sierra/mappings/mapping-iii-sierra-api-v5-token-mIRgi.json
@@ -1,7 +1,7 @@
 {
   "id" : "49eea99a-bb25-3dec-a95b-4bcda5517729",
   "request" : {
-    "url" : "/iii/sierra-api/v5/token",
+    "url" : "/iii/sierra-api/token",
     "method" : "POST",
     "headers" : {
       "Authorization" : {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object WellcomeDependencies {
 
-  val defaultVersion = "26.17.3"
+  val defaultVersion = "26.17.7"
 
   lazy val versions = new {
     val typesafe = defaultVersion

--- a/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
@@ -45,11 +45,12 @@ trait CreateRequest extends CustomDirectives with ErrorDirectives with Logging {
                   contextUrl = contextUrl,
                   DisplayError(
                     statusCode = StatusCodes.Forbidden,
-                    description = "You are at your account limit and you cannot request more items"
+                    description =
+                      "You are at your account limit and you cannot request more items"
                   )
                 )
             )
-          case Failure(err)             => failWith(err)
+          case Failure(err) => failWith(err)
         }
 
       case Right(sourceIdentifier) =>

--- a/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/RequestingScenarioTest.scala
+++ b/requests/src/test/scala/uk/ac/wellcome/platform/api/requests/RequestingScenarioTest.scala
@@ -251,11 +251,15 @@ class RequestingScenarioTest
         ),
         (
           createListHoldsRequest(patronNumber),
-          createListHoldsResponse(patronNumber, items = (1 to holdLimit).map { _ => createSierraItemNumber })
+          createListHoldsResponse(patronNumber, items = (1 to holdLimit).map {
+            _ =>
+              createSierraItemNumber
+          })
         )
       )
 
-      implicit val route: Route = createRoute(lookup, responses, holdLimit = holdLimit)
+      implicit val route: Route =
+        createRoute(lookup, responses, holdLimit = holdLimit)
 
       When("the user requests the item")
       val response = makePostRequest(
@@ -316,7 +320,8 @@ class RequestingScenarioTest
       locations = List(createPhysicalLocation)
     )
 
-  def createIdentifiedSierraItemWith(itemNumber: SierraItemNumber): Item[IdState.Identified] =
+  def createIdentifiedSierraItemWith(
+    itemNumber: SierraItemNumber): Item[IdState.Identified] =
     createIdentifiedItemWith(
       sourceIdentifier = createSourceIdentifierWith(
         identifierType = IdentifierType.SierraSystemNumber,
@@ -329,10 +334,9 @@ class RequestingScenarioTest
   def createSierraPatronNumber: SierraPatronNumber =
     SierraPatronNumber(createSierraRecordNumberString)
 
-  def createRoute(
-    itemLookup: ItemLookup,
-    responses: Seq[(HttpRequest, HttpResponse)] = Seq(),
-    holdLimit: Int = 10): Route = {
+  def createRoute(itemLookup: ItemLookup,
+                  responses: Seq[(HttpRequest, HttpResponse)] = Seq(),
+                  holdLimit: Int = 10): Route = {
     val client = new MemoryHttpClient(responses) with HttpGet with HttpPost {
       override val baseUri: Uri = Uri("http://sierra:1234")
     }
@@ -351,7 +355,8 @@ class RequestingScenarioTest
       uri = s"http://sierra:1234/v5/patrons/$patron/holds?limit=100&offset=0"
     )
 
-  def createListHoldsResponse(patron: SierraPatronNumber, items: Seq[SierraItemNumber]): HttpResponse =
+  def createListHoldsResponse(patron: SierraPatronNumber,
+                              items: Seq[SierraItemNumber]): HttpResponse =
     HttpResponse(
       entity = HttpEntity(
         contentType = ContentTypes.`application/json`,
@@ -360,17 +365,22 @@ class RequestingScenarioTest
            |  "total": ${items.size},
            |  "start": 0,
            |  "entries": [
-           |    ${items.map(it => createListHoldEntry(patron, it)).mkString(",")}
+           |    ${items
+             .map(it => createListHoldEntry(patron, it))
+             .mkString(",")}
            |  ]
            |}
            |""".stripMargin
       )
     )
 
-  private def createListHoldEntry(patron: SierraPatronNumber, item: SierraItemNumber): String =
+  private def createListHoldEntry(patron: SierraPatronNumber,
+                                  item: SierraItemNumber): String =
     s"""
        |{
-       |  "id": "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/patrons/holds/${randomInt(from = 0, to = 10000)}",
+       |  "id": "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/patrons/holds/${randomInt(
+         from = 0,
+         to = 10000)}",
        |  "record": "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/items/${item.withoutCheckDigit}",
        |  "patron": "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/patrons/${patron.withoutCheckDigit}",
        |  "frozen": false,
@@ -381,7 +391,8 @@ class RequestingScenarioTest
        |}
        |""".stripMargin
 
-  def createHoldRequest(patron: SierraPatronNumber, item: SierraItemNumber): HttpRequest =
+  def createHoldRequest(patron: SierraPatronNumber,
+                        item: SierraItemNumber): HttpRequest =
     HttpRequest(
       method = HttpMethods.POST,
       uri = s"http://sierra:1234/v5/patrons/$patron/holds/requests",


### PR DESCRIPTION
Continuing to step towards https://github.com/wellcomecollection/platform/issues/5195

This adds three scenario tests:

* The user tries to request an item which isn't on hold, and succeeds.
* The user tries to request an item they already have a hold on. Here the behaviour has changed – previously it would return a 409 Conflict response. Now we look up their list of holds, and if they already have the hold then we return a 202 Accepted response, as if they were requesting it for the first time.
* The user tries to request an item, but they're at their hold limit. Here the behaviour has changed – previously it would return a 409 Conflict response. Now it sees that they're at the hold limit, and returns a 403 Forbidden with an explanatory message.