### PR TITLE
add search_templates to rank

### DIFF
--- a/rank/pages/api/search-templates.ts
+++ b/rank/pages/api/search-templates.ts
@@ -1,0 +1,10 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { apiRes } from '../../services/api'
+import service from '../../services/search-templates'
+
+export default async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  await apiRes(req, res, service)
+}

--- a/rank/services/api.ts
+++ b/rank/services/api.ts
@@ -1,0 +1,51 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { Decoder } from '../types/decoder'
+
+export function ok(res: NextApiResponse, content: unknown): void {
+  res.statusCode = 200
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify(content))
+}
+
+export function badRequest(res: NextApiResponse, err: Error): void {
+  res.statusCode = 400
+  res.setHeader('Content-Type', 'application/json')
+  res.end(
+    JSON.stringify({
+      errorType: 'http',
+      httpStatus: 400,
+      label: 'Bad request',
+      description: `${err.message}`,
+    })
+  )
+}
+
+export function notFound(res: NextApiResponse, req: NextApiRequest): void {
+  res.statusCode = 404
+  res.setHeader('Content-Type', 'application/json')
+  res.end(
+    JSON.stringify({
+      errorType: 'http',
+      httpStatus: 404,
+      label: 'Not Found',
+      description: `Page not found for URL ${req.url}`,
+    })
+  )
+}
+
+async function apiRes<Props>(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  service: (props?: Props) => Promise<unknown>,
+  decoder?: Decoder<Props>
+) {
+  try {
+    const props = decoder ? decoder(req.query) : undefined
+    const serviceRes = props ? await service(props) : await service()
+    ok(res, serviceRes)
+  } catch (err) {
+    badRequest(res, err)
+  }
+}
+
+export { apiRes }

--- a/rank/services/list-indices.ts
+++ b/rank/services/list-indices.ts
@@ -1,0 +1,15 @@
+import { getRankClient } from './elasticsearch-clients'
+
+async function service() {
+  const { body } = await getRankClient().cat.indices({ h: ['index'] })
+  const indices = body
+    .split('\n')
+    .filter(
+      (index: string) => !index.startsWith('.') && !index.startsWith('metrics')
+    )
+    .filter(Boolean)
+
+  return indices
+}
+
+export default service

--- a/rank/types.ts
+++ b/rank/types.ts
@@ -4,7 +4,7 @@ import { SearchTemplateSource } from './services/search-templates'
 import { QueryValue } from './types/decoder'
 
 type QueryType = 'works' | 'images'
-type Env = 'prod' | 'stage'
+type Env = 'prod' | 'stage' | 'local'
 
 type TestCase = {
   query: string


### PR DESCRIPTION
Small PR to add a route to rank `/api/search-templates`.

This will then allow you to create local search-templates to run tests against and compare them to remote ones.