### PR TITLE
Retry a single timeout from Elasticsearch

### DIFF
--- a/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala
+++ b/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala
@@ -178,7 +178,9 @@ class ElasticsearchService(elasticClient: ElasticClient)(
 
   private def isRetryable(t: Throwable): Boolean =
     t match {
-      case JavaClientExceptionWrapper(exc: java.net.ConnectException) if exc.getMessage.startsWith("Timeout connecting to") => true
+      case JavaClientExceptionWrapper(exc: java.net.ConnectException)
+          if exc.getMessage.startsWith("Timeout connecting to") =>
+        true
 
       case _ => false
     }
@@ -186,11 +188,13 @@ class ElasticsearchService(elasticClient: ElasticClient)(
   private def executeRequest[Request, U](request: Request)(
     implicit
     handler: Handler[Request, U],
-    manifest: Manifest[U]): Future[Response[U]] = {
+    manifest: Manifest[U]
+  ): Future[Response[U]] = {
     debug(s"Sending ES request: ${request.show}")
 
-    val retryableFunction = ((r: Request) => withActiveTrace(elasticClient.execute(r)))
-      .retry(maxAttempts = 2, isRetryable = isRetryable)
+    val retryableFunction =
+      ((r: Request) => withActiveTrace(elasticClient.execute(r)))
+        .retry(maxAttempts = 2, isRetryable = isRetryable)
 
     retryableFunction(request)
   }

--- a/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala
+++ b/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala
@@ -120,21 +120,19 @@ class ElasticsearchService(elasticClient: ElasticClient)(
                 val (timeTakenTotal, timesTaken, results) = acc
 
                 item.response match {
-                  case Right(itemResponse) => {
+                  case Right(itemResponse) =>
                     (
                       timeTakenTotal + itemResponse.took,
                       timesTaken :+ itemResponse.took,
                       results :+ Right(itemResponse)
                     )
-                  }
 
-                  case Left(error) => {
+                  case Left(error) =>
                     (
                       timeTakenTotal,
                       timesTaken,
                       results :+ Left(ElasticsearchError(error))
                     )
-                  }
                 }
               }
 

--- a/common/search/src/main/scala/weco/api/search/elasticsearch/FutureRetryOps.scala
+++ b/common/search/src/main/scala/weco/api/search/elasticsearch/FutureRetryOps.scala
@@ -1,0 +1,44 @@
+package weco.api.search.elasticsearch
+
+import grizzled.slf4j.Logging
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/** Retry an operation which may return a `Throwable`.
+  *
+  * It tries the function up to `maxAttempts` times.  If at any point
+  * the function returns a successful Future or fails with a
+  * non-retryable Throwable, it finishes immediately.
+  *
+  */
+object FutureRetryOps extends Logging {
+  implicit class Retry[In, Out](f: In => Future[Out]) {
+
+    def retry(maxAttempts: Int = 1, isRetryable: Throwable => Boolean)(implicit ec: ExecutionContext): In => Future[Out] =
+      (in: In) => retryInternal(maxAttempts, isRetryable)(in)
+
+    private def retryInternal(remainingAttempts: Int, isRetryable: Throwable => Boolean)(
+      in: In)(implicit ec: ExecutionContext): Future[Out] =
+      f(in)
+        .map { out =>
+          debug(s"Success: retryable operation for in=$in succeeded")
+          out
+        }
+        .recoverWith {
+          case t if isRetryable(t) =>
+            debug(
+              s"Retryable error: remaining attempts = $remainingAttempts for in=$in after throwable $t")
+            if (remainingAttempts == 1) {
+              debug(s"Retryable error: marking operation as failed with $t")
+              Future.failed(t)
+            } else {
+              assert(remainingAttempts > 0)
+              debug(s"Retryable error: retrying operation with $t")
+              retryInternal(remainingAttempts - 1, isRetryable)(in)
+            }
+
+          case t =>
+            Future.failed(t)
+        }
+  }
+}

--- a/common/search/src/main/scala/weco/api/search/elasticsearch/FutureRetryOps.scala
+++ b/common/search/src/main/scala/weco/api/search/elasticsearch/FutureRetryOps.scala
@@ -14,11 +14,15 @@ import scala.concurrent.{ExecutionContext, Future}
 object FutureRetryOps extends Logging {
   implicit class Retry[In, Out](f: In => Future[Out]) {
 
-    def retry(maxAttempts: Int = 1, isRetryable: Throwable => Boolean)(implicit ec: ExecutionContext): In => Future[Out] =
+    def retry(maxAttempts: Int = 1, isRetryable: Throwable => Boolean)(
+      implicit ec: ExecutionContext
+    ): In => Future[Out] =
       (in: In) => retryInternal(maxAttempts, isRetryable)(in)
 
-    private def retryInternal(remainingAttempts: Int, isRetryable: Throwable => Boolean)(
-      in: In)(implicit ec: ExecutionContext): Future[Out] =
+    private def retryInternal(
+      remainingAttempts: Int,
+      isRetryable: Throwable => Boolean
+    )(in: In)(implicit ec: ExecutionContext): Future[Out] =
       f(in)
         .map { out =>
           debug(s"Success: retryable operation for in=$in succeeded")
@@ -27,7 +31,8 @@ object FutureRetryOps extends Logging {
         .recoverWith {
           case t if isRetryable(t) =>
             debug(
-              s"Retryable error: remaining attempts = $remainingAttempts for in=$in after throwable $t")
+              s"Retryable error: remaining attempts = $remainingAttempts for in=$in after throwable $t"
+            )
             if (remainingAttempts == 1) {
               debug(s"Retryable error: marking operation as failed with $t")
               Future.failed(t)

--- a/common/search/src/test/scala/weco/api/search/elasticsearch/FutureRetryOpsTest.scala
+++ b/common/search/src/test/scala/weco/api/search/elasticsearch/FutureRetryOpsTest.scala
@@ -29,7 +29,8 @@ class FutureRetryOpsTest extends AnyFunSpec with Matchers with ScalaFutures {
       }
     }
 
-    val retryableFunction = (canOnlyBeCalledOnce _).retry(maxAttempts = 3, isRetryable = neverRetry)
+    val retryableFunction =
+      (canOnlyBeCalledOnce _).retry(maxAttempts = 3, isRetryable = neverRetry)
 
     whenReady(retryableFunction("hello")) {
       _ shouldBe "HELLO"
@@ -51,7 +52,8 @@ class FutureRetryOpsTest extends AnyFunSpec with Matchers with ScalaFutures {
       }
     }
 
-    val retryableFunction = (countCalls _).retry(maxAttempts, isRetryable = alwaysRetry)
+    val retryableFunction =
+      (countCalls _).retry(maxAttempts, isRetryable = alwaysRetry)
 
     whenReady(retryableFunction("hello")) {
       _ shouldBe "HELLO"
@@ -72,7 +74,10 @@ class FutureRetryOpsTest extends AnyFunSpec with Matchers with ScalaFutures {
       }
     }
 
-    val retryableFunction = (failsAfterFirstCall _).retry(maxAttempts = 3, isRetryable = (t: Throwable) => t.getMessage.contains("retryable"))
+    val retryableFunction = (failsAfterFirstCall _).retry(
+      maxAttempts = 3,
+      isRetryable = (t: Throwable) => t.getMessage.contains("retryable")
+    )
 
     whenReady(retryableFunction("hello").failed) {
       _ shouldBe err
@@ -87,7 +92,8 @@ class FutureRetryOpsTest extends AnyFunSpec with Matchers with ScalaFutures {
     def alwaysFails(s: String): Future[String] =
       Future.failed(err)
 
-    val retryableFunction = (alwaysFails _).retry(maxAttempts, isRetryable = alwaysRetry)
+    val retryableFunction =
+      (alwaysFails _).retry(maxAttempts, isRetryable = alwaysRetry)
 
     whenReady(retryableFunction("hello").failed) {
       _ shouldBe err

--- a/common/search/src/test/scala/weco/api/search/elasticsearch/FutureRetryOpsTest.scala
+++ b/common/search/src/test/scala/weco/api/search/elasticsearch/FutureRetryOpsTest.scala
@@ -1,0 +1,114 @@
+package weco.api.search.elasticsearch
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class FutureRetryOpsTest extends AnyFunSpec with Matchers with ScalaFutures {
+  import FutureRetryOps._
+
+  private def alwaysRetry(t: Throwable): Boolean =
+    true
+
+  private def neverRetry(t: Throwable): Boolean =
+    false
+
+  it("if N=1 is successful, it succeeds") {
+    var callCount = 0
+
+    def canOnlyBeCalledOnce(s: String): Future[String] = {
+      callCount += 1
+
+      if (callCount == 1) {
+        Future.successful(s.toUpperCase)
+      } else {
+        Future.failed(new Throwable("BOOM!"))
+      }
+    }
+
+    val retryableFunction = (canOnlyBeCalledOnce _).retry(maxAttempts = 3, isRetryable = neverRetry)
+
+    whenReady(retryableFunction("hello")) {
+      _ shouldBe "HELLO"
+    }
+  }
+
+  it("if N=1–5 are retryable and N=6 is successful, it succeeds") {
+    val maxAttempts = 6
+
+    var callCount = 0
+
+    def countCalls(s: String): Future[String] = {
+      callCount += 1
+
+      if (callCount > maxAttempts - 1) {
+        Future.successful(s.toUpperCase)
+      } else {
+        Future.failed(new Throwable("BOOM!"))
+      }
+    }
+
+    val retryableFunction = (countCalls _).retry(maxAttempts, isRetryable = alwaysRetry)
+
+    whenReady(retryableFunction("hello")) {
+      _ shouldBe "HELLO"
+    }
+  }
+
+  it("if N=1 is retryable and N=2 isn't, it fails") {
+    var callCount = 0
+    val err = new Throwable("BOOM!")
+
+    def failsAfterFirstCall(s: String): Future[String] = {
+      callCount += 1
+
+      if (callCount == 1) {
+        Future.failed(new Throwable("retryable BOOM!"))
+      } else {
+        Future.failed(err)
+      }
+    }
+
+    val retryableFunction = (failsAfterFirstCall _).retry(maxAttempts = 3, isRetryable = (t: Throwable) => t.getMessage.contains("retryable"))
+
+    whenReady(retryableFunction("hello").failed) {
+      _ shouldBe err
+    }
+  }
+
+  it("if N=1 to maxAttempts are all retryable, it fails with the final error") {
+    val maxAttempts = 5
+
+    val err = new Throwable("BOOM!")
+
+    def alwaysFails(s: String): Future[String] =
+      Future.failed(err)
+
+    val retryableFunction = (alwaysFails _).retry(maxAttempts, isRetryable = alwaysRetry)
+
+    whenReady(retryableFunction("hello").failed) {
+      _ shouldBe err
+    }
+  }
+
+  it("makes one attempt by default") {
+    var callCount = 0
+    val err = new Throwable("BOOM!")
+
+    def countCalls(s: String): Future[String] = {
+      callCount += 1
+      Future.failed(err)
+    }
+
+    val retryableFunction = (countCalls _).retry(isRetryable = alwaysRetry)
+
+    whenReady(retryableFunction("hello").failed) {
+      _ shouldBe err
+    }
+
+    callCount shouldBe 1
+  }
+}


### PR DESCRIPTION
The recent 5xx alarms from the Catalogue API are caused by single timeouts connecting to the Elasticsearch cluster. They don't seem to be problems with the individual request or downtime in the cluster, just a momentary flake.

This patch adds logic to retry a single timeout when we see it.

For more explanation, see:

* the code comment in ElasticsearchService
* the [RetryOps object in scala-libs](https://github.com/wellcomecollection/scala-libs/blob/966099678c0767f4277652d952780524623a9a8f/storage/src/main/scala/weco/storage/RetryOps.scala
) that the FutureRetryOps object and its tests are based on