### PR TITLE
Simplify our Dockerfile layers

### DIFF
--- a/items/Dockerfile
+++ b/items/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT=items
+ENTRYPOINT ["/opt/docker/bin/items"]

--- a/requests/Dockerfile
+++ b/requests/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT=requests
+ENTRYPOINT ["/opt/docker/bin/requests"]

--- a/search/Dockerfile
+++ b/search/Dockerfile
@@ -1,5 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:104
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT search
+ENTRYPOINT ["/opt/docker/bin/search"]

--- a/snapshots/snapshot_generator/Dockerfile
+++ b/snapshots/snapshot_generator/Dockerfile
@@ -1,6 +1,7 @@
-FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/typesafe_config_base:21
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/openjdk:11
+
+LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
 
 ADD target/universal/stage /opt/docker
 
-ENV PROJECT snapshot_generator
-
+ENTRYPOINT ["/opt/docker/bin/snapshot_generator"]


### PR DESCRIPTION
The typesafe_config_base image has a couple of issues:

- It fetches ECS_METADATA_URI on startup, even though we no longer need to do this – it's a holdover from an old approach to doing logging.
- It obscures exactly how the image is being built, and what's available.
- Actually finding the Dockerfile for this image is very hard to impossible.

Since we don't need it, let's simplify the Dockerfile.

For wellcomecollection/platform#4619