### PR TITLE
Deploy the requests API from the catalogue-api repo

### DIFF
--- a/.buildkite/pipeline.deploy-prod.yml
+++ b/.buildkite/pipeline.deploy-prod.yml
@@ -36,6 +36,23 @@ steps:
               "--confirmation-wait-for", 3600 ]
     agents:
       queue: nano
+  - label: "Deploy (requests prod)"
+    branches: "main"
+    plugins:
+      - docker#v3.5.0:
+          image: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/weco-deploy:5.6
+          workdir: /repo
+          mount-ssh-agent: true
+          command: [
+              "--project-id", "requests_api",
+              "--confirm",
+              "release-deploy",
+              "--from-label", "ref.$BUILDKITE_COMMIT",
+              "--environment-id", "prod",
+              "--description", $BUILDKITE_BUILD_URL,
+              "--confirmation-wait-for", 3600 ]
+    agents:
+      queue: nano
 
   - wait
 

--- a/.buildkite/pipeline.deploy-stage.yml
+++ b/.buildkite/pipeline.deploy-stage.yml
@@ -16,6 +16,23 @@ steps:
               "--confirmation-wait-for", 3600]
     agents:
       queue: nano
+  - label: "Deploy (requests stage)"
+    branches: "main"
+    plugins:
+      - docker#v3.5.0:
+          image: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/weco-deploy:5.6
+          workdir: /repo
+          mount-ssh-agent: true
+          command: [
+              "--project-id", "requests_api",
+              "--confirm",
+              "release-deploy",
+              "--from-label", "ref.$BUILDKITE_COMMIT",
+              "--environment-id", "stage",
+              "--description", $BUILDKITE_BUILD_URL,
+              "--confirmation-wait-for", 3600]
+    agents:
+      queue: nano
 
   - wait
 


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5316

Currently nothing is deploying the requests API automatically; this fixes that.