### PR TITLE
remove metals project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -284,6 +284,7 @@ Session.vim
 tags
 # metals scala language server
 .metals
+metals.sbt
 # bloop scala build server
 .bloop
 .bsp

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,4 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8")

--- a/project/project/metals.sbt
+++ b/project/project/metals.sbt
@@ -1,4 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8")

--- a/project/project/project/metals.sbt
+++ b/project/project/project/metals.sbt
@@ -1,4 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8")


### PR DESCRIPTION
They are required for local development, but get generated by the IDE. They also differ dependant on your local setup, so removing for now.