### PR TITLE
put user safely, without overriding password

### DIFF
--- a/terraform/modules/elastic_user/main.tf
+++ b/terraform/modules/elastic_user/main.tf
@@ -1,0 +1,3 @@
+variable "username" {
+  type = string
+}

--- a/terraform/modules/elastic_user/main.tf
+++ b/terraform/modules/elastic_user/main.tf
@@ -1,3 +1,0 @@
-variable "username" {
-  type = string
-}

--- a/terraform/shared/scripts/users.py
+++ b/terraform/shared/scripts/users.py
@@ -1,0 +1,38 @@
+import elasticsearch
+import secrets
+
+"""
+This method checks if a user exists.
+Exists: it updates the roles if needed with no password update, returns None
+Missing: creates the user with a new password , returns username, password
+"""
+def put_user_safely(es, username, roles):
+    try:
+        data = es.security.get_user(username=username)
+        print(f"user: {username} exists")
+        if data[username]["roles"] != roles:
+            print(f"user: {username} updating roles...")
+            es.security.put_user(
+                username=username,
+                body={
+                    "roles": roles
+                }
+            )
+            print(f"user: {username} roles updated")
+        else:
+            print(f"user: {username} has no role updates")
+
+        return None
+
+    except elasticsearch.exceptions.NotFoundError:
+        print(f"user: {username} missing, creating...")
+        service_password = secrets.token_hex()
+        # es.security.put_user(
+        #     username=username,
+        #     body={
+        #         "password": service_password,
+        #         "roles": roles
+        #     }
+        # )
+        print(f"{username} created")
+        return username, service_password

--- a/terraform/shared/scripts/users.py
+++ b/terraform/shared/scripts/users.py
@@ -27,12 +27,12 @@ def put_user_safely(es, username, roles):
     except elasticsearch.exceptions.NotFoundError:
         print(f"user: {username} missing, creating...")
         service_password = secrets.token_hex()
-        # es.security.put_user(
-        #     username=username,
-        #     body={
-        #         "password": service_password,
-        #         "roles": roles
-        #     }
-        # )
+        es.security.put_user(
+            username=username,
+            body={
+                "password": service_password,
+                "roles": roles
+            }
+        )
         print(f"{username} created")
         return username, service_password

--- a/terraform/shared/scripts/users.py
+++ b/terraform/shared/scripts/users.py
@@ -6,6 +6,8 @@ This method checks if a user exists.
 Exists: it updates the roles if needed with no password update, returns None
 Missing: creates the user with a new password , returns username, password
 """
+
+
 def put_user_safely(es, username, roles):
     try:
         data = es.security.get_user(username=username)


### PR DESCRIPTION
Ensures that if a user exists, we leave the password as is. 

What I might prefer over this is to [store the users as secrets in terraform](https://github.com/wellcomecollection/catalogue-api/pull/208) but I just want to have something blocking us from destroying things for now.