### PR TITLE
query notes contents, not content

### DIFF
--- a/search/src/test/resources/WorksMultiMatcherQuery.json
+++ b/search/src/test/resources/WorksMultiMatcherQuery.json
@@ -93,7 +93,7 @@
             "data.physicalDescription",
             "data.language.label",
             "data.edition",
-            "data.notes.content",
+            "data.notes.contents",
             "data.lettering"
           ],
           "type": "cross_fields",


### PR DESCRIPTION
This PR should also be used in conjunction with a change to the mapping (separate PR incoming in the pipeline repo)

This change to the query is sufficient to recall the correct documents, but not enough to push them into 1st place every time.

```json
{
    "query": "2599i",
    "description": "Reference number as ID",
    "result": {
        "score": 1,
        "pass": true
    }
},
```
`2599i` has few potential fuzzy matches, so passes the precision test above. 

```json
{
    "query": "2013i",
    "description": "Reference number as ID",
    "result": {
        "score": 0,
        "pass": false
    }
}
```
`2013i` has lots of plausible fuzzy matches in fields which are more heavily boosted than notes (eg titles like `Knowledge at work, 21-28 July 2013 : programme and abstracts / ICHSTM Manchester 2013.`). Even though it's recalled, its low score hides it from users who expect to see it in first position.

We should follow up this PR with another change to treat reference numbers like identifiers (with scores boosted 1000x). See https://github.com/wellcomecollection/platform/issues/5333