### PR TITLE
Use findByMultiSearch in ItemLookup & Requests API

### DIFF
--- a/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala
+++ b/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala
@@ -105,6 +105,7 @@ class ElasticsearchService(elasticClient: ElasticClient)(
       withActiveTrace(elasticClient.execute(request))
         .map(_.toEither)
         .map {
+          case Left(err) => throw err.asException
           case Right(multiResponse) =>
             val foldInitial = (
               0L,
@@ -146,8 +147,6 @@ class ElasticsearchService(elasticClient: ElasticClient)(
             transaction.setLabel("elasticTookTotal", finalTotalTimeTaken)
 
             finalResults
-
-          case Left(err) => throw err.asException
         }
     }
 

--- a/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticsearchServiceTest.scala
+++ b/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticsearchServiceTest.scala
@@ -100,7 +100,7 @@ class ElasticsearchServiceTest
 
   describe("findById") {
     it("finds documents by ID") {
-      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+      val thingsToIndex = collectionOf(min = 5, max = 10) { randomThing } toList
 
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
@@ -116,7 +116,7 @@ class ElasticsearchServiceTest
     }
 
     it("fails if deserialising to a different type than stored") {
-      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+      val thingsToIndex = collectionOf(min = 5, max = 10) { randomThing } toList
 
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
@@ -134,7 +134,7 @@ class ElasticsearchServiceTest
     }
 
     it("should return an appropriate error if no ID matches") {
-      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+      val thingsToIndex = collectionOf(min = 5, max = 10) { randomThing } toList
 
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
@@ -178,7 +178,7 @@ class ElasticsearchServiceTest
 
   describe("findBySearch") {
     it("finds documents by search") {
-      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+      val thingsToIndex = collectionOf(min = 5, max = 10) { randomThing } toList
 
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
@@ -199,7 +199,7 @@ class ElasticsearchServiceTest
     }
 
     it("fails if deserialising to a different type than stored") {
-      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+      val thingsToIndex = collectionOf(min = 5, max = 10) { randomThing } toList
 
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
@@ -257,7 +257,7 @@ class ElasticsearchServiceTest
 
   describe("findByMultiSearch") {
     it("finds documents by performing a MultiSearch") {
-      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+      val thingsToIndex = collectionOf(min = 5, max = 10) { randomThing } toList
 
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
@@ -287,7 +287,7 @@ class ElasticsearchServiceTest
     }
 
     it("fails if deserialising to a different type than stored") {
-      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+      val thingsToIndex = collectionOf(min = 5, max = 10) { randomThing } toList
 
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
@@ -312,7 +312,7 @@ class ElasticsearchServiceTest
     }
 
     it("returns errors for queries that fail") {
-      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+      val thingsToIndex = collectionOf(min = 5, max = 10) { randomThing } toList
 
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
@@ -368,7 +368,7 @@ class ElasticsearchServiceTest
 
   describe("executeMultiSearchRequest") {
     it("performs a multiSearchRequest") {
-      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+      val thingsToIndex = collectionOf(min = 5, max = 10) { randomThing } toList
 
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
@@ -398,7 +398,7 @@ class ElasticsearchServiceTest
     }
 
     it("returns errors for queries that fail") {
-      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+      val thingsToIndex = collectionOf(min = 5, max = 10) { randomThing } toList
 
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
@@ -452,7 +452,7 @@ class ElasticsearchServiceTest
   describe("executeSearchRequest") {
     it("performs a searchRequest") {
 
-      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+      val thingsToIndex = collectionOf(min = 5, max = 10) { randomThing } toList
 
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)

--- a/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticsearchServiceTest.scala
+++ b/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticsearchServiceTest.scala
@@ -317,8 +317,7 @@ class ElasticsearchServiceTest
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
         val thingsToQueryFor = thingsToIndex.slice(0, 3)
-
-        val badIndex = Index(randomAlphanumeric(10))
+        val badIndex = createIndex
 
         val searchRequests = searchRequestForThingByName(
           index = badIndex,
@@ -404,7 +403,7 @@ class ElasticsearchServiceTest
       withExampleIndex(thingsToIndex) { index =>
         val elasticsearchService = new ElasticsearchService(elasticClient)
         val thingsToQueryFor = thingsToIndex.slice(0, 3)
-        val badIndex = Index(randomAlphanumeric(10))
+        val badIndex = createIndex
 
         val searchRequests = searchRequestForThingByName(
           index = badIndex,

--- a/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticsearchServiceTest.scala
+++ b/common/search/src/test/scala/weco/api/search/elasticsearch/ElasticsearchServiceTest.scala
@@ -1,29 +1,20 @@
 package weco.api.search.elasticsearch
 
-import com.sksamuel.elastic4s.ElasticDsl.{
-  boolQuery,
-  bulk,
-  indexInto,
-  search,
-  termQuery
-}
+import com.sksamuel.elastic4s.ElasticDsl.{boolQuery, bulk, indexInto, search, termQuery}
 import com.sksamuel.elastic4s.analysis.Analysis
 import com.sksamuel.elastic4s.fields.{KeywordField, TextField}
 import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.catalogue.internal_model.index.IndexFixtures
-import weco.elasticsearch.IndexConfig
+import weco.elasticsearch.{ElasticClientBuilder, IndexConfig}
 import weco.elasticsearch.test.fixtures.ElasticsearchFixtures
 import weco.json.JsonUtil.toJson
 import io.circe.generic.auto._
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.Index
+import com.sksamuel.elastic4s.{ElasticClient, Index}
 import com.sksamuel.elastic4s.circe.hitReaderWithCirce
-import com.sksamuel.elastic4s.requests.searches.{
-  MultiSearchRequest,
-  SearchRequest
-}
+import com.sksamuel.elastic4s.requests.searches.{MultiSearchRequest, SearchRequest}
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.time.{Seconds, Span}
@@ -43,6 +34,16 @@ class ElasticsearchServiceTest
     with ElasticsearchFixtures {
 
   case class ExampleThing(id: CanonicalId, name: String)
+  case class DifferentExampleThing(id: CanonicalId, age: Int)
+
+  val badElasticClient: ElasticClient = ElasticClientBuilder.create(
+    hostname = "noresolve",
+    port = 9200,
+    protocol = "http",
+    username = "elastic",
+    password = "changeme",
+    compressionEnabled = false,
+  )
 
   def randomThing: ExampleThing = ExampleThing(
     id = createCanonicalId,
@@ -105,6 +106,22 @@ class ElasticsearchServiceTest
       }
     }
 
+    it("fails if deserialising to a different type than stored") {
+      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+
+      withExampleIndex(thingsToIndex) { index =>
+        val elasticsearchService = new ElasticsearchService(elasticClient)
+        val thingToQueryFor = thingsToIndex.head
+
+        val findByIdFuture =
+          elasticsearchService.findById[DifferentExampleThing](thingToQueryFor.id)(index)
+
+        whenReady(findByIdFuture.failed) {
+          _.getMessage should include("Unable to parse JSON")
+        }
+      }
+    }
+
     it("should return an appropriate error if no ID matches") {
       val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
 
@@ -133,6 +150,19 @@ class ElasticsearchServiceTest
         _.left.value shouldBe a[IndexNotFoundError]
       }
     }
+
+    it("fails if it cannot connect to Elasticsearch") {
+      val elasticsearchService = new ElasticsearchService(badElasticClient)
+      val badIndex = createIndex
+
+      val findByIdFuture = elasticsearchService.findById[ExampleThing](
+        createCanonicalId
+      )(badIndex)
+
+      whenReady(findByIdFuture.failed) {
+        _.getMessage should include("UnknownHostException")
+      }
+    }
   }
 
   describe("findBySearch") {
@@ -157,6 +187,27 @@ class ElasticsearchServiceTest
       }
     }
 
+    it("fails if deserialising to a different type than stored") {
+      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+
+      withExampleIndex(thingsToIndex) { index =>
+        val elasticsearchService = new ElasticsearchService(elasticClient)
+        val thingToQueryFor = thingsToIndex.head
+
+        val searchRequest = searchRequestForThingByName(
+          index = index,
+          name = thingToQueryFor.name
+        )
+
+        val findBySearchFuture =
+          elasticsearchService.findBySearch[DifferentExampleThing](searchRequest)
+
+        whenReady(findBySearchFuture.failed) {
+          _.getMessage should include("Unable to parse JSON")
+        }
+      }
+    }
+
     it("returns an appropriate error when the specified index does not exist") {
       val elasticsearchService = new ElasticsearchService(elasticClient)
       val badIndex = createIndex
@@ -171,6 +222,22 @@ class ElasticsearchServiceTest
 
       whenReady(findBySearchFuture) {
         _.left.value shouldBe a[IndexNotFoundError]
+      }
+    }
+
+    it("fails if it cannot connect to Elasticsearch") {
+      val elasticsearchService = new ElasticsearchService(badElasticClient)
+
+      val searchRequest = searchRequestForThingByName(
+        index = createIndex,
+        name = randomAlphanumeric(10)
+      )
+
+      val findByMultiSearchFuture = elasticsearchService
+        .findBySearch[ExampleThing](searchRequest)
+
+      whenReady(findByMultiSearchFuture.failed) {
+        _.getMessage should include("UnknownHostException")
       }
     }
   }
@@ -195,10 +262,38 @@ class ElasticsearchServiceTest
         val findByMultiSearchFuture = elasticsearchService
           .findByMultiSearch[ExampleThing](multiSearchRequest)
 
-        whenReady(findByMultiSearchFuture) {
-          case (errors, foundBySearch) =>
-            errors should have length (0)
-            foundBySearch.toSet shouldBe thingsToQueryFor.toSet
+        whenReady(findByMultiSearchFuture) { results =>
+          val (errorEither, foundBySearchEither) = results.partition(_.isLeft)
+          val errors = errorEither.map(_.left.value)
+          val foundBySearch = foundBySearchEither.map(_.right.value)
+
+          errors should have length (0)
+          foundBySearch shouldBe thingsToQueryFor.map(Seq(_))
+        }
+      }
+    }
+
+    it("fails if deserialising to a different type than stored") {
+      val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
+
+      withExampleIndex(thingsToIndex) { index =>
+        val elasticsearchService = new ElasticsearchService(elasticClient)
+        val thingsToQueryFor = thingsToIndex.slice(0, 3)
+
+        val searchRequests = thingsToQueryFor.map { thing =>
+          searchRequestForThingByName(
+            index = index,
+            name = thing.name
+          )
+        }
+
+        val multiSearchRequest = MultiSearchRequest(searchRequests)
+
+        val findByMultiSearchFuture = elasticsearchService
+          .findByMultiSearch[DifferentExampleThing](multiSearchRequest)
+
+        whenReady(findByMultiSearchFuture.failed) {
+          _.getMessage should include("Unable to parse JSON")
         }
       }
     }
@@ -212,35 +307,51 @@ class ElasticsearchServiceTest
 
         val badIndex = Index(randomAlphanumeric(10))
 
-        val searchRequests = thingsToQueryFor.map { thing =>
+        val searchRequests = searchRequestForThingByName(
+          index = badIndex,
+          name = randomAlphanumeric(10)
+        ) +: thingsToQueryFor.map { thing =>
           searchRequestForThingByName(
             index = index,
             name = thing.name
           )
-        } :+ searchRequestForThingByName(
-          index = badIndex,
-          name = randomAlphanumeric(10)
-        )
+        }
 
         val multiSearchRequest = MultiSearchRequest(searchRequests)
 
         val findByMultiSearchFuture = elasticsearchService
           .findByMultiSearch[ExampleThing](multiSearchRequest)
 
-        whenReady(findByMultiSearchFuture) {
-          case (errors, foundBySearch) =>
-            foundBySearch.toSet shouldBe thingsToQueryFor.toSet
+        whenReady(findByMultiSearchFuture) {  results =>
+          val expectedFailure :: expectedSuccess = results
 
-            errors should have size (1)
-            errors.head shouldBe a[IndexNotFoundError]
+          expectedFailure.left.value shouldBe a[IndexNotFoundError]
+          expectedSuccess.map(_.right.value) shouldBe thingsToQueryFor.map(Seq(_))
         }
+      }
+    }
+
+    it("fails if it cannot connect to Elasticsearch") {
+      val elasticsearchService = new ElasticsearchService(badElasticClient)
+
+      val searchRequests = Seq(searchRequestForThingByName(
+        index = createIndex,
+        name = randomAlphanumeric(10)
+      ))
+
+      val multiSearchRequest = MultiSearchRequest(searchRequests)
+
+      val findByMultiSearchFuture = elasticsearchService
+        .findByMultiSearch[ExampleThing](multiSearchRequest)
+
+      whenReady(findByMultiSearchFuture.failed) {
+        _.getMessage should include("UnknownHostException")
       }
     }
   }
 
   describe("executeMultiSearchRequest") {
     it("performs a multiSearchRequest") {
-
       val thingsToIndex = 0.to(randomInt(5, 10)).map(_ => randomThing).toList
 
       withExampleIndex(thingsToIndex) { index =>
@@ -258,12 +369,13 @@ class ElasticsearchServiceTest
         val multiSearchResponseFuture =
           elasticsearchService.executeMultiSearchRequest(multiSearchRequest)
 
-        whenReady(multiSearchResponseFuture) {
-          case (errors, searchResponses) =>
-            errors shouldBe empty
+        whenReady(multiSearchResponseFuture) { results =>
+          val (errorEither, searchResponsesEither) = results.partition(_.isLeft)
+          val errors = errorEither.map(_.left.value)
+          val searchResponses = searchResponsesEither.flatMap(_.right.value.to[ExampleThing])
 
-            val returnedThings = searchResponses.flatMap(_.to[ExampleThing])
-            returnedThings.toSet shouldBe thingsToQueryFor.toSet
+          errors should have length (0)
+          searchResponses shouldBe thingsToQueryFor
         }
       }
     }
@@ -276,29 +388,44 @@ class ElasticsearchServiceTest
         val thingsToQueryFor = thingsToIndex.slice(0, 3)
         val badIndex = Index(randomAlphanumeric(10))
 
-        val searchRequests = thingsToQueryFor.map { thing =>
+        val searchRequests = searchRequestForThingByName(
+          index = badIndex,
+          name = randomAlphanumeric(10)
+        ) +: thingsToQueryFor.map { thing =>
           searchRequestForThingByName(
             index = index,
             name = thing.name
           )
-        } :+ searchRequestForThingByName(
-          index = badIndex,
-          name = randomAlphanumeric(10)
-        )
+        }
 
         val multiSearchRequest = MultiSearchRequest(searchRequests)
         val multiSearchResponseFuture =
           elasticsearchService.executeMultiSearchRequest(multiSearchRequest)
 
-        whenReady(multiSearchResponseFuture) {
-          case (errors, searchResponses) =>
-            val returnedThings = searchResponses.flatMap(_.to[ExampleThing])
+        whenReady(multiSearchResponseFuture) { results =>
+          val expectedFailure :: expectedSuccess = results
 
-            returnedThings.toSet shouldBe thingsToQueryFor.toSet
-
-            errors should have size (1)
-            errors.head shouldBe a[IndexNotFoundError]
+          expectedFailure.left.value shouldBe a[IndexNotFoundError]
+          expectedSuccess.flatMap(_.right.value.to[ExampleThing]) shouldBe thingsToQueryFor
         }
+      }
+    }
+
+    it("fails if it cannot connect to Elasticsearch") {
+      val elasticsearchService = new ElasticsearchService(badElasticClient)
+
+      val searchRequests = Seq(searchRequestForThingByName(
+        index = createIndex,
+        name = randomAlphanumeric(10)
+      ))
+
+      val multiSearchRequest = MultiSearchRequest(searchRequests)
+
+      val findByMultiSearchFuture = elasticsearchService
+        .executeMultiSearchRequest(multiSearchRequest)
+
+      whenReady(findByMultiSearchFuture.failed) {
+        _.getMessage should include("UnknownHostException")
       }
     }
   }
@@ -340,6 +467,22 @@ class ElasticsearchServiceTest
 
       whenReady(searchResponseFuture) {
         _.left.value shouldBe a[IndexNotFoundError]
+      }
+    }
+
+    it("fails if it cannot connect to Elasticsearch") {
+      val elasticsearchService = new ElasticsearchService(badElasticClient)
+
+      val searchRequest = searchRequestForThingByName(
+        index = createIndex,
+        name = randomAlphanumeric(10)
+      )
+
+      val findByMultiSearchFuture = elasticsearchService
+        .executeSearchRequest(searchRequest)
+
+      whenReady(findByMultiSearchFuture.failed) {
+        _.getMessage should include("UnknownHostException")
       }
     }
   }

--- a/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
@@ -20,6 +20,6 @@ trait ItemLookup {
   ): Future[Either[ElasticsearchError, Item[IdState.Identified]]]
 
   def bySourceIdentifiers(
-                           sourceIdentifiers: Seq[SourceIdentifier]
-                        ): Future[(Seq[ElasticsearchError], Seq[Item[IdState.Identified]])]
+     sourceIdentifiers: Seq[SourceIdentifier]
+  ): Future[Seq[Either[ElasticsearchError, Item[IdState.Identified]]]]
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
@@ -16,10 +16,6 @@ trait ItemLookup {
   ): Future[Either[ElasticsearchError, Item[IdState.Identified]]]
 
   def bySourceIdentifier(
-    sourceIdentifier: SourceIdentifier
-  ): Future[Either[ElasticsearchError, Item[IdState.Identified]]]
-
-  def bySourceIdentifiers(
     sourceIdentifiers: Seq[SourceIdentifier]
   ): Future[Seq[Either[ElasticsearchError, Item[IdState.Identified]]]]
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/ItemLookup.scala
@@ -18,4 +18,8 @@ trait ItemLookup {
   def bySourceIdentifier(
     sourceIdentifier: SourceIdentifier
   ): Future[Either[ElasticsearchError, Item[IdState.Identified]]]
+
+  def bySourceIdentifiers(
+                           sourceIdentifiers: Seq[SourceIdentifier]
+                        ): Future[(Seq[ElasticsearchError], Seq[Item[IdState.Identified]])]
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/services/elastic/ElasticItemLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/elastic/ElasticItemLookup.scala
@@ -102,25 +102,27 @@ class ElasticItemLookup(
 
   override def bySourceIdentifiers(
     sourceIdentifiers: Seq[SourceIdentifier]
-  ): Future[(Seq[ElasticsearchError], Seq[Item[IdState.Identified]])] = {
-    val multiSearchRequest = MultiSearchRequest(sourceIdentifiers.map(searchRequestOnIndex))
-
-    elasticsearchService.findByMultiSearch[Work[Indexed]](multiSearchRequest).map {
-      case (errors, Seq.empty) => (errors, Seq.empty)
-      case (Seq.empty, works) =>
-        val foundItems = sourceIdentifiers.flatMap(
-          srcId => matchItemsOnWorksBySourceIdentifier(works, srcId)
-        )
-        val foundSrcIds = foundItems.map(_.id.sourceIdentifier)
-        val notFoundSrcIds = sourceIdentifiers.filterNot(foundSrcIds.contains(_))
-        val notFoundErrors = notFoundSrcIds.map(DocumentNotFoundError(_))
-
-        (notFoundErrors, foundItems)
-
-      // What about where there are some errors?
-      case (foo, bar) => ???
-    }
-  }
+  ): Future[(Seq[ElasticsearchError], Seq[Item[IdState.Identified]])] = ???
+//  {
+//    val multiSearchRequest = MultiSearchRequest(sourceIdentifiers.map(searchRequestOnIndex))
+//
+//    elasticsearchService.findByMultiSearch[Work[Indexed]](multiSearchRequest).map {
+//      case (errors, Seq.empty) => (errors, Seq.empty)
+//      case (Seq.empty, works) =>
+//        val foundItems = sourceIdentifiers.flatMap(
+//          srcId => matchItemsOnWorksBySourceIdentifier(works, srcId)
+//        )
+//
+//        val foundSrcIds = foundItems.map(_.id.sourceIdentifier)
+//        val notFoundSrcIds = sourceIdentifiers.filterNot(foundSrcIds.contains(_))
+//        val notFoundErrors = notFoundSrcIds.map(DocumentNotFoundError(_))
+//
+//        (notFoundErrors, foundItems)
+//
+//      // What about where there are some errors?
+//      case (foo, bar) => ???
+//    }
+//  }
 }
 
 object ElasticItemLookup {

--- a/common/stacks/src/main/scala/weco/api/stacks/services/elastic/ElasticItemLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/elastic/ElasticItemLookup.scala
@@ -95,11 +95,12 @@ class ElasticItemLookup(
               .flatMap { _.data.items }
               .collect {
                 case item @ Item(id @ IdState.Identified(_, _, _), _, _, _)
-                  if id.sourceIdentifier == srcId =>
+                    if id.sourceIdentifier == srcId =>
                   // This .asInstanceOf[] is a no-op to help the compiler see what
                   // we can see by reading the code.
                   item.asInstanceOf[Item[IdState.Identified]]
-              }.toList match {
+              }
+              .toList match {
               // TODO: We can return multiple items from multiple works
               // TODO: Apply better logic when picking an item!
               case List(item) => Right(item)

--- a/common/stacks/src/main/scala/weco/api/stacks/services/memory/MemoryItemLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/memory/MemoryItemLookup.scala
@@ -24,16 +24,6 @@ class MemoryItemLookup(items: Seq[Item[IdState.Identified]])
     )
 
   override def bySourceIdentifier(
-    sourceIdentifier: SourceIdentifier
-  ): Future[Either[ElasticsearchError, Item[IdState.Identified]]] =
-    Future.successful(
-      items.find(_.id.sourceIdentifier == sourceIdentifier) match {
-        case Some(it) => Right(it)
-        case None     => Left(DocumentNotFoundError(sourceIdentifier))
-      }
-    )
-
-  override def bySourceIdentifiers(
     sourceIdentifiers: Seq[SourceIdentifier]
   ): Future[Seq[Either[ElasticsearchError, Item[IdState.Identified]]]] =
     Future.successful {

--- a/common/stacks/src/main/scala/weco/api/stacks/services/memory/MemoryItemLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/memory/MemoryItemLookup.scala
@@ -32,4 +32,18 @@ class MemoryItemLookup(items: Seq[Item[IdState.Identified]])
         case None     => Left(DocumentNotFoundError(sourceIdentifier))
       }
     )
+
+  override def bySourceIdentifiers(
+                                    sourceIdentifiers: Seq[SourceIdentifier]
+  ): Future[(Seq[ElasticsearchError], Seq[Item[IdState.Identified]])] = Future.successful {
+    val foldInitial = (Seq.empty[ElasticsearchError], Seq.empty[Item[IdState.Identified]]])
+    sourceIdentifiers.foldLeft(foldInitial) { (acc, sourceIdentifier) =>
+      val (errors, successes) = acc
+
+      items.find(_.id.sourceIdentifier == sourceIdentifier) match {
+        case Some(item) => (errors, successes :+ item)
+        case None => (errors :+ DocumentNotFoundError(sourceIdentifier), successes)
+      }
+    }
+  }
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/services/memory/MemoryItemLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/memory/MemoryItemLookup.scala
@@ -34,18 +34,15 @@ class MemoryItemLookup(items: Seq[Item[IdState.Identified]])
     )
 
   override def bySourceIdentifiers(
-                                    sourceIdentifiers: Seq[SourceIdentifier]
-  ): Future[(Seq[ElasticsearchError], Seq[Item[IdState.Identified]])] = ???
+    sourceIdentifiers: Seq[SourceIdentifier]
+  ): Future[Seq[Either[ElasticsearchError, Item[IdState.Identified]]]] = Future.successful {
+      val foldInitial = Seq.empty[Either[ElasticsearchError,Item[IdState.Identified]]]
 
-//    Future.successful {
-//    val foldInitial = (Seq.empty[ElasticsearchError], Seq.empty[Item[IdState.Identified]]])
-//    sourceIdentifiers.foldLeft(foldInitial) { (acc, sourceIdentifier) =>
-//      val (errors, successes) = acc
-//
-//      items.find(_.id.sourceIdentifier == sourceIdentifier) match {
-//        case Some(item) => (errors, successes :+ item)
-//        case None => (errors :+ DocumentNotFoundError(sourceIdentifier), successes)
-//      }
-//    }
-//  }
+      sourceIdentifiers.foldLeft(foldInitial) { (acc, sourceIdentifier) =>
+        items.find(_.id.sourceIdentifier == sourceIdentifier) match {
+          case Some(item) => acc :+ Right(item)
+          case None => acc :+  Left(DocumentNotFoundError(sourceIdentifier))
+        }
+      }
+  }
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/services/memory/MemoryItemLookup.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/services/memory/MemoryItemLookup.scala
@@ -35,15 +35,17 @@ class MemoryItemLookup(items: Seq[Item[IdState.Identified]])
 
   override def bySourceIdentifiers(
                                     sourceIdentifiers: Seq[SourceIdentifier]
-  ): Future[(Seq[ElasticsearchError], Seq[Item[IdState.Identified]])] = Future.successful {
-    val foldInitial = (Seq.empty[ElasticsearchError], Seq.empty[Item[IdState.Identified]]])
-    sourceIdentifiers.foldLeft(foldInitial) { (acc, sourceIdentifier) =>
-      val (errors, successes) = acc
+  ): Future[(Seq[ElasticsearchError], Seq[Item[IdState.Identified]])] = ???
 
-      items.find(_.id.sourceIdentifier == sourceIdentifier) match {
-        case Some(item) => (errors, successes :+ item)
-        case None => (errors :+ DocumentNotFoundError(sourceIdentifier), successes)
-      }
-    }
-  }
+//    Future.successful {
+//    val foldInitial = (Seq.empty[ElasticsearchError], Seq.empty[Item[IdState.Identified]]])
+//    sourceIdentifiers.foldLeft(foldInitial) { (acc, sourceIdentifier) =>
+//      val (errors, successes) = acc
+//
+//      items.find(_.id.sourceIdentifier == sourceIdentifier) match {
+//        case Some(item) => (errors, successes :+ item)
+//        case None => (errors :+ DocumentNotFoundError(sourceIdentifier), successes)
+//      }
+//    }
+//  }
 }

