### PR TITLE
Make slightly fewer requests when running the rank CLI

### DIFF
--- a/.buildkite/scripts/test_rank.sh
+++ b/.buildkite/scripts/test_rank.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash 
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset
@@ -13,12 +13,12 @@ ES_RANK_USER=$(aws secretsmanager get-secret-value \
 ES_RANK_PASSWORD=$(aws secretsmanager get-secret-value \
         --secret-id elasticsearch/rank/buildkite_password \
         --query SecretString \
-        --output text 
+        --output text
 )
 ES_RANK_CLOUD_ID=$(aws secretsmanager get-secret-value \
         --secret-id elasticsearch/rank/cloud_id \
         --query SecretString \
-        --output text 
+        --output text
 )
 echo "ES_RANK_USER: $ES_RANK_USER"
 

--- a/rank/services/search-templates.ts
+++ b/rank/services/search-templates.ts
@@ -61,11 +61,19 @@ export async function getCandidateQueries() {
   return queries
 }
 
-export async function getQueries() {
+async function getQueryFor(queryEnv: QueryEnv) {
+  switch (queryEnv) {
+    case 'candidate': return await getCandidateQueries()
+    case 'production': return await getEnvironmentQueries('production')
+    case 'staging': return await getEnvironmentQueries('staging')
+  }
+}
+
+async function getQueries() {
   const queries = {
-    candidate: await getCandidateQueries(),
-    production: await getEnvironmentQueries('production'),
-    staging: await getEnvironmentQueries('staging'),
+    candidate: await getQueryFor('candidate'),
+    production: await getQueryFor('production'),
+    staging: await getQueryFor('staging'),
   }
   return queries
 }
@@ -94,9 +102,9 @@ export async function getTemplate(
   queryEnv: QueryEnv,
   index: Index
 ): Promise<SearchTemplate> {
-  const queries = await getQueries()
-  const query = queries[queryEnv][getNamespaceFromIndexName(index)]
-  return new SearchTemplate(queryEnv, index, query)
+  const query = await getQueryFor(queryEnv)
+  const namespacedQuery = query[getNamespaceFromIndexName(index)]
+  return new SearchTemplate(queryEnv, index, namespacedQuery)
 }
 
 export default getTemplates


### PR DESCRIPTION
Previously calling `getTemplate(queryEnv)` would fetch the template for every query environment, then pick out the one you asked for.  This is clearly inefficient – this patch modifies this function to only fetch the template we want, and skip fetching the others.

Locally it takes the CLI from ~44.8s to ~42.3s.

For https://github.com/wellcomecollection/platform/issues/5350. This also shows it might be useful to run rank on pull requests, because you have no idea if the CLI portion actually works.