### PR TITLE
Provide filled out item data when returning hold list

### DIFF
--- a/common/stacks/src/main/scala/weco/api/stacks/models/StacksUserHolds.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/StacksUserHolds.scala
@@ -1,7 +1,6 @@
 package weco.api.stacks.models
 
 import weco.catalogue.internal_model.identifiers.{
-  CanonicalId,
   IdState,
   SourceIdentifier
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/models/StacksUserHolds.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/StacksUserHolds.scala
@@ -1,8 +1,9 @@
 package weco.api.stacks.models
 
-import weco.catalogue.internal_model.identifiers.{CanonicalId, SourceIdentifier}
-
+import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState, SourceIdentifier}
 import java.time.Instant
+
+import weco.catalogue.internal_model.work.Item
 
 case class StacksUserHolds(
   userId: String,
@@ -13,7 +14,7 @@ case class StacksHold(
   sourceIdentifier: SourceIdentifier,
   pickup: StacksPickup,
   status: StacksHoldStatus,
-  canonicalId: Option[CanonicalId] = None
+  item: Option[Item[IdState.Identified]] = None
 )
 
 case class StacksHoldStatus(

--- a/common/stacks/src/main/scala/weco/api/stacks/models/display/DisplayResultsList.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/display/DisplayResultsList.scala
@@ -28,7 +28,8 @@ case class DisplayResultsList(
 object DisplayRequest {
   def apply(hold: StacksHold): DisplayRequest = {
     DisplayRequest(
-      // TODO: Remove this .get!
+      // TODO: This .get should always be Some here
+      // TODO: but we should refactor to remove it!
       item = DisplayItem(
         item = hold.item.get,
         includesIdentifiers = true

--- a/common/stacks/src/main/scala/weco/api/stacks/models/display/DisplayResultsList.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/display/DisplayResultsList.scala
@@ -28,9 +28,10 @@ case class DisplayResultsList(
 object DisplayRequest {
   def apply(hold: StacksHold): DisplayRequest = {
     DisplayRequest(
-      item = new DisplayItem(
-        id = hold.canonicalId.map { _.underlying },
-        identifiers = Some(List(DisplayIdentifier(hold.sourceIdentifier)))
+      // TODO: Remove this .get!
+      item = DisplayItem(
+        item = hold.item.get,
+        includesIdentifiers = true
       ),
       pickupDate = hold.pickup.pickUpBy,
       pickupLocation = DisplayLocationDescription(

--- a/common/stacks/src/main/scala/weco/api/stacks/models/display/DisplayResultsList.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/display/DisplayResultsList.scala
@@ -7,7 +7,7 @@ import weco.api.stacks.models.{
   StacksPickupLocation,
   StacksUserHolds
 }
-import weco.catalogue.display_model.models.{DisplayIdentifier, DisplayItem}
+import weco.catalogue.display_model.models.DisplayItem
 
 object DisplayResultsList {
   def apply(

--- a/requests/src/main/scala/weco/api/requests/responses/LookupPendingRequests.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/LookupPendingRequests.scala
@@ -1,10 +1,14 @@
 package weco.api.requests.responses
 
 import akka.http.scaladsl.server.Route
+import weco.api.search.elasticsearch.ElasticsearchError
 import weco.api.stacks.models.display.DisplayResultsList
 import weco.api.search.rest.CustomDirectives
+import weco.api.stacks.models.StacksHold
 import weco.api.stacks.services.{ItemLookup, SierraService}
-import weco.sierra.models.identifiers.SierraPatronNumber
+import weco.catalogue.internal_model.identifiers.IdState
+import weco.catalogue.internal_model.work.Item
+import weco.catalogue.source_model.sierra.identifiers.SierraPatronNumber
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -21,16 +25,16 @@ trait LookupPendingRequests extends CustomDirectives {
         userHolds <- sierraService.getStacksUserHolds(patronNumber)
 
         holdsWithCatalogueIds <- Future.sequence(
-          userHolds.right.get.holds.map { hold =>
+          userHolds.right.get.holds.map { hold: StacksHold =>
             itemLookup
               .bySourceIdentifier(hold.sourceIdentifier)
               .map {
-                case Left(elasticError) =>
-                  warn(s"Unable to look up $hold in Elasticsearch")
+                case Left(elasticError: ElasticsearchError) =>
+                  warn(s"Unable to look up $hold in Elasticsearch: ${elasticError}")
                   hold
 
-                case Right(item) =>
-                  hold.copy(canonicalId = Some(item.id.canonicalId))
+                case Right(item: Item[IdState.Identified]) =>
+                  hold.copy(item = Some(item))
               }
           }
         )

--- a/requests/src/main/scala/weco/api/requests/responses/LookupPendingRequests.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/LookupPendingRequests.scala
@@ -8,7 +8,7 @@ import weco.api.stacks.models.StacksHold
 import weco.api.stacks.services.{ItemLookup, SierraService}
 import weco.catalogue.internal_model.identifiers.IdState
 import weco.catalogue.internal_model.work.Item
-import weco.catalogue.source_model.sierra.identifiers.SierraPatronNumber
+import weco.sierra.models.identifiers.SierraPatronNumber
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}

--- a/requests/src/test/scala/weco/api/requests/RequestsApiFeatureTest.scala
+++ b/requests/src/test/scala/weco/api/requests/RequestsApiFeatureTest.scala
@@ -67,12 +67,16 @@ class RequestsApiFeatureTest
         )
       )
 
+      val titleString = randomAlphanumeric(length = 20)
+
       val item = createIdentifiedItemWith(
         sourceIdentifier = SourceIdentifier(
           identifierType = SierraSystemNumber,
           value = itemNumber.withCheckDigit,
           ontologyType = "Item"
-        )
+        ),
+        locations = List.empty,
+        title = Some(titleString)
       )
 
       val lookup = new MemoryItemLookup(items = Seq(item))
@@ -98,6 +102,7 @@ class RequestsApiFeatureTest
              |            "type" : "Identifier"
              |          }
              |        ],
+             |        "title" : "${titleString}",
              |        "locations" : [
              |        ],
              |        "type" : "Item"


### PR DESCRIPTION
Put the full item into a holds list for the front-end.

Closes https://github.com/wellcomecollection/catalogue-api/issues/223