### PR TITLE
Update internal model

### DIFF
--- a/common/display/src/test/scala/weco/catalogue/display_model/models/DisplayWorkTest.scala
+++ b/common/display/src/test/scala/weco/catalogue/display_model/models/DisplayWorkTest.scala
@@ -208,8 +208,10 @@ class DisplayWorkTest
     )
   }
 
-  // ScalaCheck generates a Work by deconstructing it and
-  // implicitly providing random data for Primitive types.
+  // ScalaCheck generates a Work by using reflection to
+  // implicitly provide random data for its constituent
+  // types.
+  //
   // Where necessary to adhere to internal restrictions
   // data for a type can be provided as in this object.
   object ScalaCheckWorkImplicits {

--- a/common/stacks/src/main/scala/weco/api/stacks/services/SierraService.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/SierraService.scala
@@ -36,7 +36,7 @@ class SierraService(
 
   def getAccessCondition(
     sourceIdentifier: SourceIdentifier
-  ): Future[Either[SierraItemLookupError, Option[AccessCondition]]] = {
+  ): Future[Either[SierraItemLookupError, AccessCondition]] = {
     val itemNumber = SierraItemIdentifier.fromSourceIdentifier(sourceIdentifier)
 
     for {
@@ -195,7 +195,7 @@ class SierraService(
     }
 
   implicit class ItemDataOps(itemData: SierraItemData) {
-    def getAccessCondition(id: SierraItemNumber): Option[AccessCondition] = {
+    def getAccessCondition(id: SierraItemNumber): AccessCondition = {
 
       val location: Option[PhysicalLocationType] =
         itemData.fixedFields
@@ -216,11 +216,8 @@ class SierraService(
     }
 
     def allowsOnlineRequesting(id: SierraItemNumber): Boolean = {
-      getAccessCondition(id) match {
-        case Some(ac) if ac.method == AccessMethod.OnlineRequest =>
-          true
-        case _ => false
-      }
+      val accessCondition = getAccessCondition(id)
+      accessCondition.method == AccessMethod.OnlineRequest
     }
   }
 

--- a/common/stacks/src/test/scala/weco/api/stacks/services/SierraServiceTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/services/SierraServiceTest.scala
@@ -80,9 +80,7 @@ class SierraServiceTest
           val future = service.getAccessCondition(identifier)
 
           whenReady(future) {
-            _.value shouldBe Some(
-              AccessCondition(method = AccessMethod.OnlineRequest)
-            )
+            _.value shouldBe AccessCondition(method = AccessMethod.OnlineRequest)
           }
         }
       }

--- a/items/src/main/scala/weco/api/items/services/ItemUpdateService.scala
+++ b/items/src/main/scala/weco/api/items/services/ItemUpdateService.scala
@@ -39,11 +39,10 @@ class ItemUpdateService(
     sierraService
       .getAccessCondition(srcId)
       .map {
-        case Right(Some(accessCondition)) =>
+        case Right(accessCondition) =>
           item.copy(
             locations = updateAccessCondition(item, accessCondition)
           )
-        case Right(_) => item
         case Left(err) =>
           error(msg = f"Couldn't refresh item: ${item.id} got error $err")
           item

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object WellcomeDependencies {
     val monitoring = defaultVersion
     val storage = defaultVersion
     val elasticsearch = defaultVersion
-    val internalModel = "4960.55842c7dffef3b80fe7755768728028d75f0d866"
+    val internalModel = "5021.6fbf97350117e797abb25ab41f1a00d20d7899e5"
   }
 
   val internalModel: Seq[ModuleID] = library(

--- a/search/src/test/scala/weco/api/search/images/ImagesIncludesTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesIncludesTest.scala
@@ -16,7 +16,7 @@ class ImagesIncludesTest
       .title("Apple agitator")
       .languages(
         List(
-          Language(label = "English", id = "en"),
+          Language(label = "English", id = "eng"),
           Language(label = "Turkish", id = "tur")
         )
       )


### PR DESCRIPTION
This PR updates the internal model, and makes changes required from that update.

Extracted from https://github.com/wellcomecollection/catalogue-api/pull/197

- Add implicit for language code generation:
  - Fix for an update in the internal model breaking ScalaCheck generation of a work. Language codes got additional restrictions not reflected by the available implicits in scope in the `DisplayWorkTest`.
  - This change also adds some more comments to make it clearer what is happening with Work generation.

- Update to replace `Option[AccessCondition]` with `AccessCondition`
