### PR TITLE
Inline a single-use fixture from ApiTestBase

### DIFF
--- a/search/src/test/scala/weco/api/search/ApiTestBase.scala
+++ b/search/src/test/scala/weco/api/search/ApiTestBase.scala
@@ -1,12 +1,9 @@
 package weco.api.search
 
-import com.sksamuel.elastic4s.{ElasticDsl, Index}
-import com.sksamuel.elastic4s.ElasticDsl._
 import org.scalatest.Assertion
-import weco.fixtures.{fixture, Fixture, RandomGenerators}
 import weco.api.search.fixtures.ApiFixture
 
-trait ApiTestBase extends ApiFixture with RandomGenerators {
+trait ApiTestBase extends ApiFixture {
   val publicRootUri = "https://api-testing.local/catalogue/v2"
 
   // This is the path relative to which requests are made on the host,
@@ -68,20 +65,6 @@ trait ApiTestBase extends ApiFixture with RandomGenerators {
       "label": "Gone",
       "description": "This work has been deleted"
     }"""
-
-  def withEmptyIndex[R]: Fixture[Index, R] =
-    fixture[Index, R](
-      create = {
-        val index = createIndex
-        elasticClient
-          .execute {
-            ElasticDsl.createIndex(index.name)
-          }
-        eventuallyIndexExists(index)
-        index
-      },
-      destroy = eventuallyDeleteIndex
-    )
 
   def assertIsBadRequest(path: String, description: String): Assertion =
     withWorksApi {

--- a/search/src/test/scala/weco/api/search/works/WorksErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksErrorsTest.scala
@@ -1,6 +1,7 @@
 package weco.api.search.works
 
 import org.scalatest.Assertion
+import weco.elasticsearch.IndexConfig
 
 class WorksErrorsTest extends ApiWorksTestBase {
 
@@ -299,7 +300,7 @@ class WorksErrorsTest extends ApiWorksTestBase {
     // to sort on.  Trying to query this index of these will trigger one such exception!
     withWorksApi {
       case (_, routes) =>
-        withEmptyIndex { index =>
+        withLocalElasticsearchIndex(config = IndexConfig.empty) { index =>
           val path = s"$rootPath/works?_index=${index.name}"
           assertJsonResponse(routes, path)(
             Status.InternalServerError ->


### PR DESCRIPTION
This will allow us to make `eventuallyDeleteIndex` private in scala-libs.