### PR TITLE
rename searchtemplates' .string property .id

### DIFF
--- a/rank/pages/dev.tsx
+++ b/rank/pages/dev.tsx
@@ -32,7 +32,7 @@ export const Dev: NextPage<Props> = ({ searchTemplates }) => {
             <H3>{namespace}</H3>
             <ol key={namespace} className="list-decimal list-inside ml-5">
               {namespacedTemplates.map((template) => {
-                return <li key={template.string}>{template.string}</li>
+                return <li key={template.id}>{template.id}</li>
               })}
             </ol>
           </div>

--- a/rank/services/test.ts
+++ b/rank/services/test.ts
@@ -36,7 +36,7 @@ async function service({ env, index, testId }: Props): Promise<TestResult> {
   const requests = cases.map((testCase: TestCase) => {
     return {
       id: testCase.query,
-      template_id: template.string,
+      template_id: template.id,
       params: {
         query: testCase.query,
       },
@@ -57,7 +57,7 @@ async function service({ env, index, testId }: Props): Promise<TestResult> {
       metric,
       templates: [
         {
-          id: template.string,
+          id: template.id,
           template: { source: { query: template.query } },
         },
       ],

--- a/rank/types/searchTemplate.ts
+++ b/rank/types/searchTemplate.ts
@@ -19,14 +19,14 @@ export class SearchTemplate {
   namespace: Namespace
   env: Env
   query: Query
-  string: SearchTemplateString
+  id: SearchTemplateString
 
   constructor(env: Env, index: Index, query: Query) {
     this.env = env
     this.index = index
     this.query = query
     this.namespace = getNamespaceFromIndexName(index)
-    this.string = `${this.env}/${this.index}`
+    this.id = `${this.env}/${this.index}`
   }
 }
 


### PR DESCRIPTION
in the absence of a `toString()` fix, `id` is a much better name than `string`