### PR TITLE
Update works index to temporary: works-indexed-2021-06-27a

### DIFF
--- a/common/display/src/main/scala/weco/catalogue/display_model/ElasticConfig.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/ElasticConfig.scala
@@ -14,9 +14,15 @@ object ElasticConfig {
   // i.e. The API and the snapshot generator.
   val indexDate = "2021-06-27"
 
+  // This index has been manually created as a workaround for performance issue
+  // TODO: This line should be removed when the index moves on from 2021-06-27
+  val temporaryWorksIndex = s"works-indexed-2021-06-27a"
+
   def apply(): ElasticConfig =
     ElasticConfig(
-      worksIndex = Index(s"works-indexed-$indexDate"),
+      // worksIndex = Index(s"works-indexed-$indexDate"),
+      // TODO: This line should be removed and the one above uncommented when the index moves on from 2021-06-27
+      worksIndex = Index(temporaryWorksIndex),
       imagesIndex = Index(s"images-indexed-$indexDate")
     )
 }


### PR DESCRIPTION
This moves the API to use the temporary `works-indexed-2021-06-27a`, which is following `works-indexed-2021-06-27` in the `pipeline-2021-06-27` cluster.