### PR TITLE
Replace the indexObject() helper, which is going away

### DIFF
--- a/snapshots/snapshot_generator/src/test/scala/weco/elasticsearch/ElasticsearchScannerTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/weco/elasticsearch/ElasticsearchScannerTest.scala
@@ -28,7 +28,15 @@ class ElasticsearchScannerTest
 
   def withIndex[R](shapes: Seq[Shape])(testWith: TestWith[Index, R]): R =
     withLocalElasticsearchIndex(config = IndexConfig.empty) { index =>
-      shapes.foreach { indexObject(index, _).await }
+      shapes.foreach { s =>
+        val resp = elasticClient
+          .execute {
+            indexInto(index.name).doc(toJson(s).get)
+          }
+          .await
+
+        resp.isSuccess shouldBe true
+      }
 
       eventually {
         val response: Response[SearchResponse] = elasticClient.execute {

--- a/snapshots/snapshot_generator/src/test/scala/weco/elasticsearch/ElasticsearchScannerTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/weco/elasticsearch/ElasticsearchScannerTest.scala
@@ -29,11 +29,9 @@ class ElasticsearchScannerTest
   def withIndex[R](shapes: Seq[Shape])(testWith: TestWith[Index, R]): R =
     withLocalElasticsearchIndex(config = IndexConfig.empty) { index =>
       shapes.foreach { s =>
-        val resp = elasticClient
-          .execute {
-            indexInto(index.name).doc(toJson(s).get)
-          }
-          .await
+        val resp = elasticClient.execute {
+          indexInto(index.name).doc(toJson(s).get)
+        }.await
 
         resp.isSuccess shouldBe true
       }


### PR DESCRIPTION
In particular the indexObject() internals aren't necessarily what you'd expect; copying it here makes it more explicit that we're indexing objects without IDs.  That's fine in this case, but may not always be the case.

I've removed these helpers from the pipeline repo in https://github.com/wellcomecollection/catalogue-pipeline/pull/1848; after this I'll remove them entirely from scala-libs.