### PR TITLE
Minor improvements to the rank CLI

### DIFF
--- a/rank/__tests__/eval.test.ts
+++ b/rank/__tests__/eval.test.ts
@@ -6,7 +6,7 @@ import {
 import { getTemplates, listIndices } from '../services/search-templates'
 
 import { TestResult } from '../types/test'
-import testService from '../services/test'
+import service from '../services/test'
 import tests from '../data/tests'
 
 global.fetch = require('node-fetch')
@@ -53,7 +53,7 @@ test.each(works)('works.$id', async ({ id }) => {
     (template) => getNamespaceFromIndexName(template.index) === 'works'
   )
 
-  const result = await testService({
+  const result = await service({
     queryEnv: template.queryEnv,
     index: template.index,
     testId: id,
@@ -69,7 +69,7 @@ test.each(images)('images.$id', async ({ id }) => {
     (template) => getNamespaceFromIndexName(template.index) === 'images'
   )
 
-  const result = await testService({
+  const result = await service({
     queryEnv: template.queryEnv,
     index: template.index,
     testId: id,

--- a/rank/__tests__/eval.test.ts
+++ b/rank/__tests__/eval.test.ts
@@ -17,6 +17,8 @@ beforeAll(async () => {
   searchTemplates = await getTemplates()
 })
 
+const queryEnv = process.env.RANK_QUERY_ENVIRONMENT || 'production'
+
 declare global {
   namespace jest {
     interface Matchers<R> {
@@ -50,7 +52,9 @@ expect.extend({
 
 test.each(works)('works.$id', async ({ id }) => {
   const template = searchTemplates.find(
-    (template) => getNamespaceFromIndexName(template.index) === 'works'
+    (template) =>
+      getNamespaceFromIndexName(template.index) === 'works' &&
+        template.queryEnv === queryEnv
   )
 
   const result = await service({
@@ -66,7 +70,9 @@ test.each(works)('works.$id', async ({ id }) => {
 
 test.each(images)('images.$id', async ({ id }) => {
   const template = searchTemplates.find(
-    (template) => getNamespaceFromIndexName(template.index) === 'images'
+    (template) =>
+      getNamespaceFromIndexName(template.index) === 'images' &&
+        template.queryEnv === queryEnv
   )
 
   const result = await service({

--- a/rank/__tests__/eval.test.ts
+++ b/rank/__tests__/eval.test.ts
@@ -1,7 +1,11 @@
+import yargs from 'yargs'
+
 import {
+  QueryEnv,
   SearchTemplate,
   SearchTemplateString,
   getNamespaceFromIndexName,
+  queryEnvs,
 } from '../types/searchTemplate'
 import { getTemplates, listIndices } from '../services/search-templates'
 
@@ -17,7 +21,23 @@ beforeAll(async () => {
   searchTemplates = await getTemplates()
 })
 
-const queryEnv = process.env.RANK_QUERY_ENVIRONMENT || 'production'
+const { queryEnv } = yargs(process.argv)
+  .options({
+    'queryEnv': { type: "string", demandOption: true, choices: queryEnvs }
+  })
+  // Passing .exitProcess(false) means we get helpful error messages
+  // from jest/yargs if the CLI parsing fails.
+  //
+  // Compare:
+  //
+  //      process.exit called with "1"
+  //
+  // and:
+  //
+  //      Missing required argument: queryEnv
+  //
+  .exitProcess(false)
+  .parseSync()
 
 declare global {
   namespace jest {

--- a/rank/docs/testing.md
+++ b/rank/docs/testing.md
@@ -2,9 +2,7 @@
 
 ## CLI
 
-To run tests from the CLI, run `yarn test`.
-
-You can choose where to run the rank tests (e.g. staging) by setting the `RANK_QUERY_ENVIRONMENT` environment variable.
+To run tests from the CLI, run `yarn test --queryEnv=[production|staging|candidate]`.
 
 N.B. this command is typically invoked to test the functionality of an app.  
 Here, the `test` command does not test the rank app functionality; It runs the actual rank tests for queries/mappings/indices etc.

--- a/rank/docs/testing.md
+++ b/rank/docs/testing.md
@@ -4,6 +4,8 @@
 
 To run tests from the CLI, run `yarn test`.
 
+You can choose where to run the rank tests (e.g. staging) by setting the `RANK_QUERY_ENVIRONMENT` environment variable.
+
 N.B. this command is typically invoked to test the functionality of an app.  
 Here, the `test` command does not test the rank app functionality; It runs the actual rank tests for queries/mappings/indices etc.
 

--- a/rank/services/elasticsearch.ts
+++ b/rank/services/elasticsearch.ts
@@ -11,7 +11,9 @@ const {
 
 let rankClient
 export function getRankClient(): Client {
-  if (!ES_RANK_CLOUD_ID) throw Error(`Missing variable ES_RANK_CLOUD_ID`)
+  if (!ES_RANK_CLOUD_ID) throw Error(`Missing variable ES_RANK_CLOUD_ID`);
+  if (!ES_RANK_USER)     throw Error(`Missing variable ES_RANK_USER`);
+  if (!ES_RANK_PASSWORD) throw Error(`Missing variable ES_RANK_PASSWORD`);
   
   if (!rankClient) {
     rankClient = new Client({

--- a/rank/services/elasticsearch.ts
+++ b/rank/services/elasticsearch.ts
@@ -11,6 +11,8 @@ const {
 
 let rankClient
 export function getRankClient(): Client {
+  if (!ES_RANK_CLOUD_ID) throw Error(`Missing variable ES_RANK_CLOUD_ID`)
+  
   if (!rankClient) {
     rankClient = new Client({
       cloud: {

--- a/rank/services/search-templates.ts
+++ b/rank/services/search-templates.ts
@@ -21,11 +21,12 @@ export async function listIndices(): Promise<Index[]> {
   return indices
 }
 
-async function getLiveQueries(environment) {
-  const apiUrl = environment === 'production'
-    ? 'https://api.wellcomecollection.org/catalogue/v2/search-templates.json'
-    : 'https://api-stage.wellcomecollection.org/catalogue/v2/search-templates.json'
-  
+async function getEnvironmentQueries(env: QueryEnv) {
+  const apiUrl = {
+    'production': 'https://api.wellcomecollection.org/catalogue/v2/search-templates.json',
+    'staging': 'https://api-stage.wellcomecollection.org/catalogue/v2/search-templates.json',
+  }[env]
+
   const res = await fetch(apiUrl)
   const json: ApiSearchTemplateRes = await res.json()
   const queries = Object.fromEntries(
@@ -63,8 +64,8 @@ export async function getCandidateQueries() {
 export async function getQueries() {
   const queries = {
     candidate: await getCandidateQueries(),
-    production: await getLiveQueries('production'),
-    staging: await getLiveQueries('staging'),
+    production: await getEnvironmentQueries('production'),
+    staging: await getEnvironmentQueries('staging'),
   }
   return queries
 }

--- a/rank/services/search-templates.ts
+++ b/rank/services/search-templates.ts
@@ -22,7 +22,7 @@ export async function listIndices(): Promise<Index[]> {
 }
 
 async function getLiveQueries(environment) {
-  const apiUrl = environment === 'prod'
+  const apiUrl = environment === 'production'
     ? 'https://api.wellcomecollection.org/catalogue/v2/search-templates.json'
     : 'https://api-stage.wellcomecollection.org/catalogue/v2/search-templates.json'
   

--- a/rank/services/search-templates.ts
+++ b/rank/services/search-templates.ts
@@ -21,10 +21,12 @@ export async function listIndices(): Promise<Index[]> {
   return indices
 }
 
-export async function getProductionQueries() {
-  const res = await fetch(
-    'https://api.wellcomecollection.org/catalogue/v2/search-templates.json'
-  )
+async function getLiveQueries(environment) {
+  const apiUrl = environment === 'prod'
+    ? 'https://api.wellcomecollection.org/catalogue/v2/search-templates.json'
+    : 'https://api-stage.wellcomecollection.org/catalogue/v2/search-templates.json'
+  
+  const res = await fetch(apiUrl)
   const json: ApiSearchTemplateRes = await res.json()
   const queries = Object.fromEntries(
     json.templates.map((template) => {
@@ -61,7 +63,8 @@ export async function getCandidateQueries() {
 export async function getQueries() {
   const queries = {
     candidate: await getCandidateQueries(),
-    production: await getProductionQueries(),
+    production: await getLiveQueries('production'),
+    staging: await getLiveQueries('staging'),
   }
   return queries
 }

--- a/rank/types/searchTemplate.ts
+++ b/rank/types/searchTemplate.ts
@@ -1,4 +1,4 @@
-export const queryEnvs = ['production', 'candidate'] as const
+export const queryEnvs = ['production', 'staging', 'candidate'] as const
 export type QueryEnv = typeof queryEnvs[number]
 
 export const namespaces = ['works', 'images'] as const


### PR DESCRIPTION
Follows https://github.com/wellcomecollection/catalogue-api/pull/300, a first step towards https://github.com/wellcomecollection/platform/issues/5350

A couple of changes:

* Better error messages if you don't have the appropriate environment variables set
* Allow running the rank tests against the staging index
* Allow choosing where you run the CLI tests. In particular, you can set the `RANK_QUERY_ENVIRONMENT` variable and choose from production/staging/candidate. I was able to see this working correctly by:

    - Messing with my local copy of the candidate queries
    - Setting the env var to `candidate`
    - Watching the tests fail

    I haven't been able to check for a failure against the staging index, but at some point maybe we can deploy a deliberately broken API there and see if the tests catch it.