### PR TITLE
Include a line about pipeline health in the daily snapshot report

### DIFF
--- a/builds/publish_lambda_zip.py
+++ b/builds/publish_lambda_zip.py
@@ -124,4 +124,14 @@ if __name__ == "__main__":
     name = os.path.basename(key)
     filename = build_lambda_local(path=path, name=name)
 
-    client.upload_file(Bucket=bucket, Filename=filename, Key=key)
+    client.upload_file(
+        Bucket=bucket,
+        Filename=filename,
+        Key=key,
+        ExtraArgs={
+            "Metadata": {
+                "git.remoteUrl": git("remote", "get-url", "origin"),
+                "git.commit": git("rev-parse", "HEAD"),
+            }
+        },
+    )

--- a/snapshots/snapshot_reporter/src/snapshot_reporter.py
+++ b/snapshots/snapshot_reporter/src/snapshot_reporter.py
@@ -127,10 +127,7 @@ def prepare_slack_payload(*, snapshots, api_document_count, recent_updates):
         )
 
     snapshot_blocks = [
-        {
-            "type": "header",
-            "text": {"type": "plain_text", "text": snapshot_heading},
-        },
+        {"type": "header", "text": {"type": "plain_text", "text": snapshot_heading}},
         {"type": "section", "text": {"type": "mrkdwn", "text": snapshot_message}},
     ]
 

--- a/snapshots/terraform/stack/snapshot_reporter/iam.tf
+++ b/snapshots/terraform/stack/snapshot_reporter/iam.tf
@@ -5,8 +5,7 @@ data "aws_iam_policy_document" "read_secrets" {
     ]
 
     resources = [
-      data.aws_secretsmanager_secret_version.elastic_secret_id.arn,
-      data.aws_secretsmanager_secret_version.slack_secret_id.arn,
+      for _, secret in data.aws_secretsmanager_secret_version.secrets : secret.arn
     ]
   }
 }

--- a/snapshots/terraform/stack/snapshot_reporter/locals.tf
+++ b/snapshots/terraform/stack/snapshot_reporter/locals.tf
@@ -1,12 +1,18 @@
-data "aws_secretsmanager_secret_version" "elastic_secret_id" {
-  secret_id = local.elastic_secret_id
-}
+data "aws_secretsmanager_secret_version" "secrets" {
+  for_each = toset(local.secrets)
 
-data "aws_secretsmanager_secret_version" "slack_secret_id" {
-  secret_id = local.slack_secret_id
+  secret_id = each.key
 }
 
 locals {
   elastic_secret_id = "catalogue/snapshots/read_user"
   slack_secret_id   = "snapshot_reporter/slack_webhook"
+
+  secrets = [
+    local.elastic_secret_id,
+    local.slack_secret_id,
+    "elasticsearch/catalogue_api/search/username",
+    "elasticsearch/catalogue_api/search/password",
+    "elasticsearch/catalogue_api/public_host",
+  ]
 }


### PR DESCRIPTION
The pipeline has been a bit unreliable lately, and there have been days (possibly even a week) when we weren't processing any updates. This patch adds a one-line report to the daily snapshot report, so we can see if the pipeline has gone bang:

* Pipeline that hasn't processed updates recently:

    <img width="681" alt="Screenshot 2021-07-21 at 08 44 25" src="https://user-images.githubusercontent.com/301220/126451178-e6588e8d-df5e-4816-b2df-8142abf7f521.png">

   (I know there's an extra "at" there, removed in the code.)

* Pipeline that has processed some updates recently:

   <img width="673" alt="Screenshot 2021-07-21 at 08 44 41" src="https://user-images.githubusercontent.com/301220/126451186-0950e1ee-4520-4a85-b3e1-9f20f8f3d90c.png">

The idea is that we'll notice when it starts to drift, and have a bit more of a reminder that we need to do something about it, rather than letting it languish.

This is already deployed.

---

Implementation notes:

- This is using the timestamps we added to the WorkState in https://github.com/wellcomecollection/catalogue-pipeline/pull/1601 that track when a work was indexed in Elasticsearch.
- The Lambda is querying the API cluster because it's the only way to be sure the works are in the API – if I used the pipeline-storage cluster, it wouldn't report on CCR issues.
- I did consider adding some stats on pipeline latency – how long does it take for a work modified in a source to be indexed in the pipeline (which was the original intention of PR #​1601). Unfortunately this is trickier than I thought, because reindexes screw up the stats. We have have a work that were indexed 20 years after they were modified… because they're Sierra records that have been long-since deleted.
- The script that uploads Lambdas now adds the Git repo and the commit ID as S3 object metadata, so we get the same tracking of provenance as for our ECR images.