### PR TITLE
Extract caller ID from header to be able to serve `/users/me` paths

### DIFF
--- a/requests/src/main/scala/weco/api/requests/RequestsApi.scala
+++ b/requests/src/main/scala/weco/api/requests/RequestsApi.scala
@@ -23,38 +23,54 @@ class RequestsApi(
 ) extends CreateRequest
     with LookupPendingRequests {
   val routes: Route = concat(
-    RequestsApi.withUserId("users" / Segment / "item-requests") { userIdentifier: SierraPatronNumber =>
-      post {
-        entity(as[ItemRequest]) {
-          itemRequest: ItemRequest =>
-            // TODO: We get the work ID as part of the item request, although right now
-            // it's only for future-proofing, in case it's useful later.
-            // Should we query based on the work ID?
-            Try { CanonicalId(itemRequest.itemId) } match {
-              case Success(itemId) =>
-                withFuture {
-                  createRequest(itemId = itemId, patronNumber = userIdentifier)
-                }
+    RequestsApi.withUserId("users" / Segment / "item-requests") {
+      userIdentifier: SierraPatronNumber =>
+        post {
+          entity(as[ItemRequest]) {
+            itemRequest: ItemRequest =>
+              // TODO: We get the work ID as part of the item request, although right now
+              // it's only for future-proofing, in case it's useful later.
+              // Should we query based on the work ID?
+              Try { CanonicalId(itemRequest.itemId) } match {
+                case Success(itemId) =>
+                  withFuture {
+                    createRequest(
+                      itemId = itemId,
+                      patronNumber = userIdentifier
+                    )
+                  }
 
-              case _ =>
-                notFound(s"Item not found for identifier ${itemRequest.itemId}")
-            }
+                case _ =>
+                  notFound(
+                    s"Item not found for identifier ${itemRequest.itemId}"
+                  )
+              }
+          }
+        } ~ get {
+          lookupRequests(userIdentifier)
         }
-      } ~ get {
-        lookupRequests(userIdentifier)
-      }
     }
   )
 }
 
 object RequestsApi extends ErrorDirectives {
-  def withUserId(pathMatcher: PathMatcher[Tuple1[String]]): Directive[Tuple1[SierraPatronNumber]] = pathPrefix(pathMatcher).flatMap { pathId: String =>
-    optionalHeaderValueByName("X-Wellcome-Caller-ID").flatMap { contextId: Option[String] =>
-      (pathId, contextId) match {
-        case ("me", Some(userId)) => provide(SierraPatronNumber(userId))
-        case ("me", None) => complete(StatusCodes.Unauthorized -> DisplayError(StatusCodes.Unauthorized, "Caller attempted to operate on themselves, but request was not authorised"))
-        case (userId, _) => provide(SierraPatronNumber(userId))
+  def withUserId(
+    pathMatcher: PathMatcher[Tuple1[String]]
+  ): Directive[Tuple1[SierraPatronNumber]] = pathPrefix(pathMatcher).flatMap {
+    pathId: String =>
+      optionalHeaderValueByName("X-Wellcome-Caller-ID").flatMap {
+        contextId: Option[String] =>
+          (pathId, contextId) match {
+            case ("me", Some(userId)) => provide(SierraPatronNumber(userId))
+            case ("me", None) =>
+              complete(
+                StatusCodes.Unauthorized -> DisplayError(
+                  StatusCodes.Unauthorized,
+                  "Caller attempted to operate on themselves, but request was not authorised"
+                )
+              )
+            case (userId, _) => provide(SierraPatronNumber(userId))
+          }
       }
-    }
   }
 }

--- a/requests/src/test/scala/weco/api/requests/RequestsApiFeatureTest.scala
+++ b/requests/src/test/scala/weco/api/requests/RequestsApiFeatureTest.scala
@@ -1,14 +1,24 @@
 package weco.api.requests
 
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpMethods, HttpRequest, HttpResponse, StatusCodes}
+import akka.http.scaladsl.model.{
+  ContentTypes,
+  HttpEntity,
+  HttpMethods,
+  HttpRequest,
+  HttpResponse,
+  StatusCodes
+}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.json.utils.JsonAssertions
-import weco.catalogue.internal_model.work.generators.{ItemsGenerators, WorkGenerators}
+import weco.catalogue.internal_model.work.generators.{
+  ItemsGenerators,
+  WorkGenerators
+}
 import weco.api.requests.fixtures.RequestsApiFixture
 import weco.catalogue.internal_model.identifiers.IdentifierType.SierraSystemNumber
 import weco.catalogue.internal_model.identifiers.SourceIdentifier
@@ -26,22 +36,30 @@ class RequestsApiFeatureTest
     with ItemsGenerators
     with WorkGenerators
     with IndexFixtures
-    with SierraIdentifierGenerators with ScalatestRouteTest {
+    with SierraIdentifierGenerators
+    with ScalatestRouteTest {
 
   describe("withUserId directive") {
-    def userIdRoute = RequestsApi.withUserId("a" / Segment / "b")(patron => complete(patron.recordNumber))
+    def userIdRoute =
+      RequestsApi.withUserId("a" / Segment / "b")(
+        patron => complete(patron.recordNumber)
+      )
 
     it("extracts a user ID from a path") {
       Get("/a/1234567/b") ~> userIdRoute ~> check {
         responseAs[String] shouldBe "1234567"
       }
     }
-    it("extracts a user ID from the X-Wellcome-Caller-ID header when the path ID is 'me'") {
+    it(
+      "extracts a user ID from the X-Wellcome-Caller-ID header when the path ID is 'me'"
+    ) {
       Get("/a/me/b").withHeaders(RawHeader("X-Wellcome-Caller-ID", "1234567")) ~> userIdRoute ~> check {
         responseAs[String] shouldBe "1234567"
       }
     }
-    it("rejects as unauthorized if the X-Wellcome-Caller-ID header is not present when the path ID is 'me'") {
+    it(
+      "rejects as unauthorized if the X-Wellcome-Caller-ID header is not present when the path ID is 'me'"
+    ) {
       Get("/a/me/b") ~> userIdRoute ~> check {
         response.status shouldEqual StatusCodes.Unauthorized
       }

--- a/requests/src/test/scala/weco/api/requests/RequestsApiFeatureTest.scala
+++ b/requests/src/test/scala/weco/api/requests/RequestsApiFeatureTest.scala
@@ -1,21 +1,14 @@
 package weco.api.requests
 
-import akka.http.scaladsl.model.{
-  ContentTypes,
-  HttpEntity,
-  HttpMethods,
-  HttpRequest,
-  HttpResponse,
-  StatusCodes
-}
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpMethods, HttpRequest, HttpResponse, StatusCodes}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.json.utils.JsonAssertions
-import weco.catalogue.internal_model.work.generators.{
-  ItemsGenerators,
-  WorkGenerators
-}
+import weco.catalogue.internal_model.work.generators.{ItemsGenerators, WorkGenerators}
 import weco.api.requests.fixtures.RequestsApiFixture
 import weco.catalogue.internal_model.identifiers.IdentifierType.SierraSystemNumber
 import weco.catalogue.internal_model.identifiers.SourceIdentifier
@@ -33,7 +26,27 @@ class RequestsApiFeatureTest
     with ItemsGenerators
     with WorkGenerators
     with IndexFixtures
-    with SierraIdentifierGenerators {
+    with SierraIdentifierGenerators with ScalatestRouteTest {
+
+  describe("withUserId directive") {
+    def userIdRoute = RequestsApi.withUserId("a" / Segment / "b")(patron => complete(patron.recordNumber))
+
+    it("extracts a user ID from a path") {
+      Get("/a/1234567/b") ~> userIdRoute ~> check {
+        responseAs[String] shouldBe "1234567"
+      }
+    }
+    it("extracts a user ID from the X-Wellcome-Caller-ID header when the path ID is 'me'") {
+      Get("/a/me/b").withHeaders(RawHeader("X-Wellcome-Caller-ID", "1234567")) ~> userIdRoute ~> check {
+        responseAs[String] shouldBe "1234567"
+      }
+    }
+    it("rejects as unauthorized if the X-Wellcome-Caller-ID header is not present when the path ID is 'me'") {
+      Get("/a/me/b") ~> userIdRoute ~> check {
+        response.status shouldEqual StatusCodes.Unauthorized
+      }
+    }
+  }
 
   describe("requests") {
     it("provides information about a users' holds") {


### PR DESCRIPTION
This makes the identity API consistent - otherwise, we can use `me` everywhere except for requests.

Depends on https://github.com/wellcomecollection/identity/pull/196 for the header value 