### PR TITLE
Add our standard API Gateway responses

### DIFF
--- a/terraform/catalogue_api/.terraform.lock.hcl
+++ b/terraform/catalogue_api/.terraform.lock.hcl
@@ -18,3 +18,10 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:e1279bde388cb675d324584d965c6d22c3ec6890b13de76a50910a3bcd84ed64",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+  ]
+}

--- a/terraform/modules/stack/api_gateway.tf
+++ b/terraform/modules/stack/api_gateway.tf
@@ -20,6 +20,7 @@ resource "aws_api_gateway_deployment" "default" {
         aws_api_gateway_resource.v2.id,
         aws_api_gateway_gateway_response.no_resource.id,
         aws_api_gateway_gateway_response.not_found_404.id,
+        module.gateway_responses.fingerprint,
       ],
       module.works_route.all_ids,
       module.images_route.all_ids,

--- a/terraform/modules/stack/static_responses.tf
+++ b/terraform/modules/stack/static_responses.tf
@@ -17,6 +17,12 @@ locals {
   }
 }
 
+module "gateway_responses" {
+  source = "github.com/wellcomecollection/terraform-aws-api-gateway-responses.git?ref=v1.1.1"
+
+  rest_api_id = aws_api_gateway_rest_api.catalogue.id
+}
+
 module "v1_root_gone" {
   source = "../static_response"
 


### PR DESCRIPTION
e.g. https://api.wellcomecollection.org/catalogue/v2/works/a222zvge/items

This now returns an instance of our Error type rather than the default API Gateway response.