### PR TITLE
Revert "Remove requests deployment from catalogue-api build"

### DIFF
--- a/.wellcome_project
+++ b/.wellcome_project
@@ -14,10 +14,22 @@ catalogue_api:
     - id: snapshot_generator
       services:
         - id: snapshot-generator
-    # This service is deployed from the Identity AWS Account
-    # See: https://github.com/wellcomecollection/identity
-    - id: requests
   name: Catalogue API
   account_id: '756629837203'
   role_arn: arn:aws:iam::756629837203:role/catalogue-ci
   region_name: eu-west-1
+
+requests_api:
+   environments:
+     - id: stage
+       name: Staging
+     - id: prod
+       name: Production
+   image_repositories:
+     - id: requests
+       services:
+         - id: requests
+   name: Requests API
+   account_id: '770700576653'
+   role_arn: 'arn:aws:iam::770700576653:role/identity-ci'
+   region_name: eu-west-1

--- a/builds/publish_image_with_weco_deploy.sh
+++ b/builds/publish_image_with_weco_deploy.sh
@@ -10,7 +10,18 @@ WECO_DEPLOY_IMAGE="wellcome/weco-deploy:5.6.11"
 ROOT=$(git rev-parse --show-toplevel)
 
 IMAGE_ID="$1"
-PROJECT_ID="catalogue_api"
+
+# TODO: This is working out the weco-project project ID, which we could
+# derive programatically from .wellcome_project.
+case "$IMAGE_ID" in
+  "search" | "items" | "snapshot_generator")
+    PROJECT_ID="catalogue_api"
+    ;;
+
+  "requests")
+    PROJECT_ID="requests_api"
+    ;;
+esac
 
 docker run --tty --rm \
   --env AWS_PROFILE \

--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -20,8 +20,6 @@ else
 fi
 
 docker run --tty --rm \
-  --env AWS_PROFILE \
-  --volume ~/.aws:/root/.aws \
   --volume ~/.sbt:/root/.sbt \
   --volume ~/.ivy2:/root/.ivy2 \
   --volume "$HOST_COURSIER_CACHE:/root/$LINUX_COURSIER_CACHE" \

--- a/terraform/shared/ecr.tf
+++ b/terraform/shared/ecr.tf
@@ -6,7 +6,10 @@ resource "aws_ecr_repository" "items" {
   }
 }
 
+# This is in the identity account as it is deployed there
 resource "aws_ecr_repository" "requests" {
+  provider = aws.identity
+
   name = "uk.ac.wellcome/requests"
 
   lifecycle {

--- a/terraform/shared/ecr_permissions.tf
+++ b/terraform/shared/ecr_permissions.tf
@@ -39,30 +39,3 @@ resource "aws_ecr_repository_policy" "catalogue_access_policy" {
   repository = "uk.ac.wellcome/${local.service_repositories[count.index]}"
   policy     = data.aws_iam_policy_document.allow_catalogue_access.json
 }
-
-# Allow the identity account to read requests ECR image
-
-data "aws_iam_policy_document" "allow_identity_access" {
-  statement {
-    principals {
-      identifiers = [
-        "arn:aws:iam::770700576653:root"
-      ]
-
-      type = "AWS"
-    }
-
-    actions = [
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "ecr:BatchCheckLayerAvailability",
-    ]
-  }
-}
-
-resource "aws_ecr_repository_policy" "identity_access_policy" {
-  count      = length(local.service_repositories)
-  repository = "uk.ac.wellcome/requests"
-  policy     = data.aws_iam_policy_document.allow_identity_access.json
-}
-


### PR DESCRIPTION
Reverts wellcomecollection/catalogue-api#253

I think we'll carry on doing this and enforce buildkite access using CODEOWNERS as suggested by @alexwlchan.

Note: I'll make sure TF is happy before merging this.