### PR TITLE
Fix reading secrets in the snapshot generator

### DIFF
--- a/common/display/src/main/scala/weco/catalogue/display_model/ElasticConfig.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/ElasticConfig.scala
@@ -12,11 +12,17 @@ case class ElasticConfig(
 object ElasticConfig {
   // We use this to share config across API applications
   // i.e. The API and the snapshot generator.
-  val indexDate = "2021-08-16a"
+  //
+  // We sometimes append a suffix to the index names (e.g. 2001-01-01a)
+  // if we've had to create a new index attached to an existing pipeline.
+  // This can occur if cross-cluster replication breaks between the
+  // pipeline and API clusters.
+  val pipelineDate = "2021-08-16"
+  val suffix = "a"
 
   def apply(): ElasticConfig =
     ElasticConfig(
-      worksIndex = Index(s"works-indexed-$indexDate"),
-      imagesIndex = Index(s"images-indexed-$indexDate")
+      worksIndex = Index(s"works-indexed-$pipelineDate$suffix"),
+      imagesIndex = Index(s"images-indexed-$pipelineDate$suffix")
     )
 }

--- a/internal_model_tool/common.py
+++ b/internal_model_tool/common.py
@@ -25,8 +25,9 @@ def get_local_date():
     )
     config_text = config_file.read()
     config_file.close()
-    date = re.findall('val indexDate = "(.*)"', config_text)[0]
-    return date
+    date = re.findall('val pipelineDate = "(.*)"', config_text)[0]
+    suffix = re.findall('val suffix = "(.*)"', config_text)[0]
+    return date + suffix
 
 
 def get_remote_latest_internal_model(session, date):

