### PR TITLE
Better handle the case where a user supplies an overly-large date

### DIFF
--- a/search/src/main/scala/weco/api/search/rest/QueryParams.scala
+++ b/search/src/main/scala/weco/api/search/rest/QueryParams.scala
@@ -51,6 +51,9 @@ trait QueryParamsUtils extends Directives {
         //       "reason": "failed to parse date field [+11860-01-01] with format [strict_date_optional_time||epoch_millis]",
         //       "type": "illegal_argument_exception"
         //
+        // This would cause a 500 Internal Server Error to be thrown, when what we should
+        // be throwing is a 400 Bad Request.
+        //
         // We could catch this when we get the response from Elasticsearch, but then it's
         // harder to map back to the user-supplied parameter where the value came from.
         // Since 9999 is the max date we use in the pipeline (as a synonym for "never"),

--- a/search/src/test/scala/weco/api/search/works/WorksErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksErrorsTest.scala
@@ -241,7 +241,8 @@ class WorksErrorsTest extends ApiWorksTestBase {
     //
     it("if the date is too large") {
       assertIsBadRequest(
-        path = s"$rootPath/works?_queryType=undefined&production.dates.from=%2B011860-01-01",
+        path =
+          s"$rootPath/works?_queryType=undefined&production.dates.from=%2B011860-01-01",
         description = "production.dates.from: year must be less than 9999"
       )
     }


### PR DESCRIPTION
It now gets mapped to a 400 Bad Request instead of a 500 Internal Server Error. The explanation is in the code comments. A bit of a faff to reproduce, but hey, first bug detected and fixed from the new Slack reporting!

Closes https://github.com/wellcomecollection/platform/issues/5269