### PR TITLE
Use the new per-account SQS DLQ alarm topic

### DIFF
--- a/snapshots/terraform/locals.tf
+++ b/snapshots/terraform/locals.tf
@@ -13,8 +13,10 @@ locals {
 
   shared_logging_secrets = data.terraform_remote_state.shared.outputs.shared_secrets_logging
 
+  monitoring_outputs = data.terraform_remote_state.monitoring.outputs
+
   lambda_error_alarm_arn = data.terraform_remote_state.shared.outputs.lambda_error_alarm_arn
-  dlq_alarm_arn          = data.terraform_remote_state.shared.outputs.dlq_alarm_arn
+  dlq_alarm_arn          = local.monitoring_outputs["catalogue_dlq_alarm_topic_arn"]
 
   vpc_id  = data.terraform_remote_state.catalogue_account.outputs.catalogue_vpc_id
   subnets = data.terraform_remote_state.catalogue_account.outputs.catalogue_vpc_private_subnets

--- a/snapshots/terraform/terraform.tf
+++ b/snapshots/terraform/terraform.tf
@@ -21,6 +21,18 @@ data "terraform_remote_state" "catalogue_account" {
   }
 }
 
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/monitoring.tfstate"
+    region = "eu-west-1"
+  }
+}
+
 data "terraform_remote_state" "shared" {
   backend = "s3"
 


### PR DESCRIPTION
This uses the new SQS DLQ alerting infra from wellcomecollection/platform-infrastructure#221

If/when another message ends up on a DLQ from the snapshot generator, we should now get alerts about it in Slack.

For https://github.com/wellcomecollection/platform/issues/5245