### PR TITLE
Bump to Elasticsearch v7.14.2

### DIFF
--- a/terraform/shared/elastic.tf
+++ b/terraform/shared/elastic.tf
@@ -2,7 +2,7 @@ resource "ec_deployment" "catalogue_api" {
   name = "catalogue-api"
 
   region                 = "eu-west-1"
-  version                = "7.14.1"
+  version                = "7.14.2"
   deployment_template_id = "aws-io-optimized-v2"
 
   traffic_filter = local.catalogue_ec_traffic_filter


### PR DESCRIPTION
This is the latest patch version, which we need to bump so we can create a new cluster with the same version for the 2021-09-23 pipeline.