### PR TITLE
diff_tool needs to assume catalogue_ci

### DIFF
--- a/.buildkite/pipeline.deploy-prod.yml
+++ b/.buildkite/pipeline.deploy-prod.yml
@@ -3,7 +3,7 @@ steps:
     branches: "main"
     plugins:
       - wellcomecollection/aws-assume-role#v0.2.2:
-          role: "arn:aws:iam::760097843905:role/platform-ci"
+          role: "arn:aws:iam::756629837203:role/catalogue-ci"
       - docker-compose#v3.5.0:
           run: diff_tool
           env:


### PR DESCRIPTION
Following on from https://github.com/wellcomecollection/platform-infrastructure/pull/214 the diff_tool needs assume the catalogue-ci role so it can then _assume itself_ when run 🤦 

**Note:** there is a temporary manual permissions change to the`platform-ci` IAM role to allow it to assume `catalogue-ci`. After this PR is merged that should be removed by running a `terraform apply` in: https://github.com/wellcomecollection/platform-infrastructure/tree/main/accounts/platform