### PR TITLE
Fix the link to the pre-filled logging query in the snapshot reporter

### DIFF
--- a/snapshots/snapshot_reporter/src/snapshot_reporter.py
+++ b/snapshots/snapshot_reporter/src/snapshot_reporter.py
@@ -120,7 +120,7 @@ def prepare_slack_payload(snapshots, api_document_count):
         heading = ":white_check_mark: Catalogue Snapshot"
         message = _snapshot_message(latest_snapshot)
     else:
-        kibana_logs_link = "https://logging.wellcomecollection.org/goto/ddc4dfc7308261cf17f956515ca1ce35"
+        kibana_logs_link = "https://logging.wellcomecollection.org/goto/c98eb0e4e37c802e60d5affea422a98e"
         heading = ":interrobang: Catalogue Snapshot not found"
         message = f"No snapshot found within the last day. See logs: {kibana_logs_link}"
 

--- a/snapshots/terraform/modules/lambda/lambda_function.tf
+++ b/snapshots/terraform/modules/lambda/lambda_function.tf
@@ -13,7 +13,7 @@ resource "aws_lambda_function" "lambda_function" {
 
   role    = aws_iam_role.iam_role.arn
   handler = "${var.handler}.main"
-  runtime = "python3.6"
+  runtime = "python3.7"
   timeout = var.timeout
 
   dead_letter_config {


### PR DESCRIPTION
Plus bump the Lambda runtime, 3.6 was very old and broke when I tried to deploy the new function with the following error:

    Unable to import module 'snapshot_reporter': No module named 'contextvars'

Google suggested people had this issue when their virtualenv got broken, so bumping the Python version (which we should do anyway) forces a new environment and fixed the issue.