### PR TITLE
Make stage deploy async

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,6 +26,7 @@ steps:
   - label: trigger stage deploy
     branches: "main"
     trigger: "catalogue-api-deploy-stage"
+    async: true
     build:
       message: "${BUILDKITE_MESSAGE}"
       commit: "${BUILDKITE_COMMIT}"


### PR DESCRIPTION
At the moment a catalogue-api-stage-deploy pipeline fails the catalogue-api pipeline, resulting in doubling up notifications and arguably incorrect build status for catalogue-api.

This change makes triggering the stage-deploy an [async step](https://buildkite.com/docs/pipelines/trigger-step#trigger-step-attributes). The deploy-stage tests will no longer fail the catalogue-api pipeline.

