### PR TITLE
Remove requests deployment from catalogue-api build

### DIFF
--- a/.wellcome_project
+++ b/.wellcome_project
@@ -14,22 +14,26 @@ catalogue_api:
     - id: snapshot_generator
       services:
         - id: snapshot-generator
+    # TODO: Add note about this being deployed elsewhere
+    # TODO: It has no service, as we do not wish to deploy it in ECS
+    - id: requests
   name: Catalogue API
   account_id: '756629837203'
   role_arn: arn:aws:iam::756629837203:role/catalogue-ci
   region_name: eu-west-1
 
-requests_api:
-   environments:
-     - id: stage
-       name: Staging
-     - id: prod
-       name: Production
-   image_repositories:
-     - id: requests
-       services:
-         - id: requests
-   name: Requests API
-   account_id: '770700576653'
-   role_arn: 'arn:aws:iam::770700576653:role/identity-ci'
-   region_name: eu-west-1
+# TODO: remove this when we know the new deployment works
+#requests_api:
+#   environments:
+#     - id: stage
+#       name: Staging
+#     - id: prod
+#       name: Production
+#   image_repositories:
+#     - id: requests
+#       services:
+#         - id: requests
+#   name: Requests API
+#   account_id: '770700576653'
+#   role_arn: 'arn:aws:iam::770700576653:role/identity-ci'
+#   region_name: eu-west-1

--- a/.wellcome_project
+++ b/.wellcome_project
@@ -14,26 +14,10 @@ catalogue_api:
     - id: snapshot_generator
       services:
         - id: snapshot-generator
-    # TODO: Add note about this being deployed elsewhere
-    # TODO: It has no service, as we do not wish to deploy it in ECS
+    # This service is deployed from the Identity AWS Account
+    # See: https://github.com/wellcomecollection/identity
     - id: requests
   name: Catalogue API
   account_id: '756629837203'
   role_arn: arn:aws:iam::756629837203:role/catalogue-ci
   region_name: eu-west-1
-
-# TODO: remove this when we know the new deployment works
-#requests_api:
-#   environments:
-#     - id: stage
-#       name: Staging
-#     - id: prod
-#       name: Production
-#   image_repositories:
-#     - id: requests
-#       services:
-#         - id: requests
-#   name: Requests API
-#   account_id: '770700576653'
-#   role_arn: 'arn:aws:iam::770700576653:role/identity-ci'
-#   region_name: eu-west-1

--- a/builds/publish_image_with_weco_deploy.sh
+++ b/builds/publish_image_with_weco_deploy.sh
@@ -13,15 +13,17 @@ IMAGE_ID="$1"
 
 # TODO: This is working out the weco-project project ID, which we could
 # derive programatically from .wellcome_project.
-case "$IMAGE_ID" in
-  "search" | "items" | "snapshot_generator")
-    PROJECT_ID="catalogue_api"
-    ;;
+#case "$IMAGE_ID" in
+#  "search" | "items" | "snapshot_generator")
+#    PROJECT_ID="catalogue_api"
+#    ;;
+#
+#  "requests")
+#    PROJECT_ID="requests_api"
+#    ;;
+#esac
 
-  "requests")
-    PROJECT_ID="requests_api"
-    ;;
-esac
+PROJECT_ID="catalogue_api"
 
 docker run --tty --rm \
   --env AWS_PROFILE \

--- a/builds/publish_image_with_weco_deploy.sh
+++ b/builds/publish_image_with_weco_deploy.sh
@@ -10,19 +10,6 @@ WECO_DEPLOY_IMAGE="wellcome/weco-deploy:5.6.11"
 ROOT=$(git rev-parse --show-toplevel)
 
 IMAGE_ID="$1"
-
-# TODO: This is working out the weco-project project ID, which we could
-# derive programatically from .wellcome_project.
-#case "$IMAGE_ID" in
-#  "search" | "items" | "snapshot_generator")
-#    PROJECT_ID="catalogue_api"
-#    ;;
-#
-#  "requests")
-#    PROJECT_ID="requests_api"
-#    ;;
-#esac
-
 PROJECT_ID="catalogue_api"
 
 docker run --tty --rm \

--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -20,6 +20,8 @@ else
 fi
 
 docker run --tty --rm \
+  --env AWS_PROFILE \
+  --volume ~/.aws:/root/.aws \
   --volume ~/.sbt:/root/.sbt \
   --volume ~/.ivy2:/root/.ivy2 \
   --volume "$HOST_COURSIER_CACHE:/root/$LINUX_COURSIER_CACHE" \

--- a/terraform/shared/ecr.tf
+++ b/terraform/shared/ecr.tf
@@ -7,6 +7,7 @@ resource "aws_ecr_repository" "items" {
 }
 
 # This is in the identity account as it is deployed there
+# TODO: Remove this when we are deploying it from identity
 resource "aws_ecr_repository" "requests" {
   provider = aws.identity
 
@@ -16,6 +17,16 @@ resource "aws_ecr_repository" "requests" {
     prevent_destroy = true
   }
 }
+
+# TODO: Rename this (remove -new) by removing and importing state
+resource "aws_ecr_repository" "requests-new" {
+  name = "uk.ac.wellcome/requests"
+
+//  lifecycle {
+//    prevent_destroy = true
+//  }
+}
+
 
 resource "aws_ecr_repository" "search" {
   name = "uk.ac.wellcome/search"

--- a/terraform/shared/ecr.tf
+++ b/terraform/shared/ecr.tf
@@ -6,25 +6,12 @@ resource "aws_ecr_repository" "items" {
   }
 }
 
-# This is in the identity account as it is deployed there
-# TODO: Remove this when we are deploying it from identity
 resource "aws_ecr_repository" "requests" {
-  provider = aws.identity
-
   name = "uk.ac.wellcome/requests"
 
   lifecycle {
     prevent_destroy = true
   }
-}
-
-# TODO: Rename this (remove -new) by removing and importing state
-resource "aws_ecr_repository" "requests-new" {
-  name = "uk.ac.wellcome/requests"
-
-//  lifecycle {
-//    prevent_destroy = true
-//  }
 }
 
 

--- a/terraform/shared/ecr_permissions.tf
+++ b/terraform/shared/ecr_permissions.tf
@@ -39,3 +39,30 @@ resource "aws_ecr_repository_policy" "catalogue_access_policy" {
   repository = "uk.ac.wellcome/${local.service_repositories[count.index]}"
   policy     = data.aws_iam_policy_document.allow_catalogue_access.json
 }
+
+# Allow the identity account to read requests ECR image
+
+data "aws_iam_policy_document" "allow_identity_access" {
+  statement {
+    principals {
+      identifiers = [
+        "arn:aws:iam::770700576653:root"
+      ]
+
+      type = "AWS"
+    }
+
+    actions = [
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+    ]
+  }
+}
+
+resource "aws_ecr_repository_policy" "identity_access_policy" {
+  count      = length(local.service_repositories)
+  repository = "uk.ac.wellcome/requests"
+  policy     = data.aws_iam_policy_document.allow_identity_access.json
+}
+


### PR DESCRIPTION
In order to partition permissions in builds (catalogue-api builds **should not** reach into the identity account), this change will remove deployment into the identity AWS account from this build and move it elsewhere.

This repository will still build and push ECR images, though they will now go to the catalogue AWS account and be pulled into the identity account when deployment is triggered.

**Note:** This will pause requests-api deployment until it's configured in: https://github.com/wellcomecollection/identity. This change will be done next.