--- a/common/stacks/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/stacks/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -97,10 +97,11 @@ object SierraItemAccess extends SierraQueryOps with Logging {
           Some(OpacMsg.OnlineRequest),
           Requestable,
           Some(LocationType.ClosedStores))
-          if bibStatus.isEmpty || bibStatus.contains(AccessStatus.Open) =>
+          if bibStatus.isEmpty || bibStatus.contains(AccessStatus.Open) || bibStatus
+            .contains(AccessStatus.OpenWithAdvisory) =>
         AccessCondition(
           method = AccessMethod.OnlineRequest,
-          status = AccessStatus.Open
+          status = bibStatus.getOrElse(AccessStatus.Open)
         )
 
       // Note: it is possible for individual items within a restricted bib to be available
@@ -321,7 +322,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       // It is possible for an item to have a non-zero hold count but still be available
       // for requesting, e.g. some of our long-lived test holds didn't get cleared properly.
       // If an item seems to be stuck on a non-zero hold count, ask somebody to check Sierra.
-      case (None, Some(holdCount), _, _, _, Some(LocationType.ClosedStores))
+      case (_, Some(holdCount), _, _, _, Some(LocationType.ClosedStores))
           if holdCount > 0 =>
         AccessCondition(
           method = AccessMethod.NotRequestable,
@@ -331,7 +332,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         )
 
       case (
-          None,
+          _,
           _,
           _,
           _,

--- a/common/stacks/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/stacks/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -21,27 +21,27 @@ import weco.sierra.models.data.SierraItemData
 import weco.sierra.models.identifiers.SierraBibNumber
 
 /** There are multiple sources of truth for item information in Sierra, and whether
- * a given item can be requested online.
- *
- * This object tries to create a single, consistent view of this data.
- * It returns three values:
- *
- *   - An access condition that can be added to a location on an Item.
- *     This would be set in the Catalogue API.
- *   - A note that can be used to distinguish between different items.
- *     This should be copied to the top-level item model.
- *   - An ItemStatus that returns a simpler "is this available right now".
- *     This would be returned from the items API with the most up-to-date
- *     data from Sierra.
- *
- */
+  * a given item can be requested online.
+  *
+  * This object tries to create a single, consistent view of this data.
+  * It returns three values:
+  *
+  *   - An access condition that can be added to a location on an Item.
+  *     This would be set in the Catalogue API.
+  *   - A note that can be used to distinguish between different items.
+  *     This should be copied to the top-level item model.
+  *   - An ItemStatus that returns a simpler "is this available right now".
+  *     This would be returned from the items API with the most up-to-date
+  *     data from Sierra.
+  *
+  */
 object SierraItemAccess extends SierraQueryOps with Logging {
   def apply(
-             bibId: SierraBibNumber,
-             bibStatus: Option[AccessStatus],
-             location: Option[PhysicalLocationType],
-             itemData: SierraItemData
-           ): (AccessCondition, Option[String]) = {
+    bibId: SierraBibNumber,
+    bibStatus: Option[AccessStatus],
+    location: Option[PhysicalLocationType],
+    itemData: SierraItemData
+  ): (AccessCondition, Option[String]) = {
     val accessCondition = createAccessCondition(
       bibId = bibId,
       bibStatus = bibStatus,
@@ -63,10 +63,10 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       //
       // Otherwise, we copy the item note onto the access condition.
       case (ac, Some(displayNote))
-        if ac.note.isDefined && displayNote.isAccessNote =>
+          if ac.note.isDefined && displayNote.isAccessNote =>
         (ac, None)
       case (ac, Some(displayNote))
-        if ac.note.isEmpty && displayNote.isAccessNote =>
+          if ac.note.isEmpty && displayNote.isAccessNote =>
         (ac.copy(note = Some(displayNote)), None)
 
       // If the item note is nothing to do with the access condition, we return it to
@@ -76,32 +76,31 @@ object SierraItemAccess extends SierraQueryOps with Logging {
   }
 
   private def createAccessCondition(
-                                     bibId: SierraBibNumber,
-                                     bibStatus: Option[AccessStatus],
-                                     holdCount: Option[Int],
-                                     status: Option[String],
-                                     opacmsg: Option[String],
-                                     rulesForRequestingResult: RulesForRequestingResult,
-                                     location: Option[PhysicalLocationType],
-                                     itemData: SierraItemData
-                                   ): AccessCondition =
+    bibId: SierraBibNumber,
+    bibStatus: Option[AccessStatus],
+    holdCount: Option[Int],
+    status: Option[String],
+    opacmsg: Option[String],
+    rulesForRequestingResult: RulesForRequestingResult,
+    location: Option[PhysicalLocationType],
+    itemData: SierraItemData
+  ): AccessCondition =
     (bibStatus, holdCount, status, opacmsg, rulesForRequestingResult, location) match {
 
       // Items in the closed stores that are requestable get the "Online request" condition.
       //
       // Example: b18799966 / i17571170
       case (
-        bibStatus,
-        Some(0),
-        Some(Status.Available),
-        Some(OpacMsg.OnlineRequest),
-        Requestable,
-        Some(LocationType.ClosedStores))
-        if bibStatus.isEmpty || bibStatus.contains(AccessStatus.Open) || bibStatus
-          .contains(AccessStatus.OpenWithAdvisory) =>
+          bibStatus,
+          Some(0),
+          Some(Status.Available),
+          Some(OpacMsg.OnlineRequest),
+          Requestable,
+          Some(LocationType.ClosedStores))
+          if bibStatus.isEmpty || bibStatus.contains(AccessStatus.Open) =>
         AccessCondition(
           method = AccessMethod.OnlineRequest,
-          status = bibStatus.getOrElse(AccessStatus.Open)
+          status = AccessStatus.Open
         )
 
       // Note: it is possible for individual items within a restricted bib to be available
@@ -122,12 +121,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       //
       // Example: b1842941 / i17286803
       case (
-        Some(AccessStatus.Restricted),
-        Some(0),
-        Some(Status.Available),
-        Some(OpacMsg.OnlineRequest),
-        Requestable,
-        Some(LocationType.ClosedStores)) =>
+          Some(AccessStatus.Restricted),
+          Some(0),
+          Some(Status.Available),
+          Some(OpacMsg.OnlineRequest),
+          Requestable,
+          Some(LocationType.ClosedStores)) =>
         AccessCondition(
           method = AccessMethod.OnlineRequest,
           status = AccessStatus.Open,
@@ -146,12 +145,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       //
       // Example: b1659504x / i15894897
       case (
-        None,
-        Some(0),
-        Some(Status.Available),
-        Some(OpacMsg.OpenShelves),
-        NotRequestable.OnOpenShelves(_),
-        Some(LocationType.OpenShelves)) =>
+          None,
+          Some(0),
+          Some(Status.Available),
+          Some(OpacMsg.OpenShelves),
+          NotRequestable.OnOpenShelves(_),
+          Some(LocationType.OpenShelves)) =>
         AccessCondition(method = AccessMethod.NotRequestable)
 
       // There are some items that are labelled "bound in above" or "contained in above".
@@ -167,12 +166,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       //
       // Example: b32214832 / i19389383
       case (
-        None,
-        Some(0),
-        Some(Status.Available),
-        Some(OpacMsg.ManualRequest),
-        NotRequestable.NeedsManualRequest(_),
-        Some(LocationType.ClosedStores)) =>
+          None,
+          Some(0),
+          Some(Status.Available),
+          Some(OpacMsg.ManualRequest),
+          NotRequestable.NeedsManualRequest(_),
+          Some(LocationType.ClosedStores)) =>
         // Some items like this have a display note that explains how the manual request
         // works, e.g.
         //
@@ -197,39 +196,39 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       //
       // Examples: b20657365 / i18576503, b1899457x / i17720734
       case (
-        Some(AccessStatus.Closed),
-        _,
-        Some(Status.Closed),
-        Some(OpacMsg.Unavailable),
-        NotRequestable.ItemClosed(_),
-        locationType)
-        if locationType.isEmpty || locationType.contains(
-          LocationType.ClosedStores) =>
+          Some(AccessStatus.Closed),
+          _,
+          Some(Status.Closed),
+          Some(OpacMsg.Unavailable),
+          NotRequestable.ItemClosed(_),
+          locationType)
+          if locationType.isEmpty || locationType.contains(
+            LocationType.ClosedStores) =>
         AccessCondition(
           method = AccessMethod.NotRequestable,
           status = AccessStatus.Closed)
 
       // Handle any cases where the item is explicitly unavailable.
       case (
-        status,
-        _,
-        Some(Status.Unavailable),
-        Some(OpacMsg.Unavailable),
-        NotRequestable.ItemUnavailable(_),
-        _)
-        if status.isEmpty || status.contains(
-          AccessStatus.TemporarilyUnavailable) =>
+          status,
+          _,
+          Some(Status.Unavailable),
+          Some(OpacMsg.Unavailable),
+          NotRequestable.ItemUnavailable(_),
+          _)
+          if status.isEmpty || status.contains(
+            AccessStatus.TemporarilyUnavailable) =>
         AccessCondition(
           method = AccessMethod.NotRequestable,
           status = AccessStatus.Unavailable)
 
       case (
-        None,
-        _,
-        Some(Status.Unavailable),
-        Some(OpacMsg.AtDigitisation),
-        NotRequestable.ItemUnavailable(_),
-        _) =>
+          None,
+          _,
+          Some(Status.Unavailable),
+          Some(OpacMsg.AtDigitisation),
+          NotRequestable.ItemUnavailable(_),
+          _) =>
         AccessCondition(
           method = AccessMethod.NotRequestable,
           status = Some(AccessStatus.TemporarilyUnavailable),
@@ -242,12 +241,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       //
       // Example: b29459126 / i19023340
       case (
-        Some(AccessStatus.Restricted),
-        Some(0),
-        Some(Status.Restricted),
-        Some(OpacMsg.OnlineRequest),
-        Requestable,
-        Some(LocationType.ClosedStores)) =>
+          Some(AccessStatus.Restricted),
+          Some(0),
+          Some(Status.Restricted),
+          Some(OpacMsg.OnlineRequest),
+          Requestable,
+          Some(LocationType.ClosedStores)) =>
         AccessCondition(
           method = AccessMethod.OnlineRequest,
           status = AccessStatus.Restricted)
