### PR TITLE
Add a test for 404'ing on an image that isn't a canonical ID

### DIFF
--- a/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
@@ -23,23 +23,20 @@ class ImagesErrorsTest
         description = s"Image not found for identifier $badId"
       )
     }
-  }
 
-  it("returns a 404 error if the user asks for a non-existent index") {
-    withImagesApi {
-      case (_, routes) =>
-        val indexName = createIndexName
+    it("looking for a non-existent index") {
+      val indexName = createIndexName
 
-        val testPaths = Table(
-          "path",
-          s"$rootPath/images?_index=$indexName",
-          s"$rootPath/images?_index=$indexName&query=fish",
-          s"$rootPath/images/$createCanonicalId?_index=$indexName"
-        )
+      val testPaths = Table(
+        "path",
+        s"$rootPath/images?_index=$indexName",
+        s"$rootPath/images?_index=$indexName&query=fish",
+        s"$rootPath/images/$createCanonicalId?_index=$indexName"
+      )
 
-        forAll(testPaths) { path =>
-          assertIsNotFound(path, description = s"There is no index $indexName")
-        }
+      forAll(testPaths) { path =>
+        assertIsNotFound(path, description = s"There is no index $indexName")
+      }
     }
   }
 

--- a/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
@@ -15,6 +15,14 @@ class ImagesErrorsTest
         description = s"Image not found for identifier $id"
       )
     }
+
+    it("looking up an image with a malformed identifier") {
+      val badId = "zd224ncv]"
+      assertIsNotFound(
+        s"$rootPath/images/$badId",
+        description = s"Image not found for identifier $badId"
+      )
+    }
   }
 
   it("returns a 404 error if the user asks for a non-existent index") {


### PR DESCRIPTION
We already do the right thing here; this just makes sure we don't regress the behaviour in future.