### PR TITLE
query the search.identifiers field

### DIFF
--- a/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -12,9 +12,7 @@ import com.sksamuel.elastic4s.requests.searches.queries.matches.{
   MatchQuery,
   MultiMatchQuery
 }
-import weco.catalogue.internal_model.index.WorksAnalysis.{
-  languages,
-}
+import weco.catalogue.internal_model.index.WorksAnalysis.{languages}
 
 case object WorksMultiMatcher {
   val titleFields = Seq(

--- a/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -14,7 +14,6 @@ import com.sksamuel.elastic4s.requests.searches.queries.matches.{
 }
 import weco.catalogue.internal_model.index.WorksAnalysis.{
   languages,
-  whitespaceAnalyzer
 }
 
 case object WorksMultiMatcher {
@@ -33,26 +32,12 @@ case object WorksMultiMatcher {
   def apply(q: String): BoolQuery =
     boolQuery()
       .should(
-        MultiMatchQuery(
-          q,
+        MatchQuery(
           queryName = Some("identifiers"),
-          `type` = Some(BEST_FIELDS),
+          field = "search.identifiers",
+          value = q,
           operator = Some(OR),
-          analyzer = Some(whitespaceAnalyzer.name),
-          fields = fieldsWithBoost(
-            boost = 1000,
-            Seq(
-              "state.canonicalId",
-              "state.sourceIdentifier.value",
-              "data.otherIdentifiers.value",
-              "data.items.id.canonicalId",
-              "data.items.id.sourceIdentifier.value",
-              "data.items.id.otherIdentifiers.value",
-              "data.imageData.id.canonicalId",
-              "data.imageData.id.sourceIdentifier.value",
-              "data.imageData.id.otherIdentifiers.value"
-            )
-          )
+          boost = Some(1000)
         ),
         /**
           * This is the different ways we can match on the title fields

--- a/search/src/test/resources/WorksMultiMatcherQuery.json
+++ b/search/src/test/resources/WorksMultiMatcherQuery.json
@@ -2,23 +2,13 @@
   "bool": {
     "should": [
       {
-        "multi_match": {
-          "query": "{{query}}",
-          "fields": [
-            "state.canonicalId^1000.0",
-            "state.sourceIdentifier.value^1000.0",
-            "data.otherIdentifiers.value^1000.0",
-            "data.items.id.canonicalId^1000.0",
-            "data.items.id.sourceIdentifier.value^1000.0",
-            "data.items.id.otherIdentifiers.value^1000.0",
-            "data.imageData.id.canonicalId^1000.0",
-            "data.imageData.id.sourceIdentifier.value^1000.0",
-            "data.imageData.id.otherIdentifiers.value^1000.0"
-          ],
-          "type": "best_fields",
-          "analyzer": "whitespace_analyzer",
-          "operator": "Or",
-          "_name": "identifiers"
+        "match": {
+          "search.identifiers": {
+            "query": "{{query}}",
+            "_name": "identifiers",
+            "boost": 1000,
+            "operator": "OR"
+          }
         }
       },
       {


### PR DESCRIPTION
- the corresponding query change for https://github.com/wellcomecollection/catalogue-pipeline/pull/1974