@@ -256,27 +255,27 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       //
       // Examples: b32214832 / i19389383, b16576111 / 15862409
       case (
-        bibStatus,
-        Some(0),
-        Some(Status.PermissionRequired),
-        Some(OpacMsg.ByAppointment),
-        NotRequestable.NoPublicMessage(_),
-        Some(LocationType.ClosedStores))
-        if bibStatus.isEmpty || bibStatus.contains(AccessStatus.ByAppointment) || bibStatus
-          .contains(AccessStatus.PermissionRequired) =>
+          bibStatus,
+          Some(0),
+          Some(Status.PermissionRequired),
+          Some(OpacMsg.ByAppointment),
+          NotRequestable.NoPublicMessage(_),
+          Some(LocationType.ClosedStores))
+          if bibStatus.isEmpty || bibStatus.contains(AccessStatus.ByAppointment) || bibStatus
+            .contains(AccessStatus.PermissionRequired) =>
         AccessCondition(
           method = AccessMethod.ManualRequest,
           status = AccessStatus.ByAppointment)
 
       case (
-        bibStatus,
-        Some(0),
-        Some(Status.PermissionRequired),
-        Some(OpacMsg.DonorPermission),
-        _: NotRequestable,
-        Some(LocationType.ClosedStores))
-        if bibStatus.isEmpty || bibStatus.contains(
-          AccessStatus.PermissionRequired) =>
+          bibStatus,
+          Some(0),
+          Some(Status.PermissionRequired),
+          Some(OpacMsg.DonorPermission),
+          _: NotRequestable,
+          Some(LocationType.ClosedStores))
+          if bibStatus.isEmpty || bibStatus.contains(
+            AccessStatus.PermissionRequired) =>
         AccessCondition(
           method = AccessMethod.ManualRequest,
           status = AccessStatus.PermissionRequired)
