### PR TITLE
Add APM Tracing to requests API

### DIFF
--- a/items/src/main/scala/weco/api/items/Main.scala
+++ b/items/src/main/scala/weco/api/items/Main.scala
@@ -31,6 +31,7 @@ object Main extends WellcomeTypesafeApp {
     implicit val apiConfig: ApiConfig = ApiConfig.build(config)
 
     val elasticClient = ElasticBuilder.buildElasticClient(config)
+
     val sierraService = SierraServiceBuilder.build(config)
 
     // To add an item updater for a new service, implement ItemUpdater and add it to the list here

--- a/requests/src/main/resources/application.conf
+++ b/requests/src/main/resources/application.conf
@@ -2,6 +2,11 @@ http.externalBaseURL=${?app_base_url}
 http.host="0.0.0.0"
 http.port=9001
 
+apm.server.url=${?apm_server_url}
+apm.secret=${?apm_secret}
+apm.service.name=${?apm_service_name}
+apm.environment=${?apm_environment}
+
 es.host=${?es_host}
 es.port=${?es_port}
 es.username=${?es_username}

--- a/requests/src/main/scala/weco/api/requests/Main.scala
+++ b/requests/src/main/scala/weco/api/requests/Main.scala
@@ -2,6 +2,7 @@ package weco.api.requests
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
+import weco.Tracing
 import weco.elasticsearch.typesafe.ElasticBuilder
 import weco.http.typesafe.HTTPServerBuilder
 import weco.monitoring.typesafe.CloudWatchBuilder
@@ -17,11 +18,14 @@ import weco.http.monitoring.HttpMetrics
 import scala.concurrent.ExecutionContext
 
 object Main extends WellcomeTypesafeApp {
+
   runWithConfig { config: Config =>
     implicit val asMain: ActorSystem =
       AkkaBuilder.buildActorSystem()
     implicit val ec: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
+
+    Tracing.init(config)
 
     implicit val apiConfig: ApiConfig = ApiConfig.build(config)
 

--- a/search/src/main/scala/weco/api/search/Main.scala
+++ b/search/src/main/scala/weco/api/search/Main.scala
@@ -24,7 +24,6 @@ object Main extends WellcomeTypesafeApp {
 
     Tracing.init(config)
     val elasticClient = ElasticBuilder.buildElasticClient(config)
-
     val elasticConfig = ElasticConfig()
 
     CheckModel.checkModel(elasticConfig.worksIndex.name)(elasticClient)


### PR DESCRIPTION
Requests does not have APM Tracing unlike Items & Search - it should, this adds it.

An infra change in the https://github.com/wellcomecollection/identity is required to provide the parameters to the ECS service and should be deployed first.