### PR TITLE
Add an _elasticConfig endpoint for seeing the current index

### DIFF
--- a/search/src/main/scala/weco/api/search/Router.scala
+++ b/search/src/main/scala/weco/api/search/Router.scala
@@ -72,6 +72,9 @@ class Router(
         path("search-templates.json") {
           getSearchTemplates
         },
+        path("_elasticConfig") {
+          getElasticConfig
+        },
         pathPrefix("management") {
           concat(
             path("healthcheck") {
@@ -142,6 +145,16 @@ class Router(
       )
     )
   }
+
+  private def getElasticConfig: Route =
+    get {
+      complete(
+        Map(
+          "worksIndex" -> ElasticConfig().worksIndex.name,
+          "imagesIndex" -> ElasticConfig().imagesIndex.name
+        )
+      )
+    }
 
   def rejectionHandler =
     RejectionHandler.newBuilder


### PR DESCRIPTION
This adds an HTTP endpoint to the API that returns the current index config

    GET /_elasticConfig
    {"worksIndex": "works-indexed-2021-07-20", "imagesIndex": "images-indexed-2021-07-20"}

This is meant to be a bit easier for scripts/humans to work out the current index than looking at the search-templates endpoint.

Small convenience feature I've wanted for a while.