### PR TITLE
remove references to old catalogue EC deployment

### DIFF
--- a/terraform/shared/elastic.tf
+++ b/terraform/shared/elastic.tf
@@ -17,12 +17,6 @@ resource "ec_deployment" "catalogue_api" {
       size       = "8g"
       zone_count = 3
     }
-
-    remote_cluster {
-      deployment_id = local.catalogue_ec_cluster_id
-      alias         = local.catalogue_ec_cluster_name
-      ref_id        = local.catalogue_ec_cluster_ref_id
-    }
   }
 
   # The catalogue-api cluster gets the pipeline-storage clusters added

--- a/terraform/shared/locals.tf
+++ b/terraform/shared/locals.tf
@@ -1,8 +1,4 @@
 locals {
-  catalogue_ec_cluster_id     = data.terraform_remote_state.catalogue_infra_critical.outputs.catalogue_ec_cluster_id
-  catalogue_ec_cluster_name   = data.terraform_remote_state.catalogue_infra_critical.outputs.catalogue_ec_cluster_name
-  catalogue_ec_cluster_ref_id = data.terraform_remote_state.catalogue_infra_critical.outputs.catalogue_ec_cluster_ref_id
-
   catalogue_ec_traffic_filter = [
     data.terraform_remote_state.infra_critical.outputs.ec_public_internet_traffic_filter_id,
     data.terraform_remote_state.infra_critical.outputs.ec_platform_privatelink_traffic_filter_id,


### PR DESCRIPTION
[The cluster has been removed](https://github.com/wellcomecollection/catalogue-pipeline/pull/1730), and remote cluster management is now [dealt with in the pipeline](https://github.com/wellcomecollection/catalogue-pipeline/blob/main/pipeline/terraform/scripts/configure_cross_cluster_replication.py#L54-L88).

