### PR TITLE
bump internal version

### DIFF
--- a/common/display/src/main/scala/weco/catalogue/display_model/models/DisplayAccessCondition.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/models/DisplayAccessCondition.scala
@@ -11,7 +11,6 @@ case class DisplayAccessCondition(
   method: DisplayAccessMethod,
   status: Option[DisplayAccessStatus],
   terms: Option[String],
-  to: Option[String],
   note: Option[String],
   @JsonKey("type") @Schema(name = "type") ontologyType: String =
     "AccessCondition"
@@ -24,7 +23,6 @@ object DisplayAccessCondition {
       method = DisplayAccessMethod(accessCondition.method),
       status = accessCondition.status.map(DisplayAccessStatus.apply),
       terms = accessCondition.terms,
-      to = accessCondition.to,
       note = accessCondition.note
     )
 }

--- a/common/display/src/test/scala/weco/catalogue/display_model/models/DisplayLocationsSerialisationTest.scala
+++ b/common/display/src/test/scala/weco/catalogue/display_model/models/DisplayLocationsSerialisationTest.scala
@@ -97,7 +97,6 @@ class DisplayLocationsSerialisationTest
           method = AccessMethod.ViewOnline,
           status = Some(AccessStatus.Restricted),
           terms = Some("Ask politely"),
-          to = Some("2024-02-24")
         )
       )
     )

--- a/common/display/src/test/scala/weco/catalogue/display_model/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/weco/catalogue/display_model/models/DisplaySerialisationTestBase.scala
@@ -101,7 +101,6 @@ trait DisplaySerialisationTestBase {
           "label": "${DisplayAccessMethod(cond.method).label}"
         },
         ${optionalString("terms", cond.terms)}
-        ${optionalString("to", cond.to, trailingComma = false)}
         ${optionalObject("status", accessStatus, cond.status)}
       }
     """

--- a/common/display/src/test/scala/weco/catalogue/display_model/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/weco/catalogue/display_model/models/DisplaySerialisationTestBase.scala
@@ -100,7 +100,7 @@ trait DisplaySerialisationTestBase {
           "id": "${DisplayAccessMethod(cond.method).id}",
           "label": "${DisplayAccessMethod(cond.method).label}"
         },
-        ${optionalString("terms", cond.terms)}
+        ${optionalString("terms", cond.terms, trailingComma = false)}
         ${optionalObject("status", accessStatus, cond.status)}
       }
     """

--- a/common/stacks/src/main/scala/weco/api/stacks/services/SierraService.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/SierraService.scala
@@ -5,21 +5,10 @@ import grizzled.slf4j.Logging
 import weco.api.stacks.http.{SierraItemLookupError, SierraSource}
 import weco.api.stacks.models._
 import weco.catalogue.internal_model.identifiers.SourceIdentifier
-import weco.catalogue.internal_model.locations.{
-  AccessCondition,
-  AccessMethod,
-  PhysicalLocationType
-}
-import weco.catalogue.source_model.sierra.SierraItemData
-import weco.catalogue.source_model.sierra.identifiers.{
-  SierraBibNumber,
-  SierraItemNumber,
-  SierraPatronNumber
-}
-import weco.catalogue.source_model.sierra.rules.{
-  SierraItemAccess,
-  SierraPhysicalLocationType
-}
+import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod, PhysicalLocationType}
+import weco.catalogue.source_model.sierra.{SierraBibData, SierraItemData}
+import weco.catalogue.source_model.sierra.identifiers.{SierraBibNumber, SierraItemNumber, SierraPatronNumber}
+import weco.catalogue.source_model.sierra.rules.{SierraItemAccess, SierraPhysicalLocationType}
 import weco.http.client.{HttpClient, HttpGet, HttpPost}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -215,13 +204,14 @@ class SierraService(
           .flatMap(name => SierraPhysicalLocationType.fromName(id, name))
 
       // The bib ID is used for debugging purposes; the bib status is only used
-      // for consistency checking.  We can use placeholder data here.
-      val (ac, _, _) = SierraItemAccess(
+      // for consistency checking. We can use placeholder data here.
+      val (ac, _) = SierraItemAccess(
         bibId = SierraBibNumber("0000000"),
         itemId = id,
         bibStatus = None,
         location = location,
-        itemData = itemData
+        itemData = itemData,
+        bibData = SierraBibData()
       )
 
       ac

--- a/common/stacks/src/main/scala/weco/api/stacks/services/SierraService.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/SierraService.scala
@@ -5,10 +5,21 @@ import grizzled.slf4j.Logging
 import weco.api.stacks.http.{SierraItemLookupError, SierraSource}
 import weco.api.stacks.models._
 import weco.catalogue.internal_model.identifiers.SourceIdentifier
-import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod, PhysicalLocationType}
+import weco.catalogue.internal_model.locations.{
+  AccessCondition,
+  AccessMethod,
+  PhysicalLocationType
+}
 import weco.catalogue.source_model.sierra.{SierraBibData, SierraItemData}
-import weco.catalogue.source_model.sierra.identifiers.{SierraBibNumber, SierraItemNumber, SierraPatronNumber}
-import weco.catalogue.source_model.sierra.rules.{SierraItemAccess, SierraPhysicalLocationType}
+import weco.catalogue.source_model.sierra.identifiers.{
+  SierraBibNumber,
+  SierraItemNumber,
+  SierraPatronNumber
+}
+import weco.catalogue.source_model.sierra.rules.{
+  SierraItemAccess,
+  SierraPhysicalLocationType
+}
 import weco.http.client.{HttpClient, HttpGet, HttpPost}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object WellcomeDependencies {
     val monitoring = defaultVersion
     val storage = defaultVersion
     val elasticsearch = defaultVersion
-    val internalModel = "4622.50254173899be5d706d6af7bac15989254cd823f"
+    val internalModel = "4757.021df38b9c1c63e1168030586dbd587b3b8611bf"
   }
 
   val internalModel: Seq[ModuleID] = library(


### PR DESCRIPTION
Like [this](https://github.com/wellcomecollection/catalogue-api/pull/180) but better.

Takes into account we removed `.to` from `AccessStatus`
