### PR TITLE
Use the new Lambda error alarm ARN for the catalogue account

### DIFF
--- a/snapshots/terraform/locals.tf
+++ b/snapshots/terraform/locals.tf
@@ -15,7 +15,7 @@ locals {
 
   monitoring_outputs = data.terraform_remote_state.monitoring.outputs
 
-  lambda_error_alarm_arn = data.terraform_remote_state.shared.outputs.lambda_error_alarm_arn
+  lambda_error_alarm_arn = local.monitoring_outputs["catalogue_lambda_error_alerts_topic_arn"]
   dlq_alarm_arn          = local.monitoring_outputs["catalogue_dlq_alarm_topic_arn"]
 
   vpc_id  = data.terraform_remote_state.catalogue_account.outputs.catalogue_vpc_id


### PR DESCRIPTION
Builds on wellcomecollection/platform-infrastructure#233, for wellcomecollection/platform#5245