### PR TITLE
Auto-trim snapshots when running snapshot analysis

### DIFF
--- a/snapshots/analysis/find_works_with_unmapped_item_access.py
+++ b/snapshots/analysis/find_works_with_unmapped_item_access.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+"""
+As part of the work to put item access status on wc.org/works, there
+are some items whose status we couldn't map correctly.
+
+In these cases, we display a placeholder message:
+
+    This item cannot be requested online. Please contact
+    library@wellcomecollection.org for more information.
+
+This script analyses a catalogue API snapshot and produces a spreadsheet
+showing all the items with unmapped data.
+
+This can be passed to the Collections team for sorting out in Sierra proper.
+
+"""
+
+import csv
+import functools
+import json
+
+import boto3
+import tqdm
+
+from utils import get_works
+
+
+PLACEHOLDER_MESSAGE = (
+    "This item cannot be requested online. "
+    'Please contact <a href="mailto:library@wellcomecollection.org">library@wellcomecollection.org</a> for more information.'
+)
+
+SIERRA_ADAPTER_TABLE_NAME = "vhs-sierra-sierra-adapter-20200604"
+
+
+def find_sierra_id(identifiers):
+    return next(
+        id for id in identifiers if id["identifierType"]["id"] == "sierra-system-number"
+    )["value"]
+
+
+def find_unmapped_item_ids():
+    """
+    Generates (bib id, item id) pairs for items that haven't been mapped
+    correctly.
+    """
+    for work in get_works(fields=["items"]):
+        for item in work["items"]:
+            locations = item["locations"]
+
+            if not any(loc["type"] == "PhysicalLocation" for loc in locations):
+                continue
+
+            for loc in locations:
+                if any(
+                    ac.get("note") == PLACEHOLDER_MESSAGE
+                    for ac in loc["accessConditions"]
+                ):
+                    bib_id = find_sierra_id(work["identifiers"])
+                    item_id = find_sierra_id(item["identifiers"])
+
+                    yield (bib_id, item_id)
+
+
+@functools.lru_cache()
+def get_sierra_data(bib_id):
+    dynamo = boto3.resource("dynamodb").meta.client
+    s3 = boto3.client("s3")
+
+    dynamo_item = dynamo.get_item(
+        TableName=SIERRA_ADAPTER_TABLE_NAME, Key={"id": bib_id[1:8]}
+    )
+    s3_location = dynamo_item["Item"]["payload"]
+
+    s3_object = json.load(
+        s3.get_object(Bucket=s3_location["bucket"], Key=s3_location["key"])["Body"]
+    )
+
+    return s3_object
+
+
+def get_bib_506(sierra_data):
+    """
+    bib field 506 is used for the access status on item records.
+    """
+    bib_data = json.loads(sierra_data["maybeBibRecord"]["data"])
+
+    varfields_506 = [vf for vf in bib_data["varFields"] if vf.get("marcTag") == "506"]
+
+    if not varfields_506:
+        return ""
+
+    lines = []
+
+    for vf in varfields_506:
+        subfields = " ".join(f"{sf['tag']}|{sf['content']}" for sf in vf["subfields"])
+
+        if subfields.startswith("a|"):
+            lines.append(subfields[len("a|") :])
+        else:
+            lines.append(subfields)
+
+    return "\n".join(lines)
+
+
+def get_fixed_field(item_data, *, code):
+    try:
+        ff = item_data["fixedFields"][code]
+    except KeyError:
+        return ""
+    else:
+        try:
+            return f"{ff['value']} ({ff['display']})"
+        except KeyError:
+            return ff["value"]
+
+
+if __name__ == "__main__":
+    from pprint import pprint
+
+    with open("unmapped_item_data.csv", "w") as outfile:
+        writer = csv.DictWriter(
+            outfile,
+            fieldnames=[
+                "bib number",
+                "item number",
+                "hold count",
+                "bib 506 (restrictions on access note)",
+                "item 79 (LOCATION)",
+                "item 88 (STATUS)",
+                "item 108 (OPACMSG)",
+                "item 61 (I TYPE)",
+                "item 97 (IMESSAGE)",
+                "item 87 (LOANRULE)",
+            ],
+        )
+        writer.writeheader()
+
+        for bib_id, item_id in tqdm.tqdm(find_unmapped_item_ids()):
+            sierra_data = get_sierra_data(bib_id)
+
+            bib_506 = get_bib_506(sierra_data)
+
+            item_data = json.loads(sierra_data["itemRecords"][item_id[1:8]]["data"])
+
+            hold_count = item_data.get("holdCount", "")
+
+            writer.writerow(
+                {
+                    "bib number": bib_id,
+                    "item number": item_id,
+                    "hold count": hold_count,
+                    "bib 506 (restrictions on access note)": bib_506,
+                    "item 61 (I TYPE)": get_fixed_field(item_data, code="61"),
+                    "item 79 (LOCATION)": get_fixed_field(item_data, code="79"),
+                    "item 87 (LOANRULE)": get_fixed_field(item_data, code="87"),
+                    "item 88 (STATUS)": get_fixed_field(item_data, code="88"),
+                    "item 97 (IMESSAGE)": get_fixed_field(item_data, code="97"),
+                    "item 108 (OPACMSG)": get_fixed_field(item_data, code="108"),
+                }
+            )

