### PR TITLE
Bump internal model for the 2021-07-13 reindex

### DIFF
--- a/common/display/src/main/scala/weco/catalogue/display_model/ElasticConfig.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/ElasticConfig.scala
@@ -12,7 +12,7 @@ case class ElasticConfig(
 object ElasticConfig {
   // We use this to share config across API applications
   // i.e. The API and the snapshot generator.
-  val indexDate = "2021-07-06"
+  val indexDate = "2021-07-13"
 
   def apply(): ElasticConfig =
     ElasticConfig(

--- a/common/display/src/main/scala/weco/catalogue/display_model/models/DisplayAccessCondition.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/models/DisplayAccessCondition.scala
@@ -11,7 +11,6 @@ case class DisplayAccessCondition(
   method: DisplayAccessMethod,
   status: Option[DisplayAccessStatus],
   terms: Option[String],
-  to: Option[String],
   note: Option[String],
   @JsonKey("type") @Schema(name = "type") ontologyType: String =
     "AccessCondition"
@@ -24,7 +23,6 @@ object DisplayAccessCondition {
       method = DisplayAccessMethod(accessCondition.method),
       status = accessCondition.status.map(DisplayAccessStatus.apply),
       terms = accessCondition.terms,
-      to = accessCondition.to,
       note = accessCondition.note
     )
 }

--- a/common/display/src/test/scala/weco/catalogue/display_model/models/DisplayLocationsSerialisationTest.scala
+++ b/common/display/src/test/scala/weco/catalogue/display_model/models/DisplayLocationsSerialisationTest.scala
@@ -96,8 +96,7 @@ class DisplayLocationsSerialisationTest
         AccessCondition(
           method = AccessMethod.ViewOnline,
           status = Some(AccessStatus.Restricted),
-          terms = Some("Ask politely"),
-          to = Some("2024-02-24")
+          terms = Some("Ask politely")
         )
       )
     )

--- a/common/display/src/test/scala/weco/catalogue/display_model/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/weco/catalogue/display_model/models/DisplaySerialisationTestBase.scala
@@ -22,7 +22,7 @@ trait DisplaySerialisationTestBase {
     def tidy: String = {
       val tidiedFields =
         s
-          // Replace anything that looks like '"key": None,' in the output.
+        // Replace anything that looks like '"key": None,' in the output.
           .replaceAll(""""[a-zA-Z]+": None,""".stripMargin, "")
           // Unwrap anything that looks like '"key": Some({…})' in the output
           .replaceAll("""Some\(\{(.*)\}\)""", "{$1}")
@@ -31,7 +31,10 @@ trait DisplaySerialisationTestBase {
 
       fromJson[Json](tidiedFields) match {
         case Success(j) => j.noSpaces
-        case Failure(_) => throw new IllegalArgumentException(s"Unable to parse JSON:\n$tidiedFields")
+        case Failure(_) =>
+          throw new IllegalArgumentException(
+            s"Unable to parse JSON:\n$tidiedFields"
+          )
       }
     }
 

--- a/common/display/src/test/scala/weco/catalogue/display_model/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/weco/catalogue/display_model/models/DisplaySerialisationTestBase.scala
@@ -129,13 +129,15 @@ trait DisplaySerialisationTestBase {
     }
 
   def person(person: Person[IdState.Minted]): String =
-    s"""{
-      ${identifiers(person)}
-      "type": "Person",
-      "prefix": ${person.prefix.map(_.toJson)},
-      "numeration": ${person.numeration.map(_.toJson)},
-      "label": "${person.label}"
-    }"""
+    s"""
+       |{
+       |  ${identifiers(person)}
+       |  "type": "Person",
+       |  "prefix": ${person.prefix.map(_.toJson)},
+       |  "numeration": ${person.numeration.map(_.toJson)},
+       |  "label": "${person.label}"
+       |}
+       |""".stripMargin.tidy
 
   def organisation(organisation: Organisation[IdState.Minted]) =
     s"""{

--- a/common/display/src/test/scala/weco/catalogue/display_model/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/weco/catalogue/display_model/models/DisplaySerialisationTestBase.scala
@@ -277,12 +277,12 @@ trait DisplaySerialisationTestBase {
 
   def format(fmt: Format): String =
     s"""
-      {
-        "id": "${fmt.id}",
-        "label": "${fmt.label}",
-        "type": "Format"
-      }
-    """
+       |{
+       |  "id": "${fmt.id}",
+       |  "label": "${fmt.label}",
+       |  "type": "Format"
+       |}
+       |""".stripMargin.tidy
 
   def language(lang: Language): String =
     s"""

--- a/common/display/src/test/scala/weco/catalogue/display_model/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/weco/catalogue/display_model/models/DisplaySerialisationTestBase.scala
@@ -101,7 +101,6 @@ trait DisplaySerialisationTestBase {
           "label": "${DisplayAccessMethod(cond.method).label}"
         },
         ${optionalString("terms", cond.terms)}
-        ${optionalString("to", cond.to, trailingComma = false)}
         ${optionalObject("status", accessStatus, cond.status)}
       }
     """

--- a/common/display/src/test/scala/weco/catalogue/display_model/models/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/weco/catalogue/display_model/models/DisplaySerialisationTestBase.scala
@@ -1,5 +1,6 @@
 package weco.catalogue.display_model.models
 
+import io.circe.Json
 import org.scalatest.Suite
 import weco.json.JsonUtil._
 import weco.catalogue.internal_model.identifiers.{
@@ -12,49 +13,44 @@ import weco.catalogue.internal_model.languages.Language
 import weco.catalogue.internal_model.locations._
 import weco.catalogue.internal_model.work._
 
+import scala.util.{Failure, Success}
+
 trait DisplaySerialisationTestBase {
   this: Suite =>
 
-  def optionalString(
-    fieldName: String,
-    maybeStringValue: Option[String],
-    trailingComma: Boolean = true
-  ): String =
-    maybeStringValue match {
-      case None => ""
-      case Some(value) =>
-        s"""
-          "$fieldName": "$value"
-          ${if (trailingComma) "," else ""}
-        """
+  implicit class JsonStringOps(s: String) {
+    def tidy: String = {
+      val tidiedFields =
+        s
+          // Replace anything that looks like '"key": None,' in the output.
+          .replaceAll(""""[a-zA-Z]+": None,""".stripMargin, "")
+          // Unwrap anything that looks like '"key": Some({…})' in the output
+          .replaceAll("""Some\(\{(.*)\}\)""", "{$1}")
+          // Unwrap anything that looks like '"key": Some("…")' in the output
+          .replaceAll("""Some\("(.*)"\)""", "\"$1\"")
+
+      fromJson[Json](tidiedFields) match {
+        case Success(j) => j.noSpaces
+        case Failure(_) => throw new IllegalArgumentException(s"Unable to parse JSON:\n$tidiedFields")
+      }
     }
 
-  def optionalObject[T](
-    fieldName: String,
-    formatter: T => String,
-    maybeObjectValue: Option[T],
-    firstField: Boolean = false
-  ) =
-    maybeObjectValue match {
-      case None => ""
-      case Some(o) =>
-        s"""
-           ${if (!firstField) ","}"$fieldName": ${formatter(o)}
-         """
-    }
+    def toJson: String =
+      Json.fromString(s).noSpaces
+  }
 
   def items(items: List[Item[IdState.Minted]]) =
     items.map(item).mkString(",")
 
-  def item(item: Item[IdState.Minted]) =
+  def item(item: Item[IdState.Minted]): String =
     s"""
      {
        ${identifiers(item)}
        "type": "Item",
-       ${optionalString("title", item.title)}
+       "title": ${item.title.map(_.toJson)},
        "locations": [${locations(item.locations)}]
      }
-    """
+    """.tidy
 
   def locations(locations: List[Location]) =
     locations.map(location).mkString(",")
@@ -65,55 +61,54 @@ trait DisplaySerialisationTestBase {
       case l: PhysicalLocation => physicalLocation(l)
     }
 
-  def digitalLocation(digitalLocation: DigitalLocation) =
+  def digitalLocation(loc: DigitalLocation): String =
     s"""{
       "type": "DigitalLocation",
-      "locationType": ${locationType(digitalLocation.locationType)},
-      "url": "${digitalLocation.url}"
-      ${optionalObject("license", license, digitalLocation.license)},
-      ${optionalString("credit", digitalLocation.credit)}
-      ${optionalString("linkText", digitalLocation.linkText)}
-      "accessConditions": ${accessConditions(digitalLocation.accessConditions)}
-    }"""
+      "locationType": ${locationType(loc.locationType)},
+      "url": "${loc.url}",
+      "license": ${loc.license.map(license)},
+      "credit": ${loc.credit.map(_.toJson)},
+      "linkText": ${loc.linkText.map(_.toJson)},
+      "accessConditions": ${accessConditions(loc.accessConditions)}
+    }""".tidy
 
-  def physicalLocation(loc: PhysicalLocation) =
+  def physicalLocation(loc: PhysicalLocation): String =
     s"""
        {
         "type": "PhysicalLocation",
         "locationType": ${locationType(loc.locationType)},
-        "label": "${loc.label}"
-        ${optionalObject("license", license, loc.license)},
-        ${optionalString("shelfmark", loc.shelfmark)}
+        "label": "${loc.label}",
+        "license": ${loc.license.map(license)},
+        "shelfmark": ${loc.shelfmark.map(_.toJson)},
         "accessConditions": ${accessConditions(loc.accessConditions)}
        }
-     """
+     """.tidy
 
   def accessConditions(conds: List[AccessCondition]) =
     s"[${conds.map(accessCondition).mkString(",")}]"
 
-  def accessCondition(cond: AccessCondition) =
+  def accessCondition(cond: AccessCondition): String =
     s"""
       {
-        "type": "AccessCondition",
         "method": {
           "type": "AccessMethod",
           "id": "${DisplayAccessMethod(cond.method).id}",
           "label": "${DisplayAccessMethod(cond.method).label}"
         },
-        ${optionalString("terms", cond.terms)}
-        ${optionalObject("status", accessStatus, cond.status)}
+        "terms": ${cond.terms.map(_.toJson)},
+        "status": ${cond.status.map(accessStatus)},
+        "type": "AccessCondition"
       }
-    """
+    """.tidy
 
-  def accessStatus(status: AccessStatus) = {
-    s"""
-      {
-        "type": "AccessStatus",
-        "id": "${DisplayAccessStatus(status).id}",
-        "label": "${DisplayAccessStatus(status).label}"
-      }
-    """
-  }
+  def accessStatus(status: AccessStatus): String =
+    s"""{
+       |  "type": "AccessStatus",
+       |  "id": ${DisplayAccessStatus(status).id.toJson},
+       |  "label": ${DisplayAccessStatus(status).label.toJson}
+       |}
+       |""".stripMargin.tidy
+
   def identifiers(obj: HasId[IdState.Minted]) =
     obj.id match {
       case IdState.Identified(canonicalId, _, _) => s"""
@@ -130,14 +125,14 @@ trait DisplaySerialisationTestBase {
       case m: Meeting[IdState.Minted]      => meeting(m)
     }
 
-  def person(person: Person[IdState.Minted]) =
+  def person(person: Person[IdState.Minted]): String =
     s"""{
-       ${identifiers(person)}
-        "type": "Person",
-        ${optionalString("prefix", person.prefix)}
-        ${optionalString("numeration", person.numeration)}
-        "label": "${person.label}"
-      }"""
+      ${identifiers(person)}
+      "type": "Person",
+      "prefix": ${person.prefix.map(_.toJson)},
+      "numeration": ${person.numeration.map(_.toJson)},
+      "label": "${person.label}"
+    }"""
 
   def organisation(organisation: Organisation[IdState.Minted]) =
     s"""{
@@ -248,34 +243,34 @@ trait DisplaySerialisationTestBase {
 
   def workImageInclude(image: ImageData[IdState.Identified]) =
     s"""
-       {
-         "id": "${image.id.canonicalId}",
-         "type": "Image"
-       }
-    """
+       |{
+       |  "id": "${image.id.canonicalId}",
+       |  "type": "Image"
+       |}
+       |""".stripMargin
 
   def workImageIncludes(images: List[ImageData[IdState.Identified]]) =
     images.map(workImageInclude).mkString(",")
 
   def availability(availability: Availability): String =
     s"""
-      {
-        "id": "${availability.id}",
-        "label": "${availability.label}",
-        "type": "Availability"
-      }
-     """.stripMargin
+       |{
+       |  "id": "${availability.id}",
+       |  "label": "${availability.label}",
+       |  "type": "Availability"
+       |}
+       |""".stripMargin
 
   def productionEvent(event: ProductionEvent[IdState.Minted]): String =
     s"""
-      {
-        "label": "${event.label}",
-        "dates": [${event.dates.map(period).mkString(",")}],
-        "agents": [${event.agents.map(abstractAgent).mkString(",")}],
-        "places": [${event.places.map(place).mkString(",")}],
-        "type": "ProductionEvent"
-      }
-    """
+       |{
+       |  "label": "${event.label}",
+       |  "dates": [${event.dates.map(period).mkString(",")}],
+       |  "agents": [${event.agents.map(abstractAgent).mkString(",")}],
+       |  "places": [${event.places.map(place).mkString(",")}],
+       |  "type": "ProductionEvent"
+       |}
+       |""".stripMargin.tidy
 
   def format(fmt: Format): String =
     s"""
@@ -295,13 +290,13 @@ trait DisplaySerialisationTestBase {
        }
      """
 
-  def license(license: License) =
+  def license(license: License): String =
     s"""{
       "id": "${license.id}",
       "label": "${license.label}",
       "url": "${license.url}",
       "type": "License"
-    }"""
+    }""".tidy
 
   def identifier(identifier: SourceIdentifier) =
     s"""{
@@ -322,21 +317,18 @@ trait DisplaySerialisationTestBase {
        }
      """ stripMargin
 
-  def singleHoldings(h: Holdings): String =
+  def singleHoldings(h: Holdings): String = {
+    val enumerations = h.enumeration.map(_.toJson)
+
     s"""
        |{
-       |  ${optionalString("note", h.note)}
-       |  "enumeration": [
-       |    ${h.enumeration
-         .map { en =>
-           '"' + en + '"'
-         }
-         .mkString(",")}
-       |  ]
-       |  ${optionalObject("location", location, h.location)},
+       |  "note": ${h.note.map(_.toJson)},
+       |  "enumeration": [${enumerations.mkString(",")}],
+       |  "location": ${h.location.map(location)},
        |  "type": "Holdings"
        |}
-       |""".stripMargin
+       |""".stripMargin.tidy
+  }
 
   def listOfHoldings(hs: List[Holdings]): String =
     hs.map { singleHoldings }.mkString(",")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object WellcomeDependencies {
     val monitoring = defaultVersion
     val storage = defaultVersion
     val elasticsearch = defaultVersion
-    val internalModel = "4659.6171f9f14c5f8164c670b03f5ba97701478036cb"
+    val internalModel = "4881.54b6f2f1e1fe3085e6b53555c94a44d75b778a77"
   }
 
   val internalModel: Seq[ModuleID] = library(

--- a/search/src/test/scala/weco/api/search/images/ApiImagesTestBase.scala
+++ b/search/src/test/scala/weco/api/search/images/ApiImagesTestBase.scala
@@ -19,12 +19,12 @@ trait ApiImagesTestBase
     source match {
       case ParentWorks(work, _) =>
         s"""
-             | {
-             |   "id": "${source.id.canonicalId}",
-             |   ${optionalString("title", work.data.title)}
-             |   "type": "Work"
-             | }
-           """.stripMargin
+           |{
+           |  "id": "${source.id.canonicalId}",
+           |  "title": ${work.data.title.map(_.toJson)},
+           |  "type": "Work"
+           |}
+           |""".stripMargin.tidy
     }
 
   def imageResponse(image: Image[ImageState.Indexed]): String =

--- a/search/src/test/scala/weco/api/search/works/ApiWorksTestBase.scala
+++ b/search/src/test/scala/weco/api/search/works/ApiWorksTestBase.scala
@@ -31,14 +31,14 @@ trait ApiWorksTestBase
   def workResponse(work: Work.Visible[Indexed]): String =
     s"""
       | {
-      |   "type": "${formatOntologyType(work.data.workType)}",
       |   "id": "${work.state.canonicalId}",
       |   "title": "${work.data.title.get}",
       |   "availabilities": [${availabilities(work.state.availabilities)}],
-      |   "alternativeTitles": []
-      |   ${optionalObject("workType", format, work.data.format)}
+      |   "alternativeTitles": [],
+      |   "workType": ${work.data.format.map(format)},
+      |   "type": "${formatOntologyType(work.data.workType)}"
       | }
-    """.stripMargin
+    """.stripMargin.tidy
 
   def worksListResponse(works: Seq[Work.Visible[Indexed]]): String =
     s"""


### PR DESCRIPTION
This corresponds to https://github.com/wellcomecollection/catalogue-pipeline/pull/1762

It has to pick up an internal model change – we've removed `"to"` from access conditions, which led me to tidy up the DisplaySerialisation test base, which was getting rather fiddly with various combinations of optional fields.