### PR TITLE
Add alerts on 5xx errors from API Gateway

### DIFF
--- a/terraform/catalogue_api/locals.tf
+++ b/terraform/catalogue_api/locals.tf
@@ -24,4 +24,6 @@ locals {
     sierra_api_key    = "stacks/prod/sierra_api_key"
     sierra_api_secret = "stacks/prod/sierra_api_secret"
   }
+
+  api_gateway_alerts_topic_arn = data.terraform_remote_state.monitoring.outputs.catalogue_api_gateway_alerts_topic_arn
 }

--- a/terraform/catalogue_api/main.tf
+++ b/terraform/catalogue_api/main.tf
@@ -24,6 +24,8 @@ module "catalogue_api_prod" {
   es_search_secret_config = local.es_search_secret_config
   sierra_secret_config    = local.sierra_secret_config
 
+  api_gateway_alerts_topic_arn = local.api_gateway_alerts_topic_arn
+
   providers = {
     aws.dns        = aws.dns
     aws.experience = aws.experience
@@ -55,6 +57,8 @@ module "catalogue_api_stage" {
   es_items_secret_config  = local.es_items_secret_config
   es_search_secret_config = local.es_search_secret_config
   sierra_secret_config    = local.sierra_secret_config
+
+  api_gateway_alerts_topic_arn = local.api_gateway_alerts_topic_arn
 
   providers = {
     aws.dns        = aws.dns

--- a/terraform/catalogue_api/terraform.tf
+++ b/terraform/catalogue_api/terraform.tf
@@ -44,3 +44,14 @@ data "terraform_remote_state" "catalogue_api_shared" {
     region = "eu-west-1"
   }
 }
+
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    bucket   = "wellcomecollection-platform-infra"
+    key      = "terraform/monitoring.tfstate"
+    region   = "eu-west-1"
+  }
+}

--- a/terraform/modules/stack/alarm.tf
+++ b/terraform/modules/stack/alarm.tf
@@ -1,0 +1,17 @@
+resource "aws_cloudwatch_metric_alarm" "alarm_5xx" {
+  alarm_name          = "catalogue-api-${var.environment_name}-5xx-alarm"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "5XXError"
+  namespace           = "AWS/ApiGateway"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "0"
+
+  dimensions = {
+    ApiName = aws_api_gateway_rest_api.catalogue.name
+  }
+
+  alarm_actions = [var.api_gateway_alerts_topic_arn]
+}
+

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -69,3 +69,7 @@ variable "sierra_secret_config" {
     sierra_api_secret = string
   })
 }
+
+variable "api_gateway_alerts_topic_arn" {
+  type = string
+}


### PR DESCRIPTION
This means we'll get alerts of API Gateway errors for the Catalogue API, which we lost when we moved it into a separate account.

Requires wellcomecollection/platform-infrastructure#232, part of wellcomecollection/platform#5245