@@ -285,12 +284,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       //
       // Example: b10379198 / i10443861
       case (
-        _,
-        _,
-        Some(Status.Missing),
-        _,
-        NotRequestable.ItemMissing(message),
-        _) =>
+          _,
+          _,
+          Some(Status.Missing),
+          _,
+          NotRequestable.ItemMissing(message),
+          _) =>
         AccessCondition(
           method = AccessMethod.NotRequestable,
           status = Some(AccessStatus.Unavailable),
@@ -298,12 +297,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
 
       // A withdrawn status also overrides all other values.
       case (
-        _,
-        _,
-        Some(Status.Withdrawn),
-        _,
-        NotRequestable.ItemWithdrawn(message),
-        _) =>
+          _,
+          _,
+          Some(Status.Withdrawn),
+          _,
+          NotRequestable.ItemWithdrawn(message),
+          _) =>
         AccessCondition(
           method = AccessMethod.NotRequestable,
           status = Some(AccessStatus.Unavailable),
@@ -322,8 +321,8 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       // It is possible for an item to have a non-zero hold count but still be available
       // for requesting, e.g. some of our long-lived test holds didn't get cleared properly.
       // If an item seems to be stuck on a non-zero hold count, ask somebody to check Sierra.
-      case (_, Some(holdCount), _, _, _, Some(LocationType.ClosedStores))
-        if holdCount > 0 =>
+      case (None, Some(holdCount), _, _, _, Some(LocationType.ClosedStores))
+          if holdCount > 0 =>
         AccessCondition(
           method = AccessMethod.NotRequestable,
           status = Some(AccessStatus.TemporarilyUnavailable),
@@ -332,12 +331,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         )
 
       case (
-        _,
-        _,
-        _,
-        _,
-        NotRequestable.OnHold(_),
-        Some(LocationType.ClosedStores)) =>
+          None,
+          _,
+          _,
+          _,
+          NotRequestable.OnHold(_),
+          Some(LocationType.ClosedStores)) =>
         AccessCondition(
           method = AccessMethod.NotRequestable,
           status = Some(AccessStatus.TemporarilyUnavailable),

--- a/common/stacks/src/test/scala/weco/api/stacks/services/ItemLookupTest.scala
+++ b/common/stacks/src/test/scala/weco/api/stacks/services/ItemLookupTest.scala
@@ -228,8 +228,12 @@ class ItemLookupTest
             _ shouldBe Seq(Right(item))
           }
 
