### PR TITLE
remove legacy way of referencing elastic user secrets

### DIFF
--- a/terraform/modules/elastic_user/main.tf
+++ b/terraform/modules/elastic_user/main.tf
@@ -22,7 +22,7 @@ resource "aws_secretsmanager_secret_version" "username" {
 }
 
 resource "aws_secretsmanager_secret_version" "password" {
-  secret_id     = aws_secretsmanager_secret.username.id
+  secret_id     = aws_secretsmanager_secret.password.id
   secret_string = random_password.password.result
 
   provisioner "local-exec" {
@@ -31,9 +31,12 @@ resource "aws_secretsmanager_secret_version" "password" {
 }
 
 resource "random_password" "password" {
-  length           = 16
-  special          = true
-  override_special = "_%@"
+  length = 64
+
+  # This is to avoid us changing passwords inadvertently
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 resource "null_resource" "roles" {

--- a/terraform/modules/elastic_user/outputs.tf
+++ b/terraform/modules/elastic_user/outputs.tf
@@ -1,0 +1,7 @@
+output "aws_secretsmanager_secret_username_name" {
+  value = aws_secretsmanager_secret.username.name
+}
+
+output "aws_secretsmanager_secret_password_name" {
+  value = aws_secretsmanager_secret.password.name
+}

--- a/terraform/shared/elastic.tf
+++ b/terraform/shared/elastic.tf
@@ -66,8 +66,8 @@ locals {
     es_host     = "elasticsearch/catalogue_api/public_host"
     es_port     = "elasticsearch/catalogue_api/port"
     es_protocol = "elasticsearch/catalogue_api/protocol"
-    es_username = aws_secretsmanager_secret.service-items-username.name
-    es_password = aws_secretsmanager_secret.service-items-password.name
+    es_username = module.items_elastic_user.aws_secretsmanager_secret_username_name
+    es_password = module.items_elastic_user.aws_secretsmanager_secret_password_name
   }
 
   # This config will be consumed by the requests service in the identity stack
@@ -75,8 +75,8 @@ locals {
     es_host     = "elasticsearch/catalogue_api/public_host"
     es_port     = "elasticsearch/catalogue_api/port"
     es_protocol = "elasticsearch/catalogue_api/protocol"
-    es_username = aws_secretsmanager_secret.service-requests-username.name
-    es_password = aws_secretsmanager_secret.service-requests-password.name
+    es_username = module.requests_elastic_user.aws_secretsmanager_secret_username_name
+    es_password = module.requests_elastic_user.aws_secretsmanager_secret_password_name
   }
 
   # This config will be consumed by the search service in the catalogue_api stack
@@ -84,8 +84,8 @@ locals {
     es_host     = "elasticsearch/catalogue_api/public_host"
     es_port     = "elasticsearch/catalogue_api/port"
     es_protocol = "elasticsearch/catalogue_api/protocol"
-    es_username = aws_secretsmanager_secret.service-search-username.name
-    es_password = aws_secretsmanager_secret.service-search-password.name
+    es_username = module.search_elastic_user.aws_secretsmanager_secret_username_name
+    es_password = module.search_elastic_user.aws_secretsmanager_secret_password_name
   }
 }
 
@@ -128,103 +128,49 @@ module "identity_secrets" {
   }
 }
 
-# Search service credentials
+# Elastic users
 
-resource "aws_secretsmanager_secret" "service-search-username" {
-  name = "elasticsearch/catalogue_api/search/username"
-
-  description = "Config secret populated by Terraform"
-  tags        = local.default_tags
+module "search_elastic_user" {
+  source = "../modules/elastic_user"
+  service = "search"
+  roles = ["catalogue_read"]
 }
 
-resource "aws_secretsmanager_secret" "service-search-password" {
-  name = "elasticsearch/catalogue_api/search/password"
-
-  description = "Config secret populated by Terraform"
-  tags        = local.default_tags
+module "items_elastic_user" {
+  source = "../modules/elastic_user"
+  service = "items"
+  roles = ["catalogue_read"]
 }
 
-# Items service credentials
+module "requests_elastic_user" {
+  source = "../modules/elastic_user"
+  service = "requests"
+  roles = ["catalogue_read"]
 
-resource "aws_secretsmanager_secret" "service-items-username" {
-  name = "elasticsearch/catalogue_api/items/username"
-
-  description = "Config secret populated by Terraform"
-  tags        = local.default_tags
+  providers = {
+    aws = aws.identity
+  }
 }
 
-resource "aws_secretsmanager_secret" "service-items-password" {
-  name = "elasticsearch/catalogue_api/items/password"
-
-  description = "Config secret populated by Terraform"
-  tags        = local.default_tags
+module "replication_manager_elastic_user" {
+  source = "../modules/elastic_user"
+  service = "replication_manager"
+  roles = ["catalogue_read", "catalogue_manage_ccr"]
 }
 
-# Requests service credentials
-
-resource "aws_secretsmanager_secret" "service-requests-username" {
-  name = "elasticsearch/catalogue_api/requests/username"
-
-  description = "Config secret populated by Terraform"
-  tags        = local.default_tags
-
-  provider = aws.identity
+module "diff_tool_elastic_user" {
+  source = "../modules/elastic_user"
+  service = "diff_tool"
+  roles = ["catalogue_read"]
 }
 
-resource "aws_secretsmanager_secret" "service-requests-password" {
-  name = "elasticsearch/catalogue_api/requests/password"
-
-  description = "Config secret populated by Terraform"
-  tags        = local.default_tags
-
-  provider = aws.identity
-}
-
-# Diff tool service credentials
-
-resource "aws_secretsmanager_secret" "service-diff_tool-username" {
-  name = "elasticsearch/catalogue_api/diff_tool/username"
-
-  description = "Config secret populated by Terraform"
-  tags        = local.default_tags
-}
-
-resource "aws_secretsmanager_secret" "service-diff_tool-password" {
-  name = "elasticsearch/catalogue_api/diff_tool/password"
-
-  description = "Config secret populated by Terraform"
-  tags        = local.default_tags
-}
-
-# Replication manager service credentials
-
-resource "aws_secretsmanager_secret" "service-replication_manager-username" {
-  name = "elasticsearch/catalogue_api/replication_manager/username"
-
-  description = "Config secret populated by Terraform"
-  tags        = local.default_tags
-}
-
-resource "aws_secretsmanager_secret" "service-replication_manager-password" {
-  name = "elasticsearch/catalogue_api/replication_manager/password"
-
-  description = "Config secret populated by Terraform"
-  tags        = local.default_tags
+module "internal_model_tool_elastic_user" {
+  source = "../modules/elastic_user"
+  service = "internal_model_tool"
+  roles = ["catalogue_read"]
 }
 
 
-# Internal model tool credentials
 
-resource "aws_secretsmanager_secret" "service-internal_model_tool-username" {
-  name = "elasticsearch/catalogue_api/internal_model_tool/username"
 
-  description = "Config secret populated by Terraform"
-  tags        = local.default_tags
-}
 
-resource "aws_secretsmanager_secret" "service-internal_model_tool-password" {
-  name = "elasticsearch/catalogue_api/internal_model_tool/password"
-
-  description = "Config secret populated by Terraform"
-  tags        = local.default_tags
-}

--- a/terraform/shared/scripts/create_elastic_users_catalogue.py
+++ b/terraform/shared/scripts/create_elastic_users_catalogue.py
@@ -5,7 +5,6 @@ an Elastic Cloud cluster immediately after it's been created.
 """
 
 import functools
-import secrets
 
 import boto3
 import click
@@ -35,6 +34,7 @@ ROLES = {
         "cluster": ["manage_ccr"]
     }
 }
+
 
 @functools.lru_cache()
 def get_aws_client(resource, *, role_arn):

--- a/terraform/shared/scripts/create_elastic_users_catalogue.py
+++ b/terraform/shared/scripts/create_elastic_users_catalogue.py
@@ -36,15 +36,6 @@ ROLES = {
     }
 }
 
-SERVICES = {
-    "search": ["catalogue_read"],
-    "items": ["catalogue_read"],
-    "diff_tool": ["catalogue_read"],
-    "replication_manager": ["catalogue_read", "catalogue_manage_ccr"],
-    "internal_model_tool": ["catalogue_read"],
-}
-
-
 @functools.lru_cache()
 def get_aws_client(resource, *, role_arn):
     """
@@ -111,34 +102,6 @@ if __name__ == '__main__':
         es.security.put_role(
             role_name,
             body=index_privileges,
-        )
-
-    # Create usernames
-    newly_created_usernames = []
-    for service_name, roles in SERVICES.items():
-        service_password = secrets.token_hex()
-        es.security.put_user(
-            username=service_name,
-            body={
-                "password": service_password,
-                "roles": roles
-            }
-        )
-
-        newly_created_usernames.append((service_name, service_password))
-
-    # Store secrets
-    for service_name, service_password in newly_created_usernames:
-        store_secret(
-            secret_id=f"{secret_prefix}/{service_name}/username",
-            secret_value=service_name,
-            role_arn=role_arn
-        )
-
-        store_secret(
-            secret_id=f"{secret_prefix}/{service_name}/password",
-            secret_value=service_password,
-            role_arn=role_arn
         )
 
     # Configure cluster settings


### PR DESCRIPTION
Makes #208 the way to create elastic users

Next PRs
- [ ] Migrate ID users
- [ ] Tidy up scripts
- [ ] Tidy up docs