--- a/snapshots/analysis/find_works_with_unmapped_item_access.py
+++ b/snapshots/analysis/find_works_with_unmapped_item_access.py
@@ -116,8 +116,6 @@ def get_fixed_field(item_data, *, code):
 
 
 if __name__ == "__main__":
-    from pprint import pprint
-
     with open("unmapped_item_data.csv", "w") as outfile:
         writer = csv.DictWriter(
             outfile,

--- a/snapshots/analysis/trim_snapshot.py
+++ b/snapshots/analysis/trim_snapshot.py
@@ -22,8 +22,6 @@ import sys
 import click
 import tqdm
 
-from utils import get_latest_snapshot_filename, get_works
-
 
 def trim_snapshot(*, snapshot_filename, fields):
     fields = set(fields)
@@ -36,8 +34,10 @@ def trim_snapshot(*, snapshot_filename, fields):
     if not os.path.exists(new_name):
         tmp_path = new_name + "." + str(uuid.uuid4()) + ".tmp"
 
+        from utils import get_works
+
         with gzip.open(tmp_path, "wb") as outfile:
-            for work in tqdm.tqdm(get_works(snapshot_filename)):
+            for work in tqdm.tqdm(get_works(snapshot_filename=snapshot_filename)):
                 trimmed_work = {
                     key: value for key, value in work.items() if key in fields
                 }
@@ -55,26 +55,3 @@ def trim_snapshot(*, snapshot_filename, fields):
 
 def _size(filename):
     return os.stat(filename).st_size
-
-
-@click.command()
-@click.option("--filename", help="Snapshot to trim")
-@click.argument("fields", nargs=-1)
-def main(filename, fields):
-    if filename is None:
-        filename = get_latest_snapshot_filename()
-
-    original_snapshot = filename
-    trimmed_snapshot = trim_snapshot(snapshot_filename=filename, fields=fields)
-
-    saving = abs(1 - _size(trimmed_snapshot) / _size(original_snapshot))
-
-    print(
-        "Trimming complete; the trimmed snapshot is %.1f%% smaller" % (saving * 100),
-        file=sys.stderr,
-    )
-    print(trimmed_snapshot)
-
-
-if __name__ == "__main__":
-    main()

--- a/snapshots/analysis/trim_snapshot.py
+++ b/snapshots/analysis/trim_snapshot.py
@@ -17,9 +17,7 @@ import gzip
 import json
 import os
 import uuid
-import sys
 
-import click
 import tqdm
 
 

--- a/snapshots/analysis/utils.py
+++ b/snapshots/analysis/utils.py
@@ -48,7 +48,7 @@ def get_works(*, snapshot_filename=None, fields=None):
     if snapshot_filename is None:
         snapshot_filename = get_latest_snapshot_filename()
 
-    if interested_fields is not None:
+    if fields is not None:
         snapshot_filename = trim_snapshot(
             snapshot_filename=snapshot_filename, fields=fields
         )

--- a/snapshots/analysis/utils.py
+++ b/snapshots/analysis/utils.py
@@ -3,6 +3,8 @@ import json
 import os
 import re
 
+from trim_snapshot import trim_snapshot
+
 
 def get_latest_snapshot_filename():
     try:
@@ -17,7 +19,7 @@ def get_latest_snapshot_filename():
         raise RuntimeError("No local snapshots found!")
 
 
-def get_works(snapshot_filename=None):
+def get_works(*, snapshot_filename=None, fields=None):
     """
     Generates a list of works from a given snapshot.
     If no snapshot is given, it uses the latest snapshot.
@@ -31,9 +33,25 @@ def get_works(snapshot_filename=None):
             pprint(work)
             break
 
+    If you're only interested in a subset of fields, pass the ``fields``
+    argument, e.g.:
+
+        for work in get_works(fields=["items"]):
+            pprint(work)
+            break
+
+    This will generate Works that only have that subset of fields populated.
+    Limiting your analysis to a subset of fields can make this much faster
+    after the initial run.
+
     """
     if snapshot_filename is None:
         snapshot_filename = get_latest_snapshot_filename()
+
+    if interested_fields is not None:
+        snapshot_filename = trim_snapshot(
+            snapshot_filename=snapshot_filename, fields=fields
+        )
 
     for line in gzip.open(snapshot_filename):
         yield json.loads(line)


### PR DESCRIPTION
This is a small change to improve the ergonomics of the snapshot analysis scripts:

```python
from utils import get_works

for work in get_works(fields=["items"]):
    print(work)
```

If you're doing any sort of snapshot analysis you want to do more than once, this is substantially faster.

Plus a new script for finding items whose access status we weren't able to map to anything sensible.

## What's going on here?

When you download a catalogue API snapshot, you get all the fields on a work – about 1.4GB of compressed JSON. Simply paging through that takes quite a while, particularly the large relations on some works. You spend a lot of time parsing JSON that you don't need.

So when you pass the `fields` argument, the function starts by "trimming" the snapshot – creating a new snapshot which just contains the fields you're interested in. This takes a bit longer on the initial run, but you can page through the new snapshot much faster.

e.g. I've just trimmed a snapshot to include just items; it goes from 1.4GB to 72MB.