### PR TITLE
Handle cases where the item is already on hold, or the patron doesn't exist

### DIFF
--- a/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/SierraService.scala
+++ b/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/SierraService.scala
@@ -147,7 +147,7 @@ class SierraService(
       case Left(SierraItemLookupError.ItemNotFound) =>
         warn(
           s"User tried to place a hold on item $item, which does not exist in Sierra")
-        Left(HoldRejected.UnknownReason)
+        Left(HoldRejected.ItemMissingFromSourceSystem)
 
       case _ => Left(HoldRejected.UnknownReason)
     }

--- a/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/SierraService.scala
+++ b/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/SierraService.scala
@@ -53,7 +53,7 @@ class SierraService(
     val item = SierraItemIdentifier.fromSourceIdentifier(sourceIdentifier)
 
     sierraSource.createHold(patron, item).flatMap {
-      case Right(_) => Future.successful(HoldAccepted())
+      case Right(_) => Future.successful(HoldAccepted)
 
       // API error code "132" means "Request denied by XCirc".  This is listed in
       // the Sierra documentation:
@@ -95,10 +95,10 @@ class SierraService(
               if holds.holds
                 .map(_.sourceIdentifier)
                 .contains(sourceIdentifier) =>
-            Future.successful(HoldAccepted())
+            Future.successful(HoldAccepted)
 
           case Right(holds) if holds.holds.size >= holdLimit =>
-            Future.successful(UserAtHoldLimit())
+            Future.successful(UserAtHoldLimit)
 
           case _ => checkIfItemCanBeRequested(patron, item)
         }
@@ -125,7 +125,7 @@ class SierraService(
 
       case Left(result) =>
         warn(s"Unrecognised hold error: $result")
-        Future.successful(HoldRejected())
+        Future.successful(HoldRejected)
     }
   }
 
@@ -142,7 +142,7 @@ class SierraService(
       case Right(item) if item.deleted || item.suppressed =>
         warn(
           s"User tried to place a hold on item $item, which has been deleted/suppressed in Sierra")
-        CannotBeRequested()
+        CannotBeRequested
 
       // If the holdCount is non-zero, that means another user has a hold on this item,
       // and only a single user can have an item requested at a time.
@@ -150,7 +150,7 @@ class SierraService(
       // By this point, we've already checked the list of holds for this user -- since they
       // don't have it, this item must be on hold for another user.
       case Right(item) if item.holdCount > 0 =>
-        OnHoldForAnotherUser()
+        OnHoldForAnotherUser
 
       // This would be extremely unusual in practice -- when items are deleted
       // in Sierra, it's a soft delete.  The item still exists, but with "deleted: true".
@@ -162,9 +162,9 @@ class SierraService(
       case Left(SierraItemLookupError.ItemNotFound) =>
         warn(
           s"User tried to place a hold on item $item, which does not exist in Sierra")
-        UnknownError()
+        UnknownError
 
-      case _ => HoldRejected()
+      case _ => HoldRejected
     }
 
   protected def buildStacksHold(entry: SierraHold): StacksHold = {

--- a/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/SierraService.scala
+++ b/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/SierraService.scala
@@ -6,7 +6,10 @@ import uk.ac.wellcome.platform.api.common.models._
 import weco.api.stacks.http.{SierraItemLookupError, SierraSource}
 import weco.api.stacks.models._
 import weco.catalogue.internal_model.identifiers.SourceIdentifier
-import weco.catalogue.source_model.sierra.identifiers.{SierraItemNumber, SierraPatronNumber}
+import weco.catalogue.source_model.sierra.identifiers.{
+  SierraItemNumber,
+  SierraPatronNumber
+}
 import weco.http.client.{HttpClient, HttpGet, HttpPost}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -74,7 +77,8 @@ class SierraService(
       //    - They're not at their hold limit and they don't have a hold on this item --
       //      so we look to see if this item can be requested.
       //
-      case Left(SierraErrorCode(132, specificCode, 500, _, _)) if specificCode == 2 || specificCode == 929 =>
+      case Left(SierraErrorCode(132, specificCode, 500, _, _))
+          if specificCode == 2 || specificCode == 929 =>
         getStacksUserHolds(patron).flatMap {
           case Right(holds)
               if holds.holds
@@ -114,8 +118,9 @@ class SierraService(
     }
   }
 
-  def checkIfItemCanBeRequested(patron: SierraPatronNumber,
-                                item: SierraItemNumber): Future[Either[HoldRejected, HoldAccepted]] =
+  def checkIfItemCanBeRequested(
+    patron: SierraPatronNumber,
+    item: SierraItemNumber): Future[Either[HoldRejected, HoldAccepted]] =
     sierraSource.lookupItem(item).map {
 
       // This could occur if the item has been deleted/suppressed in Sierra,

--- a/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/SierraService.scala
+++ b/common/stacks/src/main/scala/uk/ac/wellcome/platform/api/common/services/SierraService.scala
@@ -9,6 +9,7 @@ import weco.api.stacks.models.{
   HoldAccepted,
   HoldRejected,
   HoldResponse,
+  OnHoldForAnotherUser,
   SierraErrorCode,
   SierraHold,
   SierraItemIdentifier,
@@ -133,6 +134,14 @@ class SierraService(
         warn(
           s"User tried to place a hold on item $item, which has been deleted/suppressed in Sierra")
         CannotBeRequested()
+
+      // If the holdCount is non-zero, that means another user has a hold on this item,
+      // and only a single user can have an item requested at a time.
+      //
+      // By this point, we've already checked the list of holds for this user -- since they
+      // don't have it, this item must be on hold for another user.
+      case Right(item) if item.holdCount > 0 =>
+        OnHoldForAnotherUser()
 
       // This would be extremely unusual in practice -- when items are deleted
       // in Sierra, it's a soft delete.  The item still exists, but with "deleted: true".

--- a/common/stacks/src/main/scala/weco/api/stacks/http/SierraSource.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/SierraSource.scala
@@ -64,6 +64,13 @@ class SierraSource(client: HttpClient with HttpGet with HttpPost)(
   private implicit val umHoldsList: Unmarshaller[HttpEntity, SierraHoldsList] =
     CirceMarshalling.fromDecoder[SierraHoldsList]
 
+  /** Returns a list of holds for this user.
+    *
+    * Note: do not rely on this method to prove the existence of a user.
+    * In particular, the Sierra API will return an empty list of holds if you
+    * query this API for a patron ID that doesn't exist.
+    *
+    */
   def listHolds(patron: SierraPatronNumber)
     : Future[Either[SierraErrorCode, SierraHoldsList]] =
     for {

--- a/common/stacks/src/main/scala/weco/api/stacks/http/SierraSource.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/http/SierraSource.scala
@@ -38,7 +38,7 @@ class SierraSource(client: HttpClient with HttpGet with HttpPost)(
     for {
       resp <- client.get(
         path = Path(s"v5/items/${item.withoutCheckDigit}"),
-        params = Map("fields" -> "deleted,status,suppressed")
+        params = Map("fields" -> "deleted,holdCount,status,suppressed")
       )
 
       result <- resp.status match {

--- a/common/stacks/src/main/scala/weco/api/stacks/models/HoldResponse.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/HoldResponse.scala
@@ -15,3 +15,5 @@ case class CannotBeRequested(lastModified: Instant = Instant.now())
     extends HoldResponse
 case class UnknownError(lastModified: Instant = Instant.now())
     extends HoldResponse
+case class OnHoldForAnotherUser(lastModified: Instant = Instant.now())
+  extends HoldResponse

--- a/common/stacks/src/main/scala/weco/api/stacks/models/HoldResponse.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/HoldResponse.scala
@@ -16,6 +16,7 @@ sealed trait HoldRejected extends HoldResponse
 object HoldRejected {
   case object ItemCannotBeRequested extends HoldRejected
   case object ItemIsOnHoldForAnotherUser extends HoldRejected
+  case object ItemMissingFromSourceSystem extends HoldRejected
   case object UserIsAtHoldLimit extends HoldRejected
   case class UserDoesNotExist(patron: SierraPatronNumber) extends HoldRejected
   case object UnknownReason extends HoldRejected

--- a/common/stacks/src/main/scala/weco/api/stacks/models/HoldResponse.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/HoldResponse.scala
@@ -2,22 +2,13 @@ package weco.api.stacks.models
 
 import weco.catalogue.source_model.sierra.identifiers.SierraPatronNumber
 
-import java.time.Instant
+sealed trait HoldResponse
 
-sealed trait HoldResponse {
-  val lastModified: Instant
-}
-case class HoldAccepted(lastModified: Instant = Instant.now())
-    extends HoldResponse
-case class HoldRejected(lastModified: Instant = Instant.now())
-    extends HoldResponse
-case class UserAtHoldLimit(lastModified: Instant = Instant.now())
-    extends HoldResponse
-case class CannotBeRequested(lastModified: Instant = Instant.now())
-    extends HoldResponse
-case class UnknownError(lastModified: Instant = Instant.now())
-    extends HoldResponse
-case class OnHoldForAnotherUser(lastModified: Instant = Instant.now())
-  extends HoldResponse
-case class NoSuchUser(patron: SierraPatronNumber, lastModified: Instant = Instant.now())
+case object HoldAccepted extends HoldResponse
+case object HoldRejected extends HoldResponse
+case object UserAtHoldLimit extends HoldResponse
+case object CannotBeRequested extends HoldResponse
+case object UnknownError extends HoldResponse
+case object OnHoldForAnotherUser extends HoldResponse
+case class NoSuchUser(patron: SierraPatronNumber)
     extends HoldResponse

--- a/common/stacks/src/main/scala/weco/api/stacks/models/HoldResponse.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/HoldResponse.scala
@@ -4,11 +4,19 @@ import weco.catalogue.source_model.sierra.identifiers.SierraPatronNumber
 
 sealed trait HoldResponse
 
-case object HoldAccepted extends HoldResponse
-case object HoldRejected extends HoldResponse
-case object UserAtHoldLimit extends HoldResponse
-case object CannotBeRequested extends HoldResponse
-case object UnknownError extends HoldResponse
-case object OnHoldForAnotherUser extends HoldResponse
-case class NoSuchUser(patron: SierraPatronNumber)
-    extends HoldResponse
+sealed trait HoldAccepted extends HoldResponse
+
+object HoldAccepted {
+  case object HoldCreated extends HoldAccepted
+  case object HoldAlreadyExists extends HoldAccepted
+}
+
+sealed trait HoldRejected extends HoldResponse
+
+object HoldRejected {
+  case object ItemCannotBeRequested extends HoldRejected
+  case object ItemIsOnHoldForAnotherUser extends HoldRejected
+  case object UserIsAtHoldLimit extends HoldRejected
+  case class UserDoesNotExist(patron: SierraPatronNumber) extends HoldRejected
+  case object UnknownReason extends HoldRejected
+}

--- a/common/stacks/src/main/scala/weco/api/stacks/models/HoldResponse.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/HoldResponse.scala
@@ -1,5 +1,7 @@
 package weco.api.stacks.models
 
+import weco.catalogue.source_model.sierra.identifiers.SierraPatronNumber
+
 import java.time.Instant
 
 sealed trait HoldResponse {
@@ -17,3 +19,5 @@ case class UnknownError(lastModified: Instant = Instant.now())
     extends HoldResponse
 case class OnHoldForAnotherUser(lastModified: Instant = Instant.now())
   extends HoldResponse
+case class NoSuchUser(patron: SierraPatronNumber, lastModified: Instant = Instant.now())
+    extends HoldResponse

--- a/common/stacks/src/main/scala/weco/api/stacks/models/SierraItem.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/SierraItem.scala
@@ -11,5 +11,6 @@ case class SierraItem(
   id: SierraItemNumber,
   deleted: Boolean,
   suppressed: Boolean = false,
+  holdCount: Int = 0,
   status: Option[SierraItemStatus]
 )

--- a/common/stacks/src/test/scala/uk/ac/wellcome/platform/api/common/services/SierraServiceTest.scala
+++ b/common/stacks/src/test/scala/uk/ac/wellcome/platform/api/common/services/SierraServiceTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.platform.api.common.models._
-import weco.api.stacks.models.{CannotBeRequested, HoldAccepted}
+import weco.api.stacks.models.{HoldAccepted, HoldRejected}
 import weco.catalogue.internal_model.identifiers.IdentifierType.SierraSystemNumber
 import weco.catalogue.internal_model.identifiers.SourceIdentifier
 import weco.catalogue.source_model.generators.SierraGenerators
@@ -218,7 +218,7 @@ class SierraServiceTest
             sourceIdentifier = sourceIdentifier)
 
           whenReady(future) {
-            _ shouldBe HoldAccepted
+            _.value shouldBe HoldAccepted.HoldCreated
           }
         }
       }
@@ -313,7 +313,7 @@ class SierraServiceTest
             sourceIdentifier = sourceIdentifier)
 
           whenReady(future) {
-            _ shouldBe CannotBeRequested
+            _.left.value shouldBe HoldRejected.ItemCannotBeRequested
           }
         }
       }

--- a/common/stacks/src/test/scala/uk/ac/wellcome/platform/api/common/services/SierraServiceTest.scala
+++ b/common/stacks/src/test/scala/uk/ac/wellcome/platform/api/common/services/SierraServiceTest.scala
@@ -31,7 +31,7 @@ class SierraServiceTest
         val responses = Seq(
           (
             HttpRequest(uri =
-              "http://sierra:1234/v5/items/1601017?fields=deleted,status,suppressed"),
+              "http://sierra:1234/v5/items/1601017?fields=deleted,holdCount,status,suppressed"),
             HttpResponse(
               entity = HttpEntity(
                 contentType = ContentTypes.`application/json`,
@@ -40,7 +40,8 @@ class SierraServiceTest
                    |  "id": "1601017",
                    |  "deleted": false,
                    |  "suppressed": false,
-                   |  "status": {"code": "-", "display": "Available"}
+                   |  "status": {"code": "-", "display": "Available"},
+                   |  "holdCount": 0
                    |}
                    |""".stripMargin
               )
@@ -281,7 +282,7 @@ class SierraServiceTest
           ),
           (
             HttpRequest(uri =
-              s"http://sierra:1234/v5/items/$item?fields=deleted,status,suppressed"),
+              s"http://sierra:1234/v5/items/$item?fields=deleted,holdCount,status,suppressed"),
             HttpResponse(
               entity = HttpEntity(
                 contentType = ContentTypes.`application/json`,
@@ -291,7 +292,8 @@ class SierraServiceTest
                    |  "deletedDate": "2001-01-01",
                    |  "deleted": false,
                    |  "suppressed": true,
-                   |  "status": {"code": "-", "display": "Available"}
+                   |  "status": {"code": "-", "display": "Available"},
+                   |  "holdCount": 0
                    |}
                    |""".stripMargin
               )

--- a/common/stacks/src/test/scala/uk/ac/wellcome/platform/api/common/services/SierraServiceTest.scala
+++ b/common/stacks/src/test/scala/uk/ac/wellcome/platform/api/common/services/SierraServiceTest.scala
@@ -218,7 +218,7 @@ class SierraServiceTest
             sourceIdentifier = sourceIdentifier)
 
           whenReady(future) {
-            _ shouldBe a[HoldAccepted]
+            _ shouldBe HoldAccepted
           }
         }
       }
@@ -313,7 +313,7 @@ class SierraServiceTest
             sourceIdentifier = sourceIdentifier)
 
           whenReady(future) {
-            _ shouldBe a[CannotBeRequested]
+            _ shouldBe CannotBeRequested
           }
         }
       }

--- a/common/stacks/src/test/scala/weco/api/stacks/http/SierraSourceTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/http/SierraSourceTest.scala
@@ -53,7 +53,7 @@ class SierraSourceTest
         (
           HttpRequest(
             uri = Uri(
-              "http://sierra:1234/v5/items/1146055?fields=deleted,status,suppressed")
+              "http://sierra:1234/v5/items/1146055?fields=deleted,holdCount,status,suppressed")
           ),
           HttpResponse(
             entity = HttpEntity(
@@ -111,7 +111,7 @@ class SierraSourceTest
         (
           HttpRequest(
             uri = Uri(
-              "http://sierra:1234/v5/items/1000000?fields=deleted,status,suppressed")
+              "http://sierra:1234/v5/items/1000000?fields=deleted,holdCount,status,suppressed")
           ),
           HttpResponse(
             status = StatusCodes.NotFound,
@@ -146,7 +146,7 @@ class SierraSourceTest
         (
           HttpRequest(
             uri = Uri(
-              "http://sierra:1234/v5/items/1000001?fields=deleted,status,suppressed")
+              "http://sierra:1234/v5/items/1000001?fields=deleted,holdCount,status,suppressed")
           ),
           HttpResponse(
             entity = HttpEntity(

--- a/items/src/test/scala/uk/ac/wellcome/platform/api/items/ItemsApiFeatureTest.scala
+++ b/items/src/test/scala/uk/ac/wellcome/platform/api/items/ItemsApiFeatureTest.scala
@@ -52,7 +52,7 @@ class ItemsApiFeatureTest
         (
           HttpRequest(
             uri = Uri(
-              "http://sierra:1234/v5/items/1601017?fields=deleted,status,suppressed")
+              "http://sierra:1234/v5/items/1601017?fields=deleted,holdCount,status,suppressed")
           ),
           HttpResponse(
             entity = HttpEntity(
@@ -62,7 +62,8 @@ class ItemsApiFeatureTest
                 |  "id": "1601017",
                 |  "deleted": false,
                 |  "suppressed": false,
-                |  "status": {"code": "-", "display": "Available"}
+                |  "status": {"code": "-", "display": "Available"},
+                |  "holdCount": 0
                 |}
                 |""".stripMargin
             )

--- a/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
@@ -9,6 +9,7 @@ import weco.api.stacks.models.{
   CannotBeRequested,
   HoldAccepted,
   HoldRejected,
+  OnHoldForAnotherUser,
   UnknownError,
   UserAtHoldLimit
 }
@@ -61,6 +62,19 @@ trait CreateRequest extends CustomDirectives with ErrorDirectives with Logging {
           case Success(UnknownError(_)) =>
             internalError(
               new Throwable(s"Unknown error when requesting $itemId"))
+
+          case Success(OnHoldForAnotherUser(_)) =>
+            complete(
+              StatusCodes.Conflict ->
+                ContextResponse(
+                  contextUrl = contextUrl,
+                  DisplayError(
+                    statusCode = StatusCodes.Conflict,
+                    description = s"Item $itemId is on hold for another reader"
+                  )
+                )
+            )
+
           case Failure(err) => failWith(err)
         }
 

--- a/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
@@ -38,7 +38,8 @@ trait CreateRequest extends CustomDirectives with ErrorDirectives with Logging {
           case Success(Right(_)) => complete(accepted)
 
           case Success(Left(holdRejected)) =>
-            val (status, description) = handleError(holdRejected, itemId = itemId)
+            val (status, description) =
+              handleError(holdRejected, itemId = itemId)
             complete(
               status ->
                 ContextResponse(
@@ -64,19 +65,25 @@ trait CreateRequest extends CustomDirectives with ErrorDirectives with Logging {
       case Left(err) => elasticError("Item", err)
     }
 
-  private def handleError(reason: HoldRejected, itemId: CanonicalId): (StatusCode, Option[String]) =
+  private def handleError(reason: HoldRejected,
+                          itemId: CanonicalId): (StatusCode, Option[String]) =
     reason match {
       case HoldRejected.ItemCannotBeRequested =>
         (StatusCodes.BadRequest, Some(s"You cannot request $itemId"))
 
       case HoldRejected.ItemIsOnHoldForAnotherUser =>
-        (StatusCodes.Conflict, Some(s"Item $itemId is on hold for another reader"))
+        (
+          StatusCodes.Conflict,
+          Some(s"Item $itemId is on hold for another reader"))
 
       case HoldRejected.UserDoesNotExist(patron) =>
         (StatusCodes.NotFound, Some(s"There is no such user $patron"))
 
       case HoldRejected.UserIsAtHoldLimit =>
-        (StatusCodes.Forbidden, Some("You are at your account limit and you cannot request more items"))
+        (
+          StatusCodes.Forbidden,
+          Some(
+            "You are at your account limit and you cannot request more items"))
 
       case _ =>
         (StatusCodes.InternalServerError, None)

--- a/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
@@ -9,6 +9,7 @@ import weco.api.stacks.models.{
   CannotBeRequested,
   HoldAccepted,
   HoldRejected,
+  NoSuchUser,
   OnHoldForAnotherUser,
   UnknownError,
   UserAtHoldLimit
@@ -74,6 +75,9 @@ trait CreateRequest extends CustomDirectives with ErrorDirectives with Logging {
                   )
                 )
             )
+
+          case Success(NoSuchUser(patron, _)) =>
+            notFound(s"There is no such user $patron")
 
           case Failure(err) => failWith(err)
         }

--- a/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
@@ -44,9 +44,9 @@ trait CreateRequest extends CustomDirectives with ErrorDirectives with Logging {
         val conflict = (StatusCodes.Conflict, HttpEntity.Empty)
 
         onComplete(result) {
-          case Success(HoldAccepted(_)) => complete(accepted)
-          case Success(HoldRejected(_)) => complete(conflict)
-          case Success(UserAtHoldLimit(_)) =>
+          case Success(HoldAccepted) => complete(accepted)
+          case Success(HoldRejected) => complete(conflict)
+          case Success(UserAtHoldLimit) =>
             complete(
               StatusCodes.Forbidden ->
                 ContextResponse(
@@ -58,13 +58,13 @@ trait CreateRequest extends CustomDirectives with ErrorDirectives with Logging {
                   )
                 )
             )
-          case Success(CannotBeRequested(_)) =>
+          case Success(CannotBeRequested) =>
             invalidRequest("You cannot request " + itemId)
-          case Success(UnknownError(_)) =>
+          case Success(UnknownError) =>
             internalError(
               new Throwable(s"Unknown error when requesting $itemId"))
 
-          case Success(OnHoldForAnotherUser(_)) =>
+          case Success(OnHoldForAnotherUser) =>
             complete(
               StatusCodes.Conflict ->
                 ContextResponse(
@@ -76,7 +76,7 @@ trait CreateRequest extends CustomDirectives with ErrorDirectives with Logging {
                 )
             )
 
-          case Success(NoSuchUser(patron, _)) =>
+          case Success(NoSuchUser(patron)) =>
             notFound(s"There is no such user $patron")
 
           case Failure(err) => failWith(err)

--- a/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
@@ -78,7 +78,7 @@ trait CreateRequest extends CustomDirectives with ErrorDirectives with Logging {
       case HoldRejected.UserIsAtHoldLimit =>
         (StatusCodes.Forbidden, Some("You are at your account limit and you cannot request more items"))
 
-      case HoldRejected.UnknownReason =>
+      case _ =>
         (StatusCodes.InternalServerError, None)
     }
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5195

This patch covers three new cases:

- If you try to request the same item twice in quick succession, you get a special error from the Sierra API. We now handle this error and return a success response *if your initial request succeeded*. If not, you'll go down the regular flow for handling errors.
- If you try to request an item that's on hold for another reader, you now get a 409 Conflict. We do this by inspecting the item API response for a non-zero hold count.
- If you try to request an item for a patron who doesn't exist, you now get a 404 Not Found. It turns out this is a bit simpler than I initially thought – you get a different error than if the *item* doesn't exist.

I've also rejigged the `HoldResponse` type, to give the errors better names and make the downstream code a bit easier to follow. This gets a new `UnknownReason` error, which surfaces as a 500 Internal Server Error – to make it clearer when we're hitting an error path that hasn't been handled yet.