### PR TITLE
query data.referenceNumber as an identifier

### DIFF
--- a/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -50,7 +50,8 @@ case object WorksMultiMatcher {
               "data.items.id.otherIdentifiers.value",
               "data.imageData.id.canonicalId",
               "data.imageData.id.sourceIdentifier.value",
-              "data.imageData.id.otherIdentifiers.value"
+              "data.imageData.id.otherIdentifiers.value",
+              "data.referenceNumber"
             )
           )
         ),

--- a/search/src/test/resources/WorksMultiMatcherQuery.json
+++ b/search/src/test/resources/WorksMultiMatcherQuery.json
@@ -13,7 +13,8 @@
             "data.items.id.otherIdentifiers.value^1000.0",
             "data.imageData.id.canonicalId^1000.0",
             "data.imageData.id.sourceIdentifier.value^1000.0",
-            "data.imageData.id.otherIdentifiers.value^1000.0"
+            "data.imageData.id.otherIdentifiers.value^1000.0",
+            "data.referenceNumber^1000.0"
           ],
           "type": "best_fields",
           "analyzer": "whitespace_analyzer",


### PR DESCRIPTION
This is the simple fix for https://github.com/wellcomecollection/platform/issues/5333

We'll come back to do something more comprehensive as part of https://github.com/wellcomecollection/platform/issues/5368