--- a/items/src/main/scala/weco/api/items/Main.scala
+++ b/items/src/main/scala/weco/api/items/Main.scala
@@ -54,7 +54,7 @@ object Main extends WellcomeTypesafeApp {
     val router = new ItemsApi(
       itemUpdateService = itemUpdateService,
       workLookup = WorkLookup(elasticClient),
-      index = ElasticConfig.apply().worksIndex
+      index = elasticConfig.worksIndex
     )
 
     val appName = "ItemsApi"

--- a/items/src/main/scala/weco/api/items/Main.scala
+++ b/items/src/main/scala/weco/api/items/Main.scala
@@ -14,7 +14,7 @@ import weco.monitoring.typesafe.CloudWatchBuilder
 import weco.api.search.models.{ApiConfig, CheckModel}
 import weco.typesafe.WellcomeTypesafeApp
 import weco.typesafe.config.builders.AkkaBuilder
-import weco.catalogue.display_model.ElasticConfig
+import weco.catalogue.display_model.ApiClusterElasticConfig
 import weco.http.WellcomeHttpApp
 import weco.http.monitoring.HttpMetrics
 import weco.sierra.http.SierraSource
@@ -35,7 +35,7 @@ object Main extends WellcomeTypesafeApp {
     implicit val apiConfig: ApiConfig = ApiConfig.build(config)
 
     val elasticClient = ElasticBuilder.buildElasticClient(config)
-    val elasticConfig = ElasticConfig()
+    val elasticConfig = ApiClusterElasticConfig()
 
     CheckModel.checkModel(elasticConfig.worksIndex.name)(elasticClient)
 

--- a/requests/src/main/scala/weco/api/requests/Main.scala
+++ b/requests/src/main/scala/weco/api/requests/Main.scala
@@ -14,7 +14,7 @@ import weco.monitoring.typesafe.CloudWatchBuilder
 import weco.api.search.models.{ApiConfig, CheckModel}
 import weco.typesafe.WellcomeTypesafeApp
 import weco.typesafe.config.builders.AkkaBuilder
-import weco.catalogue.display_model.ElasticConfig
+import weco.catalogue.display_model.ApiClusterElasticConfig
 import weco.http.WellcomeHttpApp
 import weco.http.monitoring.HttpMetrics
 import weco.sierra.typesafe.SierraOauthHttpClientBuilder
@@ -35,7 +35,7 @@ object Main extends WellcomeTypesafeApp {
     implicit val apiConfig: ApiConfig = ApiConfig.build(config)
 
     val elasticClient = ElasticBuilder.buildElasticClient(config)
-    val elasticConfig = ElasticConfig()
+    val elasticConfig = ApiClusterElasticConfig()
 
     CheckModel.checkModel(elasticConfig.worksIndex.name)(elasticClient)
 

--- a/search/src/main/scala/weco/api/search/Main.scala
+++ b/search/src/main/scala/weco/api/search/Main.scala
@@ -8,7 +8,7 @@ import weco.api.search.models.{ApiConfig, CheckModel, QueryConfig}
 import weco.api.search.swagger.SwaggerDocs
 import weco.typesafe.WellcomeTypesafeApp
 import weco.typesafe.config.builders.AkkaBuilder
-import weco.catalogue.display_model.ElasticConfig
+import weco.catalogue.display_model.ApiClusterElasticConfig
 import weco.http.WellcomeHttpApp
 import weco.http.monitoring.HttpMetrics
 import weco.http.typesafe.HTTPServerBuilder
@@ -29,7 +29,7 @@ object Main extends WellcomeTypesafeApp {
     implicit val apiConfig: ApiConfig = ApiConfig.build(config)
 
     val elasticClient = ElasticBuilder.buildElasticClient(config)
-    val elasticConfig = ElasticConfig()
+    val elasticConfig = ApiClusterElasticConfig()
 
     CheckModel.checkModel(elasticConfig.worksIndex.name)(elasticClient)
     CheckModel.checkModel(elasticConfig.imagesIndex.name)(elasticClient)

--- a/search/src/main/scala/weco/api/search/SearchApi.scala
+++ b/search/src/main/scala/weco/api/search/SearchApi.scala
@@ -150,8 +150,8 @@ class SearchApi(
     get {
       complete(
         Map(
-          "worksIndex" -> ElasticConfig().worksIndex.name,
-          "imagesIndex" -> ElasticConfig().imagesIndex.name
+          "worksIndex" -> elasticConfig.worksIndex.name,
+          "imagesIndex" -> elasticConfig.imagesIndex.name
         )
       )
     }

--- a/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/Main.scala
+++ b/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/Main.scala
@@ -10,7 +10,10 @@ import weco.api.snapshot_generator.services.{
   SnapshotGeneratorWorkerService,
   SnapshotService
 }
-import weco.catalogue.display_model.ElasticConfig
+import weco.catalogue.display_model.{
+  ElasticConfig,
+  PipelineClusterElasticConfig
+}
 import weco.messaging.sns.NotificationMessage
 import weco.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import weco.storage.typesafe.S3Builder
@@ -26,8 +29,10 @@ object Main extends WellcomeTypesafeApp {
     implicit val executionContext: ExecutionContext =
       AkkaBuilder.buildExecutionContext()
 
+    val elasticConfig = PipelineClusterElasticConfig()
+
     val snapshotConfig = SnapshotGeneratorConfig(
-      index = ElasticConfig().worksIndex,
+      index = elasticConfig.worksIndex,
       bulkSize = config.getIntOption("es.bulk-size").getOrElse(1000)
     )
 

--- a/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/Main.scala
+++ b/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/Main.scala
@@ -10,10 +10,7 @@ import weco.api.snapshot_generator.services.{
   SnapshotGeneratorWorkerService,
   SnapshotService
 }
-import weco.catalogue.display_model.{
-  ElasticConfig,
-  PipelineClusterElasticConfig
-}
+import weco.catalogue.display_model.PipelineClusterElasticConfig
 import weco.messaging.sns.NotificationMessage
 import weco.messaging.typesafe.{SNSBuilder, SQSBuilder}
 import weco.storage.typesafe.S3Builder

--- a/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/config/builders/SnapshotGeneratorElasticClientBuilder.scala
+++ b/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/config/builders/SnapshotGeneratorElasticClientBuilder.scala
@@ -20,7 +20,7 @@ object SnapshotGeneratorElasticClientBuilder {
     implicit val secretsClient: SecretsManagerClient =
       SecretsManagerClient.builder().build()
 
-    val pipelineDate = ElasticConfig.indexDate
+    val pipelineDate = ElasticConfig.pipelineDate
 
     val hostname = getSecretString(
       s"elasticsearch/pipeline_storage_$pipelineDate/private_host"

--- a/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/config/builders/SnapshotGeneratorElasticClientBuilder.scala
+++ b/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/config/builders/SnapshotGeneratorElasticClientBuilder.scala
@@ -3,7 +3,7 @@ package weco.api.snapshot_generator.config.builders
 import com.sksamuel.elastic4s.ElasticClient
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest
-import weco.catalogue.display_model.ElasticConfig
+import weco.catalogue.display_model.PipelineClusterElasticConfig
 import weco.elasticsearch.ElasticClientBuilder
 
 object SnapshotGeneratorElasticClientBuilder {
@@ -20,7 +20,7 @@ object SnapshotGeneratorElasticClientBuilder {
     implicit val secretsClient: SecretsManagerClient =
       SecretsManagerClient.builder().build()
 
-    val pipelineDate = ElasticConfig.pipelineDate
+    val pipelineDate = PipelineClusterElasticConfig.pipelineDate
 
     val hostname = getSecretString(
       s"elasticsearch/pipeline_storage_$pipelineDate/private_host"


### PR DESCRIPTION
The snapshot generator reads from the pipeline cluster, but the secrets for this cluster aren't in a fixed location (because we might have multiple pipeline clusters at once). Instead, these secrets are identified by the pipeline date, e.g.

```
elasticsearch/pipeline_storage_2021-08-16/es_password
```

so rather than passing secrets via ECS, the snapshot generator looks at the index name, works out the secret ID, then gets the value using the SecretsManager SDK.

Unfortunately, when the index name isn't a date (e.g. `works-indexed-2021-08-16a`), as it currently is now, the snapshot generator gets confused about what the pipeline cluster is called, and is trying to get secrets like:

```
elasticsearch/pipeline_storage_2021-08-16a/es_password
```

That secret doesn't exist, so it fails to start.

For extra complications, the API and pipeline clusters may have different names – say, if we've configured CCR.

This patch makes a couple of changes:

- it splits the "pipeline date" and "suffix", so the snapshot generator can extract exactly what it wants
- it splits ElasticConfig into ApiConfig and PipelineConfig, so applications can be explicit about which cluster they expect to use (and accordingly, which index they want)