### PR TITLE
remove title prefix part of works query

### DIFF
--- a/rank/data/queries/works-with-search-fields.ts
+++ b/rank/data/queries/works-with-search-fields.ts
@@ -28,28 +28,6 @@ export default {
         dis_max: {
           queries: [
             {
-              bool: {
-                _name: 'title prefix',
-                boost: 1000.0,
-                must: [
-                  {
-                    prefix: {
-                      'data.title.keyword': {
-                        value: '{{query}}',
-                      },
-                    },
-                  },
-                  {
-                    match_phrase: {
-                      'data.title': {
-                        query: '{{query}}',
-                      },
-                    },
-                  },
-                ],
-              },
-            },
-            {
               multi_match: {
                 _name: 'title and contributor exact spellings',
                 fields: [

--- a/rank/ranks.ts
+++ b/rank/ranks.ts
@@ -42,7 +42,7 @@ const ranks: Rank[] = [
 
       const template = {
         id: 'works-with-search-fields',
-        index: 'works-with-search-fields',
+        index: 'works-2021-06-08',
         namespace: 'works' as Namespace,
         source: { query },
       }

--- a/search/src/main/scala/uk/ac/wellcome/platform/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/uk/ac/wellcome/platform/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -53,20 +53,11 @@ case object WorksMultiMatcher {
         ),
         /**
           * This is the different ways we can match on the title fields
-          * - title prefix: An exact match, in order
           * - title exact spellings: Exact spellings as they have been catalogued
           * - title alternative spellings: Alternative spellings which people might search for e.g. in transliterations
           */
         dismax(
           queries = Seq(
-            BoolQuery(
-              queryName = Some("title prefix"),
-              boost = Some(1000),
-              must = List(
-                prefixQuery("data.title.keyword", q),
-                matchPhraseQuery("data.title", q)
-              )
-            ),
             MultiMatchQuery(
               q,
               queryName = Some("title and contributor exact spellings"),

--- a/search/src/test/resources/WorksMultiMatcherQuery.json
+++ b/search/src/test/resources/WorksMultiMatcherQuery.json
@@ -26,28 +26,6 @@
         "dis_max": {
           "queries": [
             {
-              "bool": {
-                "_name": "title prefix",
-                "boost": 1000,
-                "must": [
-                  {
-                    "prefix": {
-                      "data.title.keyword": {
-                        "value": "{{query}}"
-                      }
-                    }
-                  },
-                  {
-                    "match_phrase": {
-                      "data.title": {
-                        "query": "{{query}}"
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            {
               "multi_match": {
                 "_name": "title and contributor exact spellings",
                 "fields": [


### PR DESCRIPTION
Ref: https://github.com/wellcomecollection/catalogue-api/issues/127

The prefix part of the query helps us ensure that if someone types in the exact title of an work, this will definitely come up first. Shingles is another way we do this by upping the score on phrase matching.

The question is: Are we willing to drop this piece of the query to be able to release better fuzziness and collection search? In the famous words of @harrisonpim - search is a comprimise.


## Elastic profiling
https://github.com/wellcomecollection/catalogue-api/issues/127


## API services profiling
[Data source](https://docs.google.com/spreadsheets/d/1W9C9RYlLf_zrktxh0dM1EvQELMVLqTG-uEDjc3DdV3o/edit?usp=sharing)

Averaging the `p95` out we have:
| Env | p95 | %increase |
|---|---|---|
| Prod | 311 | 0 |1
| Candidate query | 685 | 65% |
| Candidate query from this PR | 413 | 25% |

While there is an increase, we have an increase of complexity, which I feel is just.