### PR TITLE
remove unused decoders from rank

### DIFF
--- a/rank/services/api.ts
+++ b/rank/services/api.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import { Decoder } from '../types/decoder'
+import { Decoder } from './decoder'
 
 export function ok(res: NextApiResponse, content: unknown): void {
   res.statusCode = 200

--- a/rank/services/decoder.ts
+++ b/rank/services/decoder.ts
@@ -1,21 +1,9 @@
-import { Env, Namespace, isEnv, isNamespace } from '../types/searchTemplate'
-
 import { ParsedUrlQuery } from 'querystring'
 
-type QueryValue = ParsedUrlQuery[keyof ParsedUrlQuery]
+export type Decoder<Props> = (q: ParsedUrlQuery) => Props
 
 export function decodeString(q: ParsedUrlQuery, key: string): string {
   const val = q[key]
   if (!val) throw Error(`Missing value for ${key}`)
   return val.toString()
-}
-
-export function decodeNamespace(v: QueryValue): Namespace {
-  if (!isNamespace(v)) throw Error(`${v} is not a valid namespace`)
-  return v
-}
-
-export function decodeEnv(v: QueryValue): Env {
-  if (!isEnv(v)) throw Error(`${v} is not a valid Env`)
-  return v
 }

--- a/rank/services/search.ts
+++ b/rank/services/search.ts
@@ -1,6 +1,6 @@
 import { Env, Index } from '../types/searchTemplate'
 
-import { Decoder } from '../types/decoder'
+import { Decoder } from './decoder'
 import { ParsedUrlQuery } from 'querystring'
 import { SearchResponse } from '../types/elasticsearch'
 import { decodeString } from './decoder'

--- a/rank/services/test.ts
+++ b/rank/services/test.ts
@@ -1,7 +1,7 @@
 import { Env, Index, SearchTemplate } from '../types/searchTemplate'
 import { TestCase, TestResult } from '../types/test'
 
-import { Decoder } from '../types/decoder'
+import { Decoder } from './decoder'
 import { ParsedUrlQuery } from 'querystring'
 import { RankEvalResponse } from '../types/elasticsearch'
 import { decodeString } from './decoder'

--- a/rank/types/decoder.ts
+++ b/rank/types/decoder.ts
@@ -1,3 +1,0 @@
-import { ParsedUrlQuery } from 'querystring'
-
-export type Decoder<Props> = (q: ParsedUrlQuery) => Props

--- a/rank/types/searchTemplate.ts
+++ b/rank/types/searchTemplate.ts
@@ -1,14 +1,8 @@
 export const envs = ['remote', 'local'] as const
 export type Env = typeof envs[number]
-export function isEnv(v: any): v is Env {
-  return v && envs.includes(v.toString())
-}
 
 export const namespaces = ['works', 'images'] as const
 export type Namespace = typeof namespaces[number]
-export function isNamespace(v: any): v is Namespace {
-  return v && namespaces.includes(v.toString())
-}
 
 export type Query = string | unknown
 export type Index = string


### PR DESCRIPTION
Continuing the rank cleanup in bite-sized pieces

The app no longer uses `decodeNamespace`, `decodeEnv`, `isNamespace`, or `isEnv`. We should prob strip them out of the codebase