### PR TITLE
Adds findByMultiSearch to Elasticsearchservice

### DIFF
--- a/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticsearchServiceTest.scala
+++ b/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticsearchServiceTest.scala
@@ -1,12 +1,6 @@
 package weco.api.search.elasticsearch
 
-import com.sksamuel.elastic4s.ElasticDsl.{
-  boolQuery,
-  bulk,
-  indexInto,
-  search,
-  termQuery
-}
+import com.sksamuel.elastic4s.ElasticDsl.{boolQuery, bulk, indexInto, search, termQuery}
 import com.sksamuel.elastic4s.analysis.Analysis
 import com.sksamuel.elastic4s.fields.{KeywordField, TextField}
 import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
@@ -20,10 +14,11 @@ import io.circe.generic.auto._
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.circe.hitReaderWithCirce
-import com.sksamuel.elastic4s.requests.searches.MultiSearchRequest
+import com.sksamuel.elastic4s.requests.searches.{MultiSearchRequest, SearchRequest}
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.time.{Seconds, Span}
+import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.fixtures.{RandomGenerators, TestWith}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -36,14 +31,14 @@ class ElasticsearchServiceTest
     with RandomGenerators
     with ElasticsearchFixtures {
 
-  case class ExampleThing(id: String, name: String)
+  case class ExampleThing(id: CanonicalId, name: String)
 
-  def randomThing = ExampleThing(
-    id = randomAlphanumeric(10).toLowerCase,
+  def randomThing: ExampleThing = ExampleThing(
+    id = CanonicalId(randomAlphanumeric(8).toLowerCase),
     name = randomAlphanumeric(10).toLowerCase
   )
 
-  def searchRequestForThingByName(index: Index, name: String) = {
+  def searchRequestForThingByName(index: Index, name: String): SearchRequest = {
     search(index)
       .query(
         boolQuery.filter(
@@ -68,7 +63,7 @@ class ElasticsearchServiceTest
           thingsToIndex.map { thing =>
             val jsonDoc = toJson(thing).get
             indexInto(index.name)
-              .id(thing.id)
+              .id(thing.id.underlying)
               .doc(jsonDoc)
           }
         ).refreshImmediately
@@ -82,6 +77,165 @@ class ElasticsearchServiceTest
     }
   }
 
+  describe("findById") {
+    it("finds documents by ID") {
+      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+
+      withExampleIndex(thingsToIndex) { index =>
+        val elasticsearchService = new ElasticsearchService(elasticClient)
+        val thingToQueryFor = thingsToIndex.head
+
+        val findByIdFuture = elasticsearchService.findById[ExampleThing](thingToQueryFor.id)(index)
+
+        whenReady(findByIdFuture) { findByIdEither =>
+          val foundById = findByIdEither.right.value
+          foundById shouldBe thingToQueryFor
+        }
+      }
+    }
+
+    it("should return an appropriate error if no ID matches") {
+      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+
+      withExampleIndex(thingsToIndex) { index =>
+        val elasticsearchService = new ElasticsearchService(elasticClient)
+        val badId = CanonicalId(randomAlphanumeric(8))
+
+        val findByIdFuture = elasticsearchService.findById[ExampleThing](badId)(index)
+
+        whenReady(findByIdFuture) { findByIdEither =>
+          val failedFindByID = findByIdEither.left.value
+
+          failedFindByID shouldBe a[DocumentNotFoundError[_]]
+        }
+      }
+    }
+
+    it("should return an appropriate error if the index does not exist") {
+      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+
+      withExampleIndex(thingsToIndex) { _ =>
+        val elasticsearchService = new ElasticsearchService(elasticClient)
+        val thingToQueryFor = thingsToIndex.head
+        val badIndex = Index(randomAlphanumeric(10))
+
+        val findByIdFuture = elasticsearchService.findById[ExampleThing](thingToQueryFor.id)(badIndex)
+
+        whenReady(findByIdFuture) { findByIdEither =>
+          val failedFindByID = findByIdEither.left.value
+
+          failedFindByID shouldBe a[IndexNotFoundError]
+        }
+      }
+    }
+  }
+
+  describe("findBySearch") {
+    it("finds documents by search") {
+      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+
+      withExampleIndex(thingsToIndex) { index =>
+        val elasticsearchService = new ElasticsearchService(elasticClient)
+        val thingToQueryFor = thingsToIndex.head
+
+        val searchRequest = searchRequestForThingByName(
+          index = index,
+          name = thingToQueryFor.name
+        )
+
+        val findBySearchFuture = elasticsearchService.findBySearch[ExampleThing](searchRequest)
+
+        whenReady(findBySearchFuture) { findBySearchEither =>
+          val foundBySearch = findBySearchEither.right.value
+          foundBySearch should have size(1)
+          foundBySearch.head shouldBe thingToQueryFor
+        }
+      }
+    }
+
+    it("returns an appropriate error when the specified index does not exist") {
+      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+
+      withExampleIndex(thingsToIndex) { _ =>
+        val elasticsearchService = new ElasticsearchService(elasticClient)
+        val thingToQueryFor = thingsToIndex.head
+
+        val badIndex = Index(randomAlphanumeric(10))
+
+        val searchRequest = searchRequestForThingByName(
+          index = badIndex,
+          name = thingToQueryFor.name
+        )
+
+        val findBySearchFuture = elasticsearchService.findBySearch[ExampleThing](searchRequest)
+
+        whenReady(findBySearchFuture) { findBySearchEither =>
+          val failedFindBySearch = findBySearchEither.left.value
+          failedFindBySearch shouldBe a[IndexNotFoundError]
+        }
+      }
+    }
+  }
+
+  describe("findByMultiSearch") {
+    it("finds documents by performing a MultiSearch") {
+      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+
+      withExampleIndex(thingsToIndex) { index =>
+        val elasticsearchService = new ElasticsearchService(elasticClient)
+        val thingsToQueryFor = thingsToIndex.slice(0,3)
+
+        val searchRequests = thingsToQueryFor.map { thing =>
+          searchRequestForThingByName(
+            index = index,
+            name = thing.name
+          )
+        }
+
+        val multiSearchRequest = MultiSearchRequest(searchRequests)
+
+        val findByMultiSearchFuture = elasticsearchService.findByMultiSearch[ExampleThing](multiSearchRequest)
+
+        whenReady(findByMultiSearchFuture) { case (errors, foundBySearch) =>
+          errors should have length(0)
+          foundBySearch.toSet shouldBe thingsToQueryFor.toSet
+        }
+      }
+    }
+
+    it("returns an appropriate error when the specified index does not exist") {
+      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+
+      withExampleIndex(thingsToIndex) { index =>
+        val elasticsearchService = new ElasticsearchService(elasticClient)
+        val thingsToQueryFor = thingsToIndex.slice(0,3)
+
+        val badIndex = Index(randomAlphanumeric(10))
+
+        val searchRequests = thingsToQueryFor.map { thing =>
+          searchRequestForThingByName(
+            index = index,
+            name = thing.name
+          )
+        } :+ searchRequestForThingByName(
+          index = badIndex,
+          name = randomAlphanumeric(10)
+        )
+
+        val multiSearchRequest = MultiSearchRequest(searchRequests)
+
+        val findByMultiSearchFuture = elasticsearchService.findByMultiSearch[ExampleThing](multiSearchRequest)
+
+        whenReady(findByMultiSearchFuture) { case (errors, foundBySearch) =>
+          foundBySearch.toSet shouldBe thingsToQueryFor.toSet
+
+          errors should have size(1)
+          errors.head shouldBe a[IndexNotFoundError]
+        }
+      }
+    }
+  }
+
   describe("executeMultiSearchRequest") {
     it("performs a multiSearchRequest") {
 
@@ -89,8 +243,9 @@ class ElasticsearchServiceTest
 
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
+        val thingsToQueryFor = thingsToIndex.slice(0,3)
 
-        val searchRequests = thingsToIndex.map { thing =>
+        val searchRequests = thingsToQueryFor.map { thing =>
           searchRequestForThingByName(
             index = index,
             name = thing.name
@@ -101,13 +256,44 @@ class ElasticsearchServiceTest
         val multiSearchResponseFuture =
           elasticsearchService.executeMultiSearchRequest(multiSearchRequest)
 
-        whenReady(multiSearchResponseFuture) { multiSearchResponseEither =>
-          val multiSearchResponse = multiSearchResponseEither.right.value
-          val queryResults =
-            multiSearchResponse.items.map(_.response.right.value)
-          val returnedThings = queryResults.flatMap(_.to[ExampleThing])
+        whenReady(multiSearchResponseFuture) { case (errors, searchResponses) =>
+          errors should have size(0)
 
-          returnedThings.toSet shouldBe thingsToIndex.toSet
+          val returnedThings = searchResponses.flatMap(_.to[ExampleThing])
+          returnedThings.toSet shouldBe thingsToQueryFor.toSet
+        }
+      }
+    }
+
+    it("returns an appropriate error when the specified index does not exist") {
+      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+
+      withExampleIndex(thingsToIndex) { index =>
+        val elasticsearchService = new ElasticsearchService(elasticClient)
+        val thingsToQueryFor = thingsToIndex.slice(0,3)
+        val badIndex = Index(randomAlphanumeric(10))
+
+        val searchRequests = thingsToQueryFor.map { thing =>
+          searchRequestForThingByName(
+            index = index,
+            name = thing.name
+          )
+        } :+ searchRequestForThingByName(
+          index = badIndex,
+          name = randomAlphanumeric(10)
+        )
+
+        val multiSearchRequest = MultiSearchRequest(searchRequests)
+        val multiSearchResponseFuture =
+          elasticsearchService.executeMultiSearchRequest(multiSearchRequest)
+
+        whenReady(multiSearchResponseFuture) { case (errors, searchResponses) =>
+          val returnedThings = searchResponses.flatMap(_.to[ExampleThing])
+
+          returnedThings.toSet shouldBe thingsToQueryFor.toSet
+
+          errors should have size(1)
+          errors.head shouldBe a[IndexNotFoundError]
         }
       }
     }
@@ -135,6 +321,30 @@ class ElasticsearchServiceTest
           val queryResult = searchResponse.to[ExampleThing].head
 
           queryResult shouldBe thingToQueryFor
+        }
+      }
+    }
+
+    it("returns an appropriate error when the specified index does not exist") {
+      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+
+      withExampleIndex(thingsToIndex) { _ =>
+        val elasticsearchService = new ElasticsearchService(elasticClient)
+        val thingToQueryFor = thingsToIndex.head
+        val badIndex = Index(randomAlphanumeric(10))
+
+        val searchRequest = searchRequestForThingByName(
+          index = badIndex,
+          name = thingToQueryFor.name
+        )
+
+        val searchResponseFuture =
+          elasticsearchService.executeSearchRequest(searchRequest)
+
+        whenReady(searchResponseFuture) { searchResponseEither =>
+          val failedSearchResponse = searchResponseEither.left.value
+
+          failedSearchResponse shouldBe a[IndexNotFoundError]
         }
       }
     }

--- a/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticsearchServiceTest.scala
+++ b/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticsearchServiceTest.scala
@@ -1,6 +1,12 @@
 package weco.api.search.elasticsearch
 
-import com.sksamuel.elastic4s.ElasticDsl.{boolQuery, bulk, indexInto, search, termQuery}
+import com.sksamuel.elastic4s.ElasticDsl.{
+  boolQuery,
+  bulk,
+  indexInto,
+  search,
+  termQuery
+}
 import com.sksamuel.elastic4s.analysis.Analysis
 import com.sksamuel.elastic4s.fields.{KeywordField, TextField}
 import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
@@ -14,7 +20,10 @@ import io.circe.generic.auto._
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.circe.hitReaderWithCirce
-import com.sksamuel.elastic4s.requests.searches.{MultiSearchRequest, SearchRequest}
+import com.sksamuel.elastic4s.requests.searches.{
+  MultiSearchRequest,
+  SearchRequest
+}
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.time.{Seconds, Span}
@@ -202,7 +211,9 @@ class ElasticsearchServiceTest
       }
     }
 
-    it("returns an appropriate error for only those queries where the specified index does not exist") {
+    it(
+      "returns an appropriate error for only those queries where the specified index does not exist"
+    ) {
       val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
 
       withExampleIndex(thingsToIndex) { index =>
@@ -267,7 +278,9 @@ class ElasticsearchServiceTest
       }
     }
 
-    it("returns an appropriate error for only those queries where the specified index does not exist") {
+    it(
+      "returns an appropriate error for only those queries where the specified index does not exist"
+    ) {
       val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
 
       withExampleIndex(thingsToIndex) { index =>

--- a/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticsearchServiceTest.scala
+++ b/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticsearchServiceTest.scala
@@ -99,9 +99,8 @@ class ElasticsearchServiceTest
         val findByIdFuture =
           elasticsearchService.findById[ExampleThing](thingToQueryFor.id)(index)
 
-        whenReady(findByIdFuture) { findByIdEither =>
-          val foundById = findByIdEither.right.value
-          foundById shouldBe thingToQueryFor
+        whenReady(findByIdFuture) {
+          _.right.value shouldBe thingToQueryFor
         }
       }
     }
@@ -116,10 +115,8 @@ class ElasticsearchServiceTest
         val findByIdFuture =
           elasticsearchService.findById[ExampleThing](badId)(index)
 
-        whenReady(findByIdFuture) { findByIdEither =>
-          val failedFindByID = findByIdEither.left.value
-
-          failedFindByID shouldBe a[DocumentNotFoundError[_]]
+        whenReady(findByIdFuture) {
+          _.left.value shouldBe a[DocumentNotFoundError[_]]
         }
       }
     }
@@ -132,10 +129,8 @@ class ElasticsearchServiceTest
         createCanonicalId
       )(badIndex)
 
-      whenReady(findByIdFuture) { findByIdEither =>
-        val failedFindByID = findByIdEither.left.value
-
-        failedFindByID shouldBe a[IndexNotFoundError]
+      whenReady(findByIdFuture) {
+        _.left.value shouldBe a[IndexNotFoundError]
       }
     }
   }
@@ -156,10 +151,8 @@ class ElasticsearchServiceTest
         val findBySearchFuture =
           elasticsearchService.findBySearch[ExampleThing](searchRequest)
 
-        whenReady(findBySearchFuture) { findBySearchEither =>
-          val foundBySearch = findBySearchEither.right.value
-          foundBySearch should have size (1)
-          foundBySearch.head shouldBe thingToQueryFor
+        whenReady(findBySearchFuture) {
+          _.right.value shouldBe Seq(thingToQueryFor)
         }
       }
     }
@@ -176,9 +169,8 @@ class ElasticsearchServiceTest
       val findBySearchFuture =
         elasticsearchService.findBySearch[ExampleThing](searchRequest)
 
-      whenReady(findBySearchFuture) { findBySearchEither =>
-        val failedFindBySearch = findBySearchEither.left.value
-        failedFindBySearch shouldBe a[IndexNotFoundError]
+      whenReady(findBySearchFuture) {
+        _.left.value shouldBe a[IndexNotFoundError]
       }
     }
   }
@@ -211,9 +203,7 @@ class ElasticsearchServiceTest
       }
     }
 
-    it(
-      "returns an appropriate error for only those queries where the specified index does not exist"
-    ) {
+    it("returns errors for queries that fail") {
       val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
 
       withExampleIndex(thingsToIndex) { index =>
@@ -278,9 +268,7 @@ class ElasticsearchServiceTest
       }
     }
 
-    it(
-      "returns an appropriate error for only those queries where the specified index does not exist"
-    ) {
+    it("returns errors for queries that fail") {
       val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
 
       withExampleIndex(thingsToIndex) { index =>
@@ -332,11 +320,8 @@ class ElasticsearchServiceTest
         val searchResponseFuture =
           elasticsearchService.executeSearchRequest(searchRequest)
 
-        whenReady(searchResponseFuture) { searchResponseEither =>
-          val searchResponse = searchResponseEither.right.value
-          val queryResult = searchResponse.to[ExampleThing].head
-
-          queryResult shouldBe thingToQueryFor
+        whenReady(searchResponseFuture) {
+          _.right.value.to[ExampleThing] shouldBe Seq(thingToQueryFor)
         }
       }
     }
@@ -353,10 +338,8 @@ class ElasticsearchServiceTest
       val searchResponseFuture =
         elasticsearchService.executeSearchRequest(searchRequest)
 
-      whenReady(searchResponseFuture) { searchResponseEither =>
-        val failedSearchResponse = searchResponseEither.left.value
-
-        failedSearchResponse shouldBe a[IndexNotFoundError]
+      whenReady(searchResponseFuture) {
+        _.left.value shouldBe a[IndexNotFoundError]
       }
     }
   }

--- a/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticsearchServiceTest.scala
+++ b/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticsearchServiceTest.scala
@@ -1,6 +1,12 @@
 package weco.api.search.elasticsearch
 
-import com.sksamuel.elastic4s.ElasticDsl.{boolQuery, bulk, indexInto, search, termQuery}
+import com.sksamuel.elastic4s.ElasticDsl.{
+  boolQuery,
+  bulk,
+  indexInto,
+  search,
+  termQuery
+}
 import com.sksamuel.elastic4s.analysis.Analysis
 import com.sksamuel.elastic4s.fields.{KeywordField, TextField}
 import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
@@ -14,7 +20,10 @@ import io.circe.generic.auto._
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.circe.hitReaderWithCirce
-import com.sksamuel.elastic4s.requests.searches.{MultiSearchRequest, SearchRequest}
+import com.sksamuel.elastic4s.requests.searches.{
+  MultiSearchRequest,
+  SearchRequest
+}
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.time.{Seconds, Span}
@@ -85,7 +94,8 @@ class ElasticsearchServiceTest
         val elasticsearchService = new ElasticsearchService(elasticClient)
         val thingToQueryFor = thingsToIndex.head
 
-        val findByIdFuture = elasticsearchService.findById[ExampleThing](thingToQueryFor.id)(index)
+        val findByIdFuture =
+          elasticsearchService.findById[ExampleThing](thingToQueryFor.id)(index)
 
         whenReady(findByIdFuture) { findByIdEither =>
           val foundById = findByIdEither.right.value
@@ -101,7 +111,8 @@ class ElasticsearchServiceTest
         val elasticsearchService = new ElasticsearchService(elasticClient)
         val badId = CanonicalId(randomAlphanumeric(8))
 
-        val findByIdFuture = elasticsearchService.findById[ExampleThing](badId)(index)
+        val findByIdFuture =
+          elasticsearchService.findById[ExampleThing](badId)(index)
 
         whenReady(findByIdFuture) { findByIdEither =>
           val failedFindByID = findByIdEither.left.value
@@ -119,7 +130,9 @@ class ElasticsearchServiceTest
         val thingToQueryFor = thingsToIndex.head
         val badIndex = Index(randomAlphanumeric(10))
 
-        val findByIdFuture = elasticsearchService.findById[ExampleThing](thingToQueryFor.id)(badIndex)
+        val findByIdFuture = elasticsearchService.findById[ExampleThing](
+          thingToQueryFor.id
+        )(badIndex)
 
         whenReady(findByIdFuture) { findByIdEither =>
           val failedFindByID = findByIdEither.left.value
@@ -143,11 +156,12 @@ class ElasticsearchServiceTest
           name = thingToQueryFor.name
         )
 
-        val findBySearchFuture = elasticsearchService.findBySearch[ExampleThing](searchRequest)
+        val findBySearchFuture =
+          elasticsearchService.findBySearch[ExampleThing](searchRequest)
 
         whenReady(findBySearchFuture) { findBySearchEither =>
           val foundBySearch = findBySearchEither.right.value
-          foundBySearch should have size(1)
+          foundBySearch should have size (1)
           foundBySearch.head shouldBe thingToQueryFor
         }
       }
@@ -167,7 +181,8 @@ class ElasticsearchServiceTest
           name = thingToQueryFor.name
         )
 
-        val findBySearchFuture = elasticsearchService.findBySearch[ExampleThing](searchRequest)
+        val findBySearchFuture =
+          elasticsearchService.findBySearch[ExampleThing](searchRequest)
 
         whenReady(findBySearchFuture) { findBySearchEither =>
           val failedFindBySearch = findBySearchEither.left.value
@@ -183,7 +198,7 @@ class ElasticsearchServiceTest
 
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
-        val thingsToQueryFor = thingsToIndex.slice(0,3)
+        val thingsToQueryFor = thingsToIndex.slice(0, 3)
 
         val searchRequests = thingsToQueryFor.map { thing =>
           searchRequestForThingByName(
@@ -194,11 +209,13 @@ class ElasticsearchServiceTest
 
         val multiSearchRequest = MultiSearchRequest(searchRequests)
 
-        val findByMultiSearchFuture = elasticsearchService.findByMultiSearch[ExampleThing](multiSearchRequest)
+        val findByMultiSearchFuture = elasticsearchService
+          .findByMultiSearch[ExampleThing](multiSearchRequest)
 
-        whenReady(findByMultiSearchFuture) { case (errors, foundBySearch) =>
-          errors should have length(0)
-          foundBySearch.toSet shouldBe thingsToQueryFor.toSet
+        whenReady(findByMultiSearchFuture) {
+          case (errors, foundBySearch) =>
+            errors should have length (0)
+            foundBySearch.toSet shouldBe thingsToQueryFor.toSet
         }
       }
     }
@@ -208,7 +225,7 @@ class ElasticsearchServiceTest
 
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
-        val thingsToQueryFor = thingsToIndex.slice(0,3)
+        val thingsToQueryFor = thingsToIndex.slice(0, 3)
 
         val badIndex = Index(randomAlphanumeric(10))
 
@@ -224,13 +241,15 @@ class ElasticsearchServiceTest
 
         val multiSearchRequest = MultiSearchRequest(searchRequests)
 
-        val findByMultiSearchFuture = elasticsearchService.findByMultiSearch[ExampleThing](multiSearchRequest)
+        val findByMultiSearchFuture = elasticsearchService
+          .findByMultiSearch[ExampleThing](multiSearchRequest)
 
-        whenReady(findByMultiSearchFuture) { case (errors, foundBySearch) =>
-          foundBySearch.toSet shouldBe thingsToQueryFor.toSet
+        whenReady(findByMultiSearchFuture) {
+          case (errors, foundBySearch) =>
+            foundBySearch.toSet shouldBe thingsToQueryFor.toSet
 
-          errors should have size(1)
-          errors.head shouldBe a[IndexNotFoundError]
+            errors should have size (1)
+            errors.head shouldBe a[IndexNotFoundError]
         }
       }
     }
@@ -243,7 +262,7 @@ class ElasticsearchServiceTest
 
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
-        val thingsToQueryFor = thingsToIndex.slice(0,3)
+        val thingsToQueryFor = thingsToIndex.slice(0, 3)
 
         val searchRequests = thingsToQueryFor.map { thing =>
           searchRequestForThingByName(
@@ -256,11 +275,12 @@ class ElasticsearchServiceTest
         val multiSearchResponseFuture =
           elasticsearchService.executeMultiSearchRequest(multiSearchRequest)
 
-        whenReady(multiSearchResponseFuture) { case (errors, searchResponses) =>
-          errors should have size(0)
+        whenReady(multiSearchResponseFuture) {
+          case (errors, searchResponses) =>
+            errors should have size (0)
 
-          val returnedThings = searchResponses.flatMap(_.to[ExampleThing])
-          returnedThings.toSet shouldBe thingsToQueryFor.toSet
+            val returnedThings = searchResponses.flatMap(_.to[ExampleThing])
+            returnedThings.toSet shouldBe thingsToQueryFor.toSet
         }
       }
     }
@@ -270,7 +290,7 @@ class ElasticsearchServiceTest
 
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
-        val thingsToQueryFor = thingsToIndex.slice(0,3)
+        val thingsToQueryFor = thingsToIndex.slice(0, 3)
         val badIndex = Index(randomAlphanumeric(10))
 
         val searchRequests = thingsToQueryFor.map { thing =>
@@ -287,13 +307,14 @@ class ElasticsearchServiceTest
         val multiSearchResponseFuture =
           elasticsearchService.executeMultiSearchRequest(multiSearchRequest)
 
-        whenReady(multiSearchResponseFuture) { case (errors, searchResponses) =>
-          val returnedThings = searchResponses.flatMap(_.to[ExampleThing])
+        whenReady(multiSearchResponseFuture) {
+          case (errors, searchResponses) =>
+            val returnedThings = searchResponses.flatMap(_.to[ExampleThing])
 
-          returnedThings.toSet shouldBe thingsToQueryFor.toSet
+            returnedThings.toSet shouldBe thingsToQueryFor.toSet
 
-          errors should have size(1)
-          errors.head shouldBe a[IndexNotFoundError]
+            errors should have size (1)
+            errors.head shouldBe a[IndexNotFoundError]
         }
       }
     }

--- a/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
@@ -1,11 +1,14 @@
 package weco.api.stacks.services
 
 import weco.api.search.elasticsearch.ElasticsearchError
-import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.{
+  CanonicalId,
+  IdState,
+  SourceIdentifier
+}
 import weco.catalogue.internal_model.work.Item
 
 import scala.concurrent.Future
-
 
 trait ItemLookup {
   def byCanonicalId(
@@ -16,5 +19,3 @@ trait ItemLookup {
     sourceIdentifier: SourceIdentifier
   ): Future[Either[ElasticsearchError, Item[IdState.Identified]]]
 }
-
-

--- a/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
@@ -1,14 +1,11 @@
 package weco.api.stacks.services
 
 import weco.api.search.elasticsearch.ElasticsearchError
-import weco.catalogue.internal_model.identifiers.{
-  CanonicalId,
-  IdState,
-  SourceIdentifier
-}
+import weco.catalogue.internal_model.identifiers.{CanonicalId, IdState, SourceIdentifier}
 import weco.catalogue.internal_model.work.Item
 
 import scala.concurrent.Future
+
 
 trait ItemLookup {
   def byCanonicalId(
@@ -19,3 +16,5 @@ trait ItemLookup {
     sourceIdentifier: SourceIdentifier
   ): Future[Either[ElasticsearchError, Item[IdState.Identified]]]
 }
+
+


### PR DESCRIPTION
Part of https://github.com/wellcomecollection/catalogue-api/issues/231

In order to eventually update [`ItemLookup`](https://github.com/wellcomecollection/catalogue-api/blob/main/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala#L13) to query on multiple `SourceIdentifier` in a performant way this change adds a `findByMultiSearch` function to `ElasticsearchService`.

This change also add more tests `ElasticsearchService`. It is used in some fundamental operations and is quite under-tested.