### PR TITLE
Return a 5xx if the default Elasticsearch index doesn't exist

### DIFF
--- a/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchErrorHandler.scala
+++ b/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchErrorHandler.scala
@@ -64,7 +64,7 @@ object ElasticsearchErrorHandler extends Logging {
   //
   // If a user doesn't specify an index, e.g. /works, and the default index doesn't exist,
   // we want to return a 500 error -- something is wrong with our defaults.
-  implicit class RouteOps[T](result: Either[ElasticsearchError, T]) {
+  implicit class ErrorRouteOps[T](result: Either[ElasticsearchError, T]) {
     def mapNotFound(usingDefaultIndex: Boolean): Either[ElasticsearchError, T] =
       result match {
         case Left(IndexNotFoundError(elasticError)) if usingDefaultIndex =>

--- a/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchErrorHandler.scala
+++ b/common/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchErrorHandler.scala
@@ -58,22 +58,6 @@ object ElasticsearchErrorHandler extends Logging {
         serverError("Unknown error", e)
     }
 
-  // If a user specifies an index explicitly, e.g. /works?_index=my-great-index, and
-  // that index doesn't exist, we want to return a 404 error -- they've asked for
-  // something that can't be found.
-  //
-  // If a user doesn't specify an index, e.g. /works, and the default index doesn't exist,
-  // we want to return a 500 error -- something is wrong with our defaults.
-  implicit class ErrorRouteOps[T](result: Either[ElasticsearchError, T]) {
-    def mapNotFound(usingDefaultIndex: Boolean): Either[ElasticsearchError, T] =
-      result match {
-        case Left(IndexNotFoundError(elasticError)) if usingDefaultIndex =>
-          Left(UnknownError(elasticError))
-
-        case other => other
-      }
-  }
-
   private def userError(
     message: String,
     elasticError: ElasticError

--- a/common/search/src/main/scala/weco/api/search/rest/CustomDirectives.scala
+++ b/common/search/src/main/scala/weco/api/search/rest/CustomDirectives.scala
@@ -25,7 +25,7 @@ trait CustomDirectives extends FutureDirectives {
         )
     }
 
-  def elasticError(documentType: String, err: ElasticsearchError, usingDefaultIndex: Boolean): Route = {
+  def elasticError(documentType: String, err: ElasticsearchError, usingDefaultIndex: Boolean = true): Route = {
     val displayError =
       err match {
 

--- a/common/search/src/main/scala/weco/api/search/rest/CustomDirectives.scala
+++ b/common/search/src/main/scala/weco/api/search/rest/CustomDirectives.scala
@@ -25,7 +25,7 @@ trait CustomDirectives extends FutureDirectives {
         )
     }
 
-  def elasticError(documentType: String, err: ElasticsearchError, usingDefaultIndex: Boolean = true): Route = {
+  def elasticError(documentType: String, err: ElasticsearchError, usingUserSpecifiedIndex: Boolean = false): Route = {
     val displayError =
       err match {
 
@@ -35,7 +35,7 @@ trait CustomDirectives extends FutureDirectives {
         //
         // If a user doesn't specify an index, e.g. /works, and the default index doesn't exist,
         // we want to return a 500 error -- something is wrong with our defaults.
-        case IndexNotFoundError(underlying) if usingDefaultIndex =>
+        case IndexNotFoundError(underlying) if !usingUserSpecifiedIndex =>
           ElasticsearchErrorHandler.buildDisplayError(documentType, e = UnknownError(underlying))
 
         case otherError =>

--- a/common/search/src/main/scala/weco/api/search/rest/CustomDirectives.scala
+++ b/common/search/src/main/scala/weco/api/search/rest/CustomDirectives.scala
@@ -2,7 +2,12 @@ package weco.api.search.rest
 
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.server.{Directive, Route}
-import weco.api.search.elasticsearch.{ElasticsearchError, ElasticsearchErrorHandler, IndexNotFoundError, UnknownError}
+import weco.api.search.elasticsearch.{
+  ElasticsearchError,
+  ElasticsearchErrorHandler,
+  IndexNotFoundError,
+  UnknownError
+}
 import weco.api.search.models.ApiConfig
 import weco.http.FutureDirectives
 
@@ -25,7 +30,11 @@ trait CustomDirectives extends FutureDirectives {
         )
     }
 
-  def elasticError(documentType: String, err: ElasticsearchError, usingUserSpecifiedIndex: Boolean = false): Route = {
+  def elasticError(
+    documentType: String,
+    err: ElasticsearchError,
+    usingUserSpecifiedIndex: Boolean = false
+  ): Route = {
     val displayError =
       err match {
 
@@ -36,10 +45,16 @@ trait CustomDirectives extends FutureDirectives {
         // If a user doesn't specify an index, e.g. /works, and the default index doesn't exist,
         // we want to return a 500 error -- something is wrong with our defaults.
         case IndexNotFoundError(underlying) if !usingUserSpecifiedIndex =>
-          ElasticsearchErrorHandler.buildDisplayError(documentType, e = UnknownError(underlying))
+          ElasticsearchErrorHandler.buildDisplayError(
+            documentType,
+            e = UnknownError(underlying)
+          )
 
         case otherError =>
-          ElasticsearchErrorHandler.buildDisplayError(documentType, e = otherError)
+          ElasticsearchErrorHandler.buildDisplayError(
+            documentType,
+            e = otherError
+          )
       }
 
     complete(displayError.httpStatus -> displayError)

--- a/common/search/src/main/scala/weco/api/search/rest/SingleWorkDirectives.scala
+++ b/common/search/src/main/scala/weco/api/search/rest/SingleWorkDirectives.scala
@@ -15,7 +15,8 @@ trait SingleWorkDirectives extends CustomDirectives {
     work: Future[Either[ElasticsearchError, Work[WorkState.Indexed]]]
   ) {
     def mapVisible(
-      f: Work.Visible[WorkState.Indexed] => Future[Route]
+      f: Work.Visible[WorkState.Indexed] => Future[Route],
+      usingDefaultIndex: Boolean
     ): Future[Route] =
       work.map {
         case Right(work: Work.Visible[Indexed]) =>
@@ -26,7 +27,12 @@ trait SingleWorkDirectives extends CustomDirectives {
           gone("This work has been deleted")
         case Right(_: Work.Deleted[Indexed]) =>
           gone("This work has been deleted")
-        case Left(err) => elasticError("Work", err)
+        case Left(err) =>
+          elasticError(
+            documentType = "Work",
+            err = err,
+            usingDefaultIndex = usingDefaultIndex
+          )
       }
   }
 

--- a/common/search/src/main/scala/weco/api/search/rest/SingleWorkDirectives.scala
+++ b/common/search/src/main/scala/weco/api/search/rest/SingleWorkDirectives.scala
@@ -16,7 +16,7 @@ trait SingleWorkDirectives extends CustomDirectives {
   ) {
     def mapVisible(
       f: Work.Visible[WorkState.Indexed] => Future[Route],
-      usingDefaultIndex: Boolean
+      usingUserSpecifiedIndex: Boolean = false
     ): Future[Route] =
       work.map {
         case Right(work: Work.Visible[Indexed]) =>
@@ -31,7 +31,7 @@ trait SingleWorkDirectives extends CustomDirectives {
           elasticError(
             documentType = "Work",
             err = err,
-            usingDefaultIndex = usingDefaultIndex
+            usingUserSpecifiedIndex = usingUserSpecifiedIndex
           )
       }
   }

--- a/requests/src/test/scala/weco/api/requests/RequestsErrorsTest.scala
+++ b/requests/src/test/scala/weco/api/requests/RequestsErrorsTest.scala
@@ -7,7 +7,12 @@ import weco.api.requests.fixtures.RequestsApiFixture
 import weco.catalogue.internal_model.generators.IdentifiersGenerators
 import weco.elasticsearch.test.fixtures.ElasticsearchFixtures
 
-class RequestsErrorsTest extends AnyFunSpec with Matchers with RequestsApiFixture with ElasticsearchFixtures with IdentifiersGenerators {
+class RequestsErrorsTest
+    extends AnyFunSpec
+    with Matchers
+    with RequestsApiFixture
+    with ElasticsearchFixtures
+    with IdentifiersGenerators {
   it("returns a 500 error if the catalogue index doesn't exist") {
     withRequestsApi(elasticClient, index = createIndex) { _ =>
       val path = "/users/1234567/item-requests"

--- a/requests/src/test/scala/weco/api/requests/RequestsErrorsTest.scala
+++ b/requests/src/test/scala/weco/api/requests/RequestsErrorsTest.scala
@@ -1,0 +1,29 @@
+package weco.api.requests
+
+import akka.http.scaladsl.model.StatusCodes
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import weco.api.requests.fixtures.RequestsApiFixture
+import weco.catalogue.internal_model.generators.IdentifiersGenerators
+import weco.elasticsearch.test.fixtures.ElasticsearchFixtures
+
+class RequestsErrorsTest extends AnyFunSpec with Matchers with RequestsApiFixture with ElasticsearchFixtures with IdentifiersGenerators {
+  it("returns a 500 error if the catalogue index doesn't exist") {
+    withRequestsApi(elasticClient, index = createIndex) { _ =>
+      val path = "/users/1234567/item-requests"
+      val entity = createJsonHttpEntityWith(
+        s"""
+           |{
+           |  "itemId": "$createCanonicalId",
+           |  "workId": "$createCanonicalId",
+           |  "type": "ItemRequest"
+           |}
+           |""".stripMargin
+      )
+
+      whenPostRequestReady(path, entity) {
+        assertIsDisplayError(_, statusCode = StatusCodes.InternalServerError)
+      }
+    }
+  }
+}

--- a/search/src/main/scala/weco/api/search/models/SearchOptions.scala
+++ b/search/src/main/scala/weco/api/search/models/SearchOptions.scala
@@ -1,6 +1,5 @@
 package weco.api.search.models
 
-import weco.catalogue.display_model.models.WorkAggregationRequest
 import weco.catalogue.display_model.models.{
   ImageAggregationRequest,
   SortRequest,

--- a/search/src/main/scala/weco/api/search/rest/ImagesController.scala
+++ b/search/src/main/scala/weco/api/search/rest/ImagesController.scala
@@ -66,7 +66,7 @@ class ImagesController(
                 elasticError(
                   documentType = "Image",
                   err = err,
-                  usingDefaultIndex = userSpecifiedIndex.isEmpty
+                  usingUserSpecifiedIndex = userSpecifiedIndex.isDefined
                 )
               )
             }
@@ -90,7 +90,7 @@ class ImagesController(
                 elasticError(
                   documentType = "Image",
                   err = err,
-                  usingDefaultIndex = userSpecifiedIndex.isEmpty
+                  usingUserSpecifiedIndex = userSpecifiedIndex.isDefined
                 )
 
               case Right(resultList) =>

--- a/search/src/main/scala/weco/api/search/rest/ImagesController.scala
+++ b/search/src/main/scala/weco/api/search/rest/ImagesController.scala
@@ -62,13 +62,14 @@ class ImagesController(
                     )
                   }
 
-              case Left(err) => Future.successful(
-                elasticError(
-                  documentType = "Image",
-                  err = err,
-                  usingUserSpecifiedIndex = userSpecifiedIndex.isDefined
+              case Left(err) =>
+                Future.successful(
+                  elasticError(
+                    documentType = "Image",
+                    err = err,
+                    usingUserSpecifiedIndex = userSpecifiedIndex.isDefined
+                  )
                 )
-              )
             }
         }
       }

--- a/search/src/main/scala/weco/api/search/rest/WorksController.scala
+++ b/search/src/main/scala/weco/api/search/rest/WorksController.scala
@@ -39,7 +39,7 @@ class WorksController(
                 elasticError(
                   documentType = "Work",
                   err = err,
-                  usingDefaultIndex = userSpecifiedIndex.isEmpty
+                  usingUserSpecifiedIndex = userSpecifiedIndex.isDefined
                 )
 
               case Right(resultList) =>
@@ -74,7 +74,7 @@ class WorksController(
                 Future.successful(
                   complete(DisplayWork(work, includes))
                 ),
-              usingDefaultIndex = userSpecifiedIndex.isEmpty
+              usingUserSpecifiedIndex = userSpecifiedIndex.isDefined
             )
         }
       }

--- a/search/src/test/scala/weco/api/search/fixtures/ApiFixture.scala
+++ b/search/src/test/scala/weco/api/search/fixtures/ApiFixture.scala
@@ -36,7 +36,7 @@ trait ApiFixture extends AnyFunSpec with ScalatestRouteTest with IndexFixtures {
   // of times we have to create it.
   lazy val swaggerDocs = new SwaggerDocs(apiConfig)
 
-  private def withRouter[R](
+  def withRouter[R](
     elasticConfig: ElasticConfig
   )(testWith: TestWith[Route, R]): R = {
     val router = new SearchApi(

--- a/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
@@ -4,7 +4,9 @@ import org.scalatest.Assertion
 import org.scalatest.prop.TableDrivenPropertyChecks
 import weco.catalogue.display_model.ElasticConfig
 
-class ImagesErrorsTest extends ApiImagesTestBase with TableDrivenPropertyChecks {
+class ImagesErrorsTest
+    extends ApiImagesTestBase
+    with TableDrivenPropertyChecks {
   describe("returns a 404 for missing resources") {
     it("looking up an image that doesn't exist") {
       val id = "blahblah"
@@ -16,19 +18,20 @@ class ImagesErrorsTest extends ApiImagesTestBase with TableDrivenPropertyChecks 
   }
 
   it("returns a 404 error if the user asks for a non-existent index") {
-    withImagesApi { case (_, routes) =>
-      val indexName = createIndexName
+    withImagesApi {
+      case (_, routes) =>
+        val indexName = createIndexName
 
-      val testPaths = Table(
-        "path",
-        s"$rootPath/images?_index=$indexName",
-        s"$rootPath/images?_index=$indexName&query=fish",
-        s"$rootPath/images/$createCanonicalId?_index=$indexName"
-      )
+        val testPaths = Table(
+          "path",
+          s"$rootPath/images?_index=$indexName",
+          s"$rootPath/images?_index=$indexName&query=fish",
+          s"$rootPath/images/$createCanonicalId?_index=$indexName"
+        )
 
-      forAll(testPaths) { path =>
-        assertIsNotFound(path, description = s"There is no index $indexName")
-      }
+        forAll(testPaths) { path =>
+          assertIsNotFound(path, description = s"There is no index $indexName")
+        }
     }
   }
 

--- a/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
@@ -1,8 +1,10 @@
 package weco.api.search.images
 
 import org.scalatest.Assertion
+import org.scalatest.prop.TableDrivenPropertyChecks
+import weco.catalogue.display_model.ElasticConfig
 
-class ImagesErrorsTest extends ApiImagesTestBase {
+class ImagesErrorsTest extends ApiImagesTestBase with TableDrivenPropertyChecks {
   describe("returns a 404 for missing resources") {
     it("looking up an image that doesn't exist") {
       val id = "blahblah"
@@ -10,6 +12,53 @@ class ImagesErrorsTest extends ApiImagesTestBase {
         s"$rootPath/images/$id",
         description = s"Image not found for identifier $id"
       )
+    }
+  }
+
+  it("returns a 404 error if the user asks for a non-existent index") {
+    withImagesApi { case (_, routes) =>
+      val indexName = createIndexName
+
+      val testPaths = Table(
+        "path",
+        s"$rootPath/images?_index=$indexName",
+        s"$rootPath/images?_index=$indexName&query=fish",
+        s"$rootPath/images/$createCanonicalId?_index=$indexName"
+      )
+
+      forAll(testPaths) { path =>
+        assertIsNotFound(path, description = s"There is no index $indexName")
+      }
+    }
+  }
+
+  it("returns a 500 error if the default index doesn't exist") {
+    val elasticConfig = ElasticConfig(
+      worksIndex = createIndex,
+      imagesIndex = createIndex
+    )
+
+    val testPaths = Table(
+      "path",
+      s"$rootPath/images",
+      s"$rootPath/images?query=fish",
+      s"$rootPath/images/$createCanonicalId"
+    )
+
+    withRouter(elasticConfig) { routes =>
+      forAll(testPaths) { path =>
+        assertJsonResponse(routes, path)(
+          Status.InternalServerError ->
+            s"""
+               |{
+               |  "type": "Error",
+               |  "errorType": "http",
+               |  "httpStatus": 500,
+               |  "label": "Internal Server Error"
+               |}
+            """.stripMargin
+        )
+      }
     }
   }
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5316

## The context

In the catalogue API, we let users specify an index on their requests by passing the `_index` parameter, e.g.

```
GET /works?_index=my-great-index
```

This is useful for testing changes in indexes that haven't yet gone out, e.g. I think it's how we select the "tei-on" index for the TEI toggle.

It's possible to select an index that doesn't exist with this parameter, so like a well-behaved HTTP API we return a 404 Not Found if we go to query an index and the index doesn't exist.

## The problem

We return a 404 Not Found _even if the user didn't specify an index_. That is, a request to

```
GET /works
```

would return a 404 if the default index is missing. This is wrong – if the default index is missing, that's a problem in the server that we need to fix.

It also means these errors don't get caught by our 5xx alerting. The requests API was serving 404s for almost 24 hours before we noticed, because we'd deleted the underlying Elasticsearch index.

## The solution

We return a 500 Internal Server Error if the index is missing **unless** the user has explicitly told us which index to use.

That means we'll continue to return 404s when somebody asks for a missing index, but if the default index is missing we'll get a 5xx which will be easier to spot in our alerting.