### PR TITLE
Use scalacheck implicits from pipeline

### DIFF
--- a/common/display/src/test/scala/weco/catalogue/display_model/models/DisplayWorkTest.scala
+++ b/common/display/src/test/scala/weco/catalogue/display_model/models/DisplayWorkTest.scala
@@ -1,19 +1,12 @@
 package weco.catalogue.display_model.models
 
-import java.time.Instant
-import org.scalacheck.Arbitrary
-import org.scalacheck.Gen.chooseNum
 import org.scalacheck.ScalacheckShapeless._
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import weco.catalogue.internal_model.work.generators.ProductionEventGenerators
+import weco.catalogue.internal_model.work.generators.{ProductionEventGenerators, WorkGenerators}
 import weco.catalogue.internal_model.generators.ImageGenerators
-import weco.catalogue.internal_model.identifiers.{
-  CanonicalId,
-  IdState,
-  SourceIdentifier
-}
+import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.languages.Language
 import weco.catalogue.internal_model.locations._
 import weco.catalogue.internal_model.work._
@@ -23,6 +16,7 @@ class DisplayWorkTest
     with Matchers
     with ProductionEventGenerators
     with ImageGenerators
+    with WorkGenerators
     with ScalaCheckPropertyChecks {
 
   it("parses a Work without any items") {
@@ -209,55 +203,8 @@ class DisplayWorkTest
   }
 
   // ScalaCheck generates a Work by using reflection to
-  // implicitly provide random data for its constituent
-  // types.
-  //
-  // Where necessary to adhere to internal restrictions
-  // data for a type can be provided as in this object.
-  object ScalaCheckWorkImplicits {
-    // We use this for the scalacheck of the java.time.Instant type
-    // We could just import the library, but I might wait until we need more
-    // Taken from here:
-    // https://github.com/rallyhealth/scalacheck-ops/blob/master/core/src/main/scala/org/scalacheck/ops/time/ImplicitJavaTimeGenerators.scala
-    implicit val arbInstant: Arbitrary[Instant] =
-      Arbitrary {
-        for {
-          millis <- chooseNum(
-            Instant.MIN.getEpochSecond,
-            Instant.MAX.getEpochSecond
-          )
-          nanos <- chooseNum(Instant.MIN.getNano, Instant.MAX.getNano)
-        } yield {
-          Instant.ofEpochMilli(millis).plusNanos(nanos)
-        }
-      }
-
-    // We have a rule that says SourceIdentifier isn't allowed to contain whitespace,
-    // but sometimes scalacheck will happen to generate such a string, which breaks
-    // tests in CI.  This generator is meant to create SourceIdentifiers that
-    // don't contain whitespace.
-    implicit val arbitrarySourceIdentifier: Arbitrary[SourceIdentifier] =
-      Arbitrary {
-        createSourceIdentifier
-      }
-
-    implicit val arbitraryCanonicalId: Arbitrary[CanonicalId] =
-      Arbitrary {
-        createCanonicalId
-      }
-
-    // We have a rule that says language codes should be exactly 3 characters long
-    implicit val arbitraryLanguage: Arbitrary[Language] =
-      Arbitrary {
-        Language(
-          id = randomAlphanumeric(length = 3),
-          label = randomAlphanumeric()
-        )
-      }
-  }
-
+  // provide random data for its constituent types
   it("does not extract includes set to false") {
-    import ScalaCheckWorkImplicits._
 
     forAll { work: Work.Visible[WorkState.Indexed] =>
       val displayWork = DisplayWork(work, includes = WorksIncludes.none)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object WellcomeDependencies {
     val monitoring = defaultVersion
     val storage = defaultVersion
     val elasticsearch = defaultVersion
-    val internalModel = "5021.6fbf97350117e797abb25ab41f1a00d20d7899e5"
+    val internalModel = "5039.87b9d60881aa84ed04650386e9dd3ade4ad18156"
   }
 
   val internalModel: Seq[ModuleID] = library(


### PR DESCRIPTION
Following: https://github.com/wellcomecollection/catalogue-pipeline/pull/1786

Removes unnecessary implicits.

Note: this change bumps the internal model version and will not be compatible with the current elasticsearch index unless its metadata is updated.