### PR TITLE
rename rank cluster

### DIFF
--- a/rank/terraform/main.tf
+++ b/rank/terraform/main.tf
@@ -8,8 +8,8 @@ data "ec_stack" "latest" {
 }
 
 
-resource "ec_deployment" "rank_catalogue" {
-  name                   = "rank-catalogue"
+resource "ec_deployment" "rank" {
+  name                   = "rank"
   region                 = "eu-west-1"
   version                = data.ec_stack.latest.version
   deployment_template_id = "aws-io-optimized-v2"


### PR DESCRIPTION
Needed to rebuild the rank cluster from terraform, and it seemed like a good opportunity to clear up its name.

The cluster's called `rank` instead of `rank-catalogue` now.