-          whenReady(lookup.bySourceIdentifier(Seq(item.id.otherIdentifiers.head))) {
-            _ shouldBe Seq(Left(DocumentNotFoundError(item.id.otherIdentifiers.head)))
+          whenReady(
+            lookup.bySourceIdentifier(Seq(item.id.otherIdentifiers.head))
+          ) {
+            _ shouldBe Seq(
+              Left(DocumentNotFoundError(item.id.otherIdentifiers.head))
+            )
           }
         }
       }

--- a/common/stacks/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/stacks/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -87,6 +87,36 @@ class SierraItemAccessTest
               status = AccessStatus.Open)
         }
 
+        it("if it has no restrictions and the bib is open with advisory") {
+          val itemData = createSierraItemDataWith(
+            fixedFields = Map(
+              "79" -> FixedField(
+                label = "LOCATION",
+                value = "scmac",
+                display = "Closed stores Arch. & MSS"),
+              "88" -> FixedField(
+                label = "STATUS",
+                value = "-",
+                display = "Available"),
+              "108" -> FixedField(
+                label = "OPACMSG",
+                value = "f",
+                display = "Online request"),
+            )
+          )
+
+          val (ac, _) = getItemAccess(
+            bibStatus = Some(AccessStatus.OpenWithAdvisory),
+            location = Some(LocationType.ClosedStores),
+            itemData = itemData
+          )
+
+          ac shouldBe
+            AccessCondition(
+              method = AccessMethod.OnlineRequest,
+              status = AccessStatus.OpenWithAdvisory)
+        }
+
         it("if it's restricted") {
           val itemData = createSierraItemDataWith(
             fixedFields = Map(
@@ -590,8 +620,8 @@ class SierraItemAccessTest
       }
     }
 
-    describe("that's on hold") {
-      it("can't be requested when another reader has placed a hold") {
+    describe("that's on hold can't be requested") {
+      it("when another reader has placed a hold") {
         val itemData = createSierraItemDataWith(
           holdCount = Some(1),
           fixedFields = Map(
@@ -625,7 +655,7 @@ class SierraItemAccessTest
           )
       }
 
-      it("can't be requested when an item is on hold for a loan rule") {
+      it("when an item is on hold for a loan rule") {
         val itemData = createSierraItemDataWith(
           holdCount = Some(1),
           fixedFields = Map(
@@ -660,7 +690,7 @@ class SierraItemAccessTest
           )
       }
 
-      it("can't be requested when a manual request item is on hold for somebody else") {
+      it("when a manual request item is on hold for somebody else") {
         val itemData = createSierraItemDataWith(
           holdCount = Some(1),
           fixedFields = Map(
@@ -698,7 +728,7 @@ class SierraItemAccessTest
           )
       }
 
-      it("can't be requested when it's on the hold shelf for another reader") {
+      it("when it's on the hold shelf for another reader") {
         val itemData = createSierraItemDataWith(
           holdCount = Some(1),
           fixedFields = Map(
@@ -719,6 +749,41 @@ class SierraItemAccessTest
 
         val (ac, _) = getItemAccess(
           bibStatus = None,
+          location = Some(LocationType.ClosedStores),
+          itemData = itemData
+        )
+
+        ac shouldBe
+          AccessCondition(
+            method = AccessMethod.NotRequestable,
+            status = Some(AccessStatus.TemporarilyUnavailable),
+            note = Some(
+              "Item is in use by another reader. Please ask at Enquiry Desk.")
+          )
+      }
+
+      it("if there's a status on the bib") {
+        // This is based on b32204887 / i19379778, as retrieved 13 August 2021
+        val itemData = createSierraItemDataWith(
+          holdCount = Some(1),
+          fixedFields = Map(
+            "79" -> FixedField(
+              label = "scmac",
+              value = "swms4",
+              display = "Closed stores Arch. & MSS"),
+            "88" -> FixedField(
+              label = "STATUS",
+              value = "!",
+              display = "On holdshelf"),
+            "108" -> FixedField(
+              label = "OPACMSG",
+              value = "a",
+              display = "By appointment"),
+          )
+        )
+
+        val (ac, _) = getItemAccess(
+          bibStatus = Some(AccessStatus.ByAppointment),
           location = Some(LocationType.ClosedStores),
           itemData = itemData
         )

--- a/common/stacks/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/stacks/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -22,7 +22,7 @@ import weco.sierra.models.identifiers.SierraBibNumber
 import weco.sierra.models.marc.{FixedField, VarField}
 
 class SierraItemAccessTest
-  extends AnyFunSpec
+    extends AnyFunSpec
     with Matchers
     with SierraDataGenerators {
   describe("an item in the closed stores") {
@@ -85,36 +85,6 @@ class SierraItemAccessTest
             AccessCondition(
               method = AccessMethod.OnlineRequest,
               status = AccessStatus.Open)
-        }
-
-        it("if it has no restrictions and the bib is open with advisory") {
-          val itemData = createSierraItemDataWith(
-            fixedFields = Map(
-              "79" -> FixedField(
-                label = "LOCATION",
-                value = "scmac",
-                display = "Closed stores Arch. & MSS"),
-              "88" -> FixedField(
-                label = "STATUS",
-                value = "-",
-                display = "Available"),
-              "108" -> FixedField(
-                label = "OPACMSG",
-                value = "f",
-                display = "Online request"),
-            )
-          )
-
-          val (ac, _) = getItemAccess(
-            bibStatus = Some(AccessStatus.OpenWithAdvisory),
-            location = Some(LocationType.ClosedStores),
-            itemData = itemData
-          )
-
-          ac shouldBe
-            AccessCondition(
-              method = AccessMethod.OnlineRequest,
-              status = AccessStatus.OpenWithAdvisory)
         }
 
         it("if it's restricted") {
@@ -620,8 +590,8 @@ class SierraItemAccessTest
       }
     }
 
-    describe("that's on hold can't be requested") {
-      it("when another reader has placed a hold") {
+    describe("that's on hold") {
+      it("can't be requested when another reader has placed a hold") {
         val itemData = createSierraItemDataWith(
           holdCount = Some(1),
           fixedFields = Map(
@@ -655,7 +625,7 @@ class SierraItemAccessTest
           )
       }
 
-      it("when an item is on hold for a loan rule") {
+      it("can't be requested when an item is on hold for a loan rule") {
         val itemData = createSierraItemDataWith(
           holdCount = Some(1),
           fixedFields = Map(
@@ -690,7 +660,7 @@ class SierraItemAccessTest
           )
       }
 
-      it("when a manual request item is on hold for somebody else") {
+      it("can't be requested when a manual request item is on hold for somebody else") {
         val itemData = createSierraItemDataWith(
           holdCount = Some(1),
           fixedFields = Map(
@@ -728,7 +698,7 @@ class SierraItemAccessTest
           )
       }
 
-      it("when it's on the hold shelf for another reader") {
+      it("can't be requested when it's on the hold shelf for another reader") {
         val itemData = createSierraItemDataWith(
           holdCount = Some(1),
           fixedFields = Map(
@@ -749,41 +719,6 @@ class SierraItemAccessTest
 
         val (ac, _) = getItemAccess(
           bibStatus = None,
-          location = Some(LocationType.ClosedStores),
-          itemData = itemData
-        )
-
-        ac shouldBe
-          AccessCondition(
-            method = AccessMethod.NotRequestable,
-            status = Some(AccessStatus.TemporarilyUnavailable),
-            note = Some(
-              "Item is in use by another reader. Please ask at Enquiry Desk.")
-          )
-      }
-
-      it("if there's a status on the bib") {
-        // This is based on b32204887 / i19379778, as retrieved 13 August 2021
-        val itemData = createSierraItemDataWith(
-          holdCount = Some(1),
-          fixedFields = Map(
-            "79" -> FixedField(
-              label = "scmac",
-              value = "swms4",
-              display = "Closed stores Arch. & MSS"),
-            "88" -> FixedField(
-              label = "STATUS",
-              value = "!",
-              display = "On holdshelf"),
-            "108" -> FixedField(
-              label = "OPACMSG",
-              value = "a",
-              display = "By appointment"),
-          )
-        )
-
-        val (ac, _) = getItemAccess(
-          bibStatus = Some(AccessStatus.ByAppointment),
           location = Some(LocationType.ClosedStores),
           itemData = itemData
         )
@@ -1084,11 +1019,11 @@ class SierraItemAccessTest
   }
 
   private def getItemAccess(
-                             bibId: SierraBibNumber = createSierraBibNumber,
-                             bibStatus: Option[AccessStatus],
-                             location: Option[PhysicalLocationType],
-                             itemData: SierraItemData
-                           ): (AccessCondition, Option[String]) =
+    bibId: SierraBibNumber = createSierraBibNumber,
+    bibStatus: Option[AccessStatus],
+    location: Option[PhysicalLocationType],
+    itemData: SierraItemData
+  ): (AccessCondition, Option[String]) =
     SierraItemAccess(
       bibId = bibId,
       bibStatus = bibStatus,

--- a/requests/src/main/scala/weco/api/requests/responses/LookupPendingRequests.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/LookupPendingRequests.scala
@@ -20,13 +20,13 @@ trait LookupPendingRequests extends CustomDirectives {
     val itemHolds = for {
       holdsMap <- sierraService.getHolds(patronNumber)
 
-      itemLookupResults <- itemLookup.bySourceIdentifiers(holdsMap.keys.toSeq)
+      itemLookupResults <- itemLookup.bySourceIdentifier(holdsMap.keys.toSeq)
 
       itemsFound = itemLookupResults.zip(holdsMap.keys).flatMap {
         case (Right(item), _) => Some(item)
         case (Left(elasticError: ElasticsearchError), srcId) =>
           warn(
-            s"Error looking up item ${srcId}. Elasticsearch error: ${elasticError}"
+            s"Error looking up item $srcId. Elasticsearch error: $elasticError"
           )
           None
       }

--- a/requests/src/main/scala/weco/api/requests/responses/LookupPendingRequests.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/LookupPendingRequests.scala
@@ -5,8 +5,6 @@ import weco.api.search.elasticsearch.ElasticsearchError
 import weco.api.search.rest.CustomDirectives
 import weco.api.requests.models.display.DisplayResultsList
 import weco.api.stacks.services.{ItemLookup, SierraService}
-import weco.catalogue.internal_model.identifiers.IdState
-import weco.catalogue.internal_model.work.Item
 import weco.sierra.models.identifiers.SierraPatronNumber
 
 import scala.concurrent.ExecutionContext
@@ -22,7 +20,7 @@ trait LookupPendingRequests extends CustomDirectives {
     val itemHolds = for {
       holdsMap <- sierraService.getHolds(patronNumber)
 
-      itemLookupResults: Seq[Either[ElasticsearchError, Item[IdState.Identified]]] <- itemLookup.bySourceIdentifiers(holdsMap.keys.toSeq)
+      itemLookupResults <- itemLookup.bySourceIdentifiers(holdsMap.keys.toSeq)
 
       itemsFound = itemLookupResults.zip(holdsMap.keys).flatMap {
         case (Right(item), _) => Some(item)


### PR DESCRIPTION
Continuing to work on making sensible catalogue API queries to fill out items on holds.

This change connects the requests API hold listing to the `findByMultiSearch` function through `ItemLookup`. Updates to the interface of `findByMultiSearch` were required to effectively identify missing items.

I've refrained from adding many more tests to requests or starting on the logic to add the correct work title to holds (see https://github.com/wellcomecollection/platform/issues/5267), that work will be required in future PRs.

Follows: https://github.com/wellcomecollection/catalogue-api/pull/235
Part of: https://github.com/wellcomecollection/catalogue-api/issues/231

