### PR TITLE
scale rank cluster down to 1g

### DIFF
--- a/rank/terraform/main.tf
+++ b/rank/terraform/main.tf
@@ -17,7 +17,7 @@ resource "ec_deployment" "rank_catalogue" {
   elasticsearch {
     topology {
       id         = "hot_content"
-      size       = "2g"
+      size       = "1g"
       zone_count = 2
     }
   }


### PR DESCRIPTION
It seems to run fine at that size. The biggest issue was having 1 zone, which causes loads of replication issues, which in turn mucks up the shards, which makes searching mega-slow. We'll keep looking at running this cost down.

This now stands at $637.728 / year.