### PR TITLE
Speed up the catalogue-api builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,6 +24,10 @@ steps:
     agents:
       queue: "scala"
 
+    # We increase the priority of this task because it may push a commit
+    # and trigger a new build; if so, we want that to happen ASAP.
+    priority: 1
+
   - command: .buildkite/scripts/run_job.py display
     label: "display"
     agents:
@@ -44,10 +48,11 @@ steps:
     agents:
       queue: "scala"
 
-  - command: .buildkite/scripts/test_rank.sh
-    label: "rank"
-    env:
-      QUERY_ENV: "candidate"
+    # We increase the priority of this task because it's the longest
+    # running task in this pipeline.  Increasing the priority means it
+    # will be assigned to the first available instance, rather than waiting
+    # for other, faster tasks to be started and new instances created.
+    priority: 1
 
   - command: .buildkite/scripts/run_job.py items
     label: "Stacks: Items API"
@@ -60,9 +65,14 @@ steps:
       queue: "scala"
 
   - command: .buildkite/scripts/run_job.py snapshot_generator
-    label: "snapshot generator"
+    label: "Snapshot generator"
     agents:
       queue: "scala"
+
+  - command: .buildkite/scripts/test_rank.sh
+    label: "rank"
+    env:
+      QUERY_ENV: "candidate"
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 steps:
-  - label: "Internal model tool: check compatibility"
+  - label: "check internal model compatibility"
     plugins:
       - wellcomecollection/aws-assume-role#v0.2.2:
           role: "arn:aws:iam::756629837203:role/catalogue-ci"
@@ -13,12 +13,11 @@ steps:
             - AWS_DEFAULT_REGION=eu-west-1
     agents:
       queue: nano
+
   - command: .buildkite/scripts/check_vendored_code.py
     label: "check vendored code"
     agents:
       queue: nano
-
-  - wait
 
   - command: .buildkite/scripts/run_autoformat.py
     label: "autoformat"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,14 +22,29 @@ steps:
 
   - command: .buildkite/scripts/run_autoformat.py
     label: "autoformat"
+    agents:
+      queue: "scala"
+
   - command: .buildkite/scripts/run_job.py display
     label: "display"
+    agents:
+      queue: "scala"
+
   - command: .buildkite/scripts/run_job.py search_common
     label: "search_common"
+    agents:
+      queue: "scala"
+
   - command: .buildkite/scripts/run_job.py stacks
     label: "stacks_common"
+    agents:
+      queue: "scala"
+
   - command: .buildkite/scripts/run_job.py search
     label: "Search API (Works & Images)"
+    agents:
+      queue: "scala"
+
   - command: .buildkite/scripts/test_rank.sh
     label: "rank"
     env:
@@ -37,10 +52,18 @@ steps:
 
   - command: .buildkite/scripts/run_job.py items
     label: "Stacks: Items API"
+    agents:
+      queue: "scala"
+
   - command: .buildkite/scripts/run_job.py requests
     label: "Stacks: Requests API"
+    agents:
+      queue: "scala"
+
   - command: .buildkite/scripts/run_job.py snapshot_generator
     label: "snapshot generator"
+    agents:
+      queue: "scala"
 
   - wait
 

--- a/builds/run_sbt_task_in_docker.sh
+++ b/builds/run_sbt_task_in_docker.sh
@@ -24,7 +24,7 @@ docker run --tty --rm \
   --volume ~/.ivy2:/root/.ivy2 \
   --volume "$HOST_COURSIER_CACHE:/root/$LINUX_COURSIER_CACHE" \
   --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume "$DOCKER_CONFIG:/root/.docker" \
+  --volume "${DOCKER_CONFIG:-$HOME/.docker}:/root/.docker" \
   --net host \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \

--- a/search/src/test/scala/weco/api/search/ApiErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/ApiErrorsTest.scala
@@ -7,7 +7,8 @@ class ApiErrorsTest extends ApiWorksTestBase {
     withApi { route =>
       assertNotFound(route)(
         path = s"$rootPath/foo/bar",
-        description = s"Page not found for URL ${apiConfig.publicRootPath}/foo/bar"
+        description =
+          s"Page not found for URL ${apiConfig.publicRootPath}/foo/bar"
       )
     }
   }

--- a/search/src/test/scala/weco/api/search/ApiErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/ApiErrorsTest.scala
@@ -3,14 +3,12 @@ package weco.api.search
 import weco.api.search.works.ApiWorksTestBase
 
 class ApiErrorsTest extends ApiWorksTestBase {
-
   it("returns a Not Found error if you try to get an unrecognised path") {
-    withApi { routes =>
-      assertJsonResponse(routes, s"$rootPath/foo/bar") {
-        Status.NotFound -> notFound(
-          s"Page not found for URL ${apiConfig.publicRootPath}/foo/bar"
-        )
-      }
+    withApi { route =>
+      assertNotFound(route)(
+        path = s"$rootPath/foo/bar",
+        description = s"Page not found for URL ${apiConfig.publicRootPath}/foo/bar"
+      )
     }
   }
 }

--- a/search/src/test/scala/weco/api/search/ApiTestBase.scala
+++ b/search/src/test/scala/weco/api/search/ApiTestBase.scala
@@ -76,6 +76,11 @@ trait ApiTestBase extends ApiFixture {
         )
     }
 
+  def assertBadRequest(route: Route)(path: String, description: String): Assertion =
+    assertJsonResponse(route, path)(
+      Status.BadRequest -> badRequest(description = description)
+    )
+
   def assertNotFound(route: Route)(path: String, description: String): Assertion =
     assertJsonResponse(route, path)(
       Status.NotFound -> notFound(description = description)

--- a/search/src/test/scala/weco/api/search/ApiTestBase.scala
+++ b/search/src/test/scala/weco/api/search/ApiTestBase.scala
@@ -76,12 +76,16 @@ trait ApiTestBase extends ApiFixture {
         )
     }
 
-  def assertBadRequest(route: Route)(path: String, description: String): Assertion =
+  def assertBadRequest(
+    route: Route
+  )(path: String, description: String): Assertion =
     assertJsonResponse(route, path)(
       Status.BadRequest -> badRequest(description = description)
     )
 
-  def assertNotFound(route: Route)(path: String, description: String): Assertion =
+  def assertNotFound(
+    route: Route
+  )(path: String, description: String): Assertion =
     assertJsonResponse(route, path)(
       Status.NotFound -> notFound(description = description)
     )

--- a/search/src/test/scala/weco/api/search/ApiTestBase.scala
+++ b/search/src/test/scala/weco/api/search/ApiTestBase.scala
@@ -1,5 +1,6 @@
 package weco.api.search
 
+import akka.http.scaladsl.server.Route
 import org.scalatest.Assertion
 import weco.api.search.fixtures.ApiFixture
 
@@ -74,4 +75,9 @@ trait ApiTestBase extends ApiFixture {
             badRequest(description = description)
         )
     }
+
+  def assertNotFound(route: Route)(path: String, description: String): Assertion =
+    assertJsonResponse(route, path)(
+      Status.NotFound -> notFound(description = description)
+    )
 }

--- a/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
@@ -10,11 +10,12 @@ class ImagesErrorsTest
     it("looking up an image that doesn't exist") {
       val id = "blahblah"
 
-      withImagesApi { case (_, route) =>
-        assertNotFound(route)(
-          path = s"$rootPath/images/$id",
-          description = s"Image not found for identifier $id"
-        )
+      withImagesApi {
+        case (_, route) =>
+          assertNotFound(route)(
+            path = s"$rootPath/images/$id",
+            description = s"Image not found for identifier $id"
+          )
       }
     }
 
@@ -41,7 +42,10 @@ class ImagesErrorsTest
 
       withApi { route =>
         forAll(testPaths) { path =>
-          assertNotFound(route)(path, description = s"There is no index $indexName")
+          assertNotFound(route)(
+            path,
+            description = s"There is no index $indexName"
+          )
         }
       }
     }

--- a/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
@@ -1,6 +1,5 @@
 package weco.api.search.images
 
-import org.scalatest.Assertion
 import org.scalatest.prop.TableDrivenPropertyChecks
 import weco.catalogue.display_model.ElasticConfig
 
@@ -10,18 +9,24 @@ class ImagesErrorsTest
   describe("returns a 404 for missing resources") {
     it("looking up an image that doesn't exist") {
       val id = "blahblah"
-      assertIsNotFound(
-        s"$rootPath/images/$id",
-        description = s"Image not found for identifier $id"
-      )
+
+      withImagesApi { case (_, route) =>
+        assertNotFound(route)(
+          path = s"$rootPath/images/$id",
+          description = s"Image not found for identifier $id"
+        )
+      }
     }
 
     it("looking up an image with a malformed identifier") {
       val badId = "zd224ncv]"
-      assertIsNotFound(
-        s"$rootPath/images/$badId",
-        description = s"Image not found for identifier $badId"
-      )
+
+      withApi { route =>
+        assertNotFound(route)(
+          path = s"$rootPath/images/$badId",
+          description = s"Image not found for identifier $badId"
+        )
+      }
     }
 
     it("looking for a non-existent index") {
@@ -34,8 +39,10 @@ class ImagesErrorsTest
         s"$rootPath/images/$createCanonicalId?_index=$indexName"
       )
 
-      forAll(testPaths) { path =>
-        assertIsNotFound(path, description = s"There is no index $indexName")
+      withApi { route =>
+        forAll(testPaths) { path =>
+          assertNotFound(route)(path, description = s"There is no index $indexName")
+        }
       }
     }
   }
@@ -69,15 +76,4 @@ class ImagesErrorsTest
       }
     }
   }
-
-  def assertIsNotFound(path: String, description: String): Assertion =
-    withImagesApi {
-      case (_, routes) =>
-        assertJsonResponse(routes, path)(
-          Status.NotFound ->
-            notFound(
-              description = description
-            )
-        )
-    }
 }

--- a/search/src/test/scala/weco/api/search/works/WorksErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksErrorsTest.scala
@@ -137,7 +137,8 @@ class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
         case (_, route) =>
           assertJsonResponse(
             route,
-            path = s"$rootPath/works?_queryType=athingwewouldneverusebutmightbecausewesaidwewouldnot"
+            path =
+              s"$rootPath/works?_queryType=athingwewouldneverusebutmightbecausewesaidwewouldnot"
           ) {
             Status.OK -> emptyJsonResult
           }
@@ -224,11 +225,12 @@ class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
         "https://developers.wellcomecollection.org/datasets"
 
       it("a very large page") {
-        withWorksApi { case (_, route) =>
-          assertBadRequest(route)(
-            path = s"$rootPath/works?page=10000",
-            description = description
-          )
+        withWorksApi {
+          case (_, route) =>
+            assertBadRequest(route)(
+              path = s"$rootPath/works?page=10000",
+              description = description
+            )
         }
       }
 
@@ -237,20 +239,22 @@ class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
       // We saw real requests like this, which we traced to an overflow in the
       // page offset we were requesting in Elasticsearch.
       it("so many pages that a naive (page * pageSize) would overflow") {
-        withWorksApi { case (_, route) =>
-          assertBadRequest(route)(
-            path = s"$rootPath/works?page=2000000000&pageSize=100",
-            description = description
-          )
+        withWorksApi {
+          case (_, route) =>
+            assertBadRequest(route)(
+              path = s"$rootPath/works?page=2000000000&pageSize=100",
+              description = description
+            )
         }
       }
 
       it("the 101th page with 100 results per page") {
-        withWorksApi { case (_, route) =>
-          assertBadRequest(route)(
-            path = s"$rootPath/works?page=101&pageSize=100",
-            description = description
-          )
+        withWorksApi {
+          case (_, route) =>
+            assertBadRequest(route)(
+              path = s"$rootPath/works?page=101&pageSize=100",
+              description = description
+            )
         }
       }
     }
@@ -286,12 +290,13 @@ class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
     // could arise which we aren't covering.
     //
     it("if the date is too large") {
-      withWorksApi { case (_, route) =>
-        assertBadRequest(route)(
-          path =
-            s"$rootPath/works?_queryType=undefined&production.dates.from=%2B011860-01-01",
-          description = "production.dates.from: year must be less than 9999"
-        )
+      withWorksApi {
+        case (_, route) =>
+          assertBadRequest(route)(
+            path =
+              s"$rootPath/works?_queryType=undefined&production.dates.from=%2B011860-01-01",
+            description = "production.dates.from: year must be less than 9999"
+          )
       }
     }
   }
@@ -299,21 +304,23 @@ class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
   describe("returns a 404 Not Found for missing resources") {
     it("looking up a work that doesn't exist") {
       val badId = "doesnotexist"
-      withWorksApi { case (_, route) =>
-        assertNotFound(route)(
-          path = s"$rootPath/works/$badId",
-          description = s"Work not found for identifier $badId"
-        )
+      withWorksApi {
+        case (_, route) =>
+          assertNotFound(route)(
+            path = s"$rootPath/works/$badId",
+            description = s"Work not found for identifier $badId"
+          )
       }
     }
 
     it("looking up a work with a malformed identifier") {
       val badId = "zd224ncv]"
-      withWorksApi { case (_, route) =>
-        assertNotFound(route)(
-          path = s"$rootPath/works/$badId",
-          description = s"Work not found for identifier $badId"
-        )
+      withWorksApi {
+        case (_, route) =>
+          assertNotFound(route)(
+            path = s"$rootPath/works/$badId",
+            description = s"Work not found for identifier $badId"
+          )
       }
     }
 
@@ -341,7 +348,8 @@ class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
       it("searching") {
         withApi { route =>
           assertNotFound(route)(
-            path = s"$rootPath/works/$createCanonicalId?_index=$indexName&query=foobar",
+            path =
+              s"$rootPath/works/$createCanonicalId?_index=$indexName&query=foobar",
             description = s"There is no index $indexName"
           )
         }

--- a/search/src/test/scala/weco/api/search/works/WorksErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksErrorsTest.scala
@@ -1,8 +1,6 @@
 package weco.api.search.works
 
-import org.scalatest.Assertion
 import org.scalatest.prop.TableDrivenPropertyChecks
-import weco.catalogue.display_model.ElasticConfig
 import weco.elasticsearch.IndexConfig
 
 class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
@@ -12,35 +10,43 @@ class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
 
   describe("returns a 400 Bad Request for errors in the ?include parameter") {
     it("a single invalid include") {
-      assertIsBadRequest(
-        s"$rootPath/works?include=foo",
-        description =
-          s"include: 'foo' is not a valid value. Please choose one of: $includesString"
-      )
+      withApi { route =>
+        assertBadRequest(route)(
+          path = s"$rootPath/works?include=foo",
+          description =
+            s"include: 'foo' is not a valid value. Please choose one of: $includesString"
+        )
+      }
     }
 
     it("multiple invalid includes") {
-      assertIsBadRequest(
-        s"$rootPath/works?include=foo,bar",
-        description =
-          s"include: 'foo', 'bar' are not valid values. Please choose one of: $includesString"
-      )
+      withApi { route =>
+        assertBadRequest(route)(
+          path = s"$rootPath/works?include=foo,bar",
+          description =
+            s"include: 'foo', 'bar' are not valid values. Please choose one of: $includesString"
+        )
+      }
     }
 
     it("a mixture of valid and invalid includes") {
-      assertIsBadRequest(
-        s"$rootPath/works?include=foo,identifiers,bar",
-        description =
-          s"include: 'foo', 'bar' are not valid values. Please choose one of: $includesString"
-      )
+      withApi { route =>
+        assertBadRequest(route)(
+          path = s"$rootPath/works?include=foo,identifiers,bar",
+          description =
+            s"include: 'foo', 'bar' are not valid values. Please choose one of: $includesString"
+        )
+      }
     }
 
     it("an invalid include on an individual work") {
-      assertIsBadRequest(
-        s"$rootPath/works/nfdn7wac?include=foo",
-        description =
-          s"include: 'foo' is not a valid value. Please choose one of: $includesString"
-      )
+      withApi { route =>
+        assertBadRequest(route)(
+          path = s"$rootPath/works/nfdn7wac?include=foo",
+          description =
+            s"include: 'foo' is not a valid value. Please choose one of: $includesString"
+        )
+      }
     }
   }
 
@@ -51,61 +57,75 @@ class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
     "returns a 400 Bad Request for errors in the ?aggregations parameter"
   ) {
     it("a single invalid aggregation") {
-      assertIsBadRequest(
-        s"$rootPath/works?aggregations=foo",
-        description =
-          s"aggregations: 'foo' is not a valid value. Please choose one of: $aggregationsString"
-      )
+      withApi { route =>
+        assertBadRequest(route)(
+          path = s"$rootPath/works?aggregations=foo",
+          description =
+            s"aggregations: 'foo' is not a valid value. Please choose one of: $aggregationsString"
+        )
+      }
     }
 
     it("multiple invalid aggregations") {
-      assertIsBadRequest(
-        s"$rootPath/works?aggregations=foo,bar",
-        description =
-          s"aggregations: 'foo', 'bar' are not valid values. Please choose one of: $aggregationsString"
-      )
+      withApi { route =>
+        assertBadRequest(route)(
+          path = s"$rootPath/works?aggregations=foo,bar",
+          description =
+            s"aggregations: 'foo', 'bar' are not valid values. Please choose one of: $aggregationsString"
+        )
+      }
     }
 
     it("a mixture of valid and invalid aggregations") {
-      assertIsBadRequest(
-        s"$rootPath/works?aggregations=foo,workType,bar",
-        description =
-          s"aggregations: 'foo', 'bar' are not valid values. Please choose one of: $aggregationsString"
-      )
+      withApi { route =>
+        assertBadRequest(route)(
+          path = s"$rootPath/works?aggregations=foo,workType,bar",
+          description =
+            s"aggregations: 'foo', 'bar' are not valid values. Please choose one of: $aggregationsString"
+        )
+      }
     }
   }
 
   it("multiple invalid sorts") {
-    assertIsBadRequest(
-      s"$rootPath/works?sort=foo,bar",
-      description =
-        "sort: 'foo', 'bar' are not valid values. Please choose one of: ['production.dates']"
-    )
+    withApi { route =>
+      assertBadRequest(route)(
+        path = s"$rootPath/works?sort=foo,bar",
+        description =
+          "sort: 'foo', 'bar' are not valid values. Please choose one of: ['production.dates']"
+      )
+    }
   }
 
   describe("returns a 400 Bad Request for errors in the ?sort parameter") {
     it("a single invalid sort") {
-      assertIsBadRequest(
-        s"$rootPath/works?sort=foo",
-        description =
-          "sort: 'foo' is not a valid value. Please choose one of: ['production.dates']"
-      )
+      withApi { route =>
+        assertBadRequest(route)(
+          path = s"$rootPath/works?sort=foo",
+          description =
+            "sort: 'foo' is not a valid value. Please choose one of: ['production.dates']"
+        )
+      }
     }
 
     it("multiple invalid sorts") {
-      assertIsBadRequest(
-        s"$rootPath/works?sort=foo,bar",
-        description =
-          "sort: 'foo', 'bar' are not valid values. Please choose one of: ['production.dates']"
-      )
+      withApi { route =>
+        assertBadRequest(route)(
+          path = s"$rootPath/works?sort=foo,bar",
+          description =
+            "sort: 'foo', 'bar' are not valid values. Please choose one of: ['production.dates']"
+        )
+      }
     }
 
     it("a mixture of valid and invalid sort") {
-      assertIsBadRequest(
-        s"$rootPath/works?sort=foo,production.dates,bar",
-        description =
-          "sort: 'foo', 'bar' are not valid values. Please choose one of: ['production.dates']"
-      )
+      withApi { route =>
+        assertBadRequest(route)(
+          path = s"$rootPath/works?sort=foo,production.dates,bar",
+          description =
+            "sort: 'foo', 'bar' are not valid values. Please choose one of: ['production.dates']"
+        )
+      }
     }
   }
 
@@ -114,10 +134,10 @@ class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
   describe("returns a 200 for invalid values in the ?_queryType parameter") {
     it("200s despite being a unknown value") {
       withWorksApi {
-        case (_, routes) =>
+        case (_, route) =>
           assertJsonResponse(
-            routes,
-            s"$rootPath/works?_queryType=athingwewouldneverusebutmightbecausewesaidwewouldnot"
+            route,
+            path = s"$rootPath/works?_queryType=athingwewouldneverusebutmightbecausewesaidwewouldnot"
           ) {
             Status.OK -> emptyJsonResult
           }
@@ -129,52 +149,64 @@ class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
     describe("errors in the ?pageSize query") {
       it("not an integer") {
         val pageSize = "penguin"
-        assertIsBadRequest(
-          s"$rootPath/works?pageSize=$pageSize",
-          description = s"pageSize: must be a valid Integer"
-        )
+        withApi { route =>
+          assertBadRequest(route)(
+            path = s"$rootPath/works?pageSize=$pageSize",
+            description = s"pageSize: must be a valid Integer"
+          )
+        }
       }
 
       it("just over the maximum") {
         val pageSize = 101
-        assertIsBadRequest(
-          s"$rootPath/works?pageSize=$pageSize",
-          description = "pageSize: must be between 1 and 100"
-        )
+        withApi { route =>
+          assertBadRequest(route)(
+            path = s"$rootPath/works?pageSize=$pageSize",
+            description = "pageSize: must be between 1 and 100"
+          )
+        }
       }
 
       it("just below the minimum (zero)") {
         val pageSize = 0
-        assertIsBadRequest(
-          s"$rootPath/works?pageSize=$pageSize",
-          description = "pageSize: must be between 1 and 100"
-        )
+        withApi { route =>
+          assertBadRequest(route)(
+            path = s"$rootPath/works?pageSize=$pageSize",
+            description = "pageSize: must be between 1 and 100"
+          )
+        }
       }
 
       it("a large page size") {
-        val pageSize = 100000
-        assertIsBadRequest(
-          s"$rootPath/works?pageSize=$pageSize",
-          description = "pageSize: must be between 1 and 100"
-        )
+        val pageSize = 1000
+        withApi { route =>
+          assertBadRequest(route)(
+            path = s"$rootPath/works?pageSize=$pageSize",
+            description = "pageSize: must be between 1 and 100"
+          )
+        }
       }
 
       it("a negative page size") {
         val pageSize = -50
-        assertIsBadRequest(
-          s"$rootPath/works?pageSize=$pageSize",
-          description = "pageSize: must be between 1 and 100"
-        )
+        withApi { route =>
+          assertBadRequest(route)(
+            path = s"$rootPath/works?pageSize=$pageSize",
+            description = "pageSize: must be between 1 and 100"
+          )
+        }
       }
     }
 
     describe("errors in the ?page query") {
       it("page 0") {
         val page = 0
-        assertIsBadRequest(
-          s"$rootPath/works?page=$page",
-          description = "page: must be greater than 1"
-        )
+        withApi { route =>
+          assertBadRequest(route)(
+            path = s"$rootPath/works?page=$page",
+            description = "page: must be greater than 1"
+          )
+        }
       }
 
       it("a negative page") {
@@ -192,36 +224,47 @@ class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
         "https://developers.wellcomecollection.org/datasets"
 
       it("a very large page") {
-        assertIsBadRequest(
-          s"$rootPath/works?page=10000",
-          description = description
-        )
+        withWorksApi { case (_, route) =>
+          assertBadRequest(route)(
+            path = s"$rootPath/works?page=10000",
+            description = description
+          )
+        }
       }
 
-      // https://github.com/wellcometrust/platform/issues/3233
+      // This is a regression test for https://github.com/wellcometrust/platform/issues/3233
+      //
+      // We saw real requests like this, which we traced to an overflow in the
+      // page offset we were requesting in Elasticsearch.
       it("so many pages that a naive (page * pageSize) would overflow") {
-        assertIsBadRequest(
-          s"$rootPath/works?page=2000000000&pageSize=100",
-          description = description
-        )
+        withWorksApi { case (_, route) =>
+          assertBadRequest(route)(
+            path = s"$rootPath/works?page=2000000000&pageSize=100",
+            description = description
+          )
+        }
       }
 
       it("the 101th page with 100 results per page") {
-        assertIsBadRequest(
-          s"$rootPath/works?page=101&pageSize=100",
-          description = description
-        )
+        withWorksApi { case (_, route) =>
+          assertBadRequest(route)(
+            path = s"$rootPath/works?page=101&pageSize=100",
+            description = description
+          )
+        }
       }
     }
 
     it("returns multiple errors if there's more than one invalid parameter") {
       val pageSize = -60
       val page = -50
-      assertIsBadRequest(
-        s"$rootPath/works?pageSize=$pageSize&page=$page",
-        description =
-          "page: must be greater than 1, pageSize: must be between 1 and 100"
-      )
+      withApi { route =>
+        assertBadRequest(route)(
+          path = s"$rootPath/works?pageSize=$pageSize&page=$page",
+          description =
+            "page: must be greater than 1, pageSize: must be between 1 and 100"
+        )
+      }
     }
 
     // This test is a best-effort regression test for a real query we saw, which caused
@@ -243,63 +286,70 @@ class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
     // could arise which we aren't covering.
     //
     it("if the date is too large") {
-      assertIsBadRequest(
-        path =
-          s"$rootPath/works?_queryType=undefined&production.dates.from=%2B011860-01-01",
-        description = "production.dates.from: year must be less than 9999"
-      )
+      withWorksApi { case (_, route) =>
+        assertBadRequest(route)(
+          path =
+            s"$rootPath/works?_queryType=undefined&production.dates.from=%2B011860-01-01",
+          description = "production.dates.from: year must be less than 9999"
+        )
+      }
     }
   }
 
   describe("returns a 404 Not Found for missing resources") {
     it("looking up a work that doesn't exist") {
       val badId = "doesnotexist"
-      assertIsNotFound(
-        s"$rootPath/works/$badId",
-        description = s"Work not found for identifier $badId"
-      )
+      withWorksApi { case (_, route) =>
+        assertNotFound(route)(
+          path = s"$rootPath/works/$badId",
+          description = s"Work not found for identifier $badId"
+        )
+      }
     }
 
     it("looking up a work with a malformed identifier") {
       val badId = "zd224ncv]"
-      assertIsNotFound(
-        s"$rootPath/works/$badId",
-        description = s"Work not found for identifier $badId"
-      )
+      withWorksApi { case (_, route) =>
+        assertNotFound(route)(
+          path = s"$rootPath/works/$badId",
+          description = s"Work not found for identifier $badId"
+        )
+      }
     }
 
     describe("an index that doesn't exist") {
       val indexName = "foobarbaz"
 
       it("listing") {
-        assertIsNotFound(
-          s"$rootPath/works?_index=$indexName",
-          description = s"There is no index $indexName"
-        )
+        withApi { route =>
+          assertNotFound(route)(
+            path = s"$rootPath/works?_index=$indexName",
+            description = s"There is no index $indexName"
+          )
+        }
       }
 
       it("looking up a work") {
-        assertIsNotFound(
-          s"$rootPath/works/$createCanonicalId?_index=$indexName",
-          description = s"There is no index $indexName"
-        )
+        withApi { route =>
+          assertNotFound(route)(
+            path = s"$rootPath/works/$createCanonicalId?_index=$indexName",
+            description = s"There is no index $indexName"
+          )
+        }
       }
 
       it("searching") {
-        assertIsNotFound(
-          s"$rootPath/works/$createCanonicalId?_index=$indexName&query=foobar",
-          description = s"There is no index $indexName"
-        )
+        withApi { route =>
+          assertNotFound(route)(
+            path = s"$rootPath/works/$createCanonicalId?_index=$indexName&query=foobar",
+            description = s"There is no index $indexName"
+          )
+        }
       }
     }
   }
 
   it("returns a 500 error if the default index doesn't exist") {
-    val elasticConfig = ElasticConfig(
-      worksIndex = createIndex,
-      imagesIndex = createIndex
-    )
-
     val testPaths = Table(
       "path",
       s"$rootPath/works",
@@ -307,9 +357,9 @@ class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
       s"$rootPath/works/$createCanonicalId"
     )
 
-    withRouter(elasticConfig) { routes =>
+    withApi { route =>
       forAll(testPaths) { path =>
-        assertJsonResponse(routes, path)(
+        assertJsonResponse(route, path)(
           Status.InternalServerError ->
             s"""
                |{
@@ -331,10 +381,10 @@ class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
     // By creating an index without a mapping, we don't have a canonicalId field
     // to sort on.  Trying to query this index of these will trigger one such exception!
     withWorksApi {
-      case (_, routes) =>
+      case (_, route) =>
         withLocalElasticsearchIndex(config = IndexConfig.empty) { index =>
           val path = s"$rootPath/works?_index=${index.name}"
-          assertJsonResponse(routes, path)(
+          assertJsonResponse(route, path)(
             Status.InternalServerError ->
               s"""
                  |{
@@ -348,15 +398,4 @@ class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
         }
     }
   }
-
-  def assertIsNotFound(path: String, description: String): Assertion =
-    withWorksApi {
-      case (_, routes) =>
-        assertJsonResponse(routes, path)(
-          Status.NotFound ->
-            notFound(
-              description = description
-            )
-        )
-    }
 }

--- a/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala
@@ -409,16 +409,17 @@ class WorksFiltersTest
     )
 
     it("filters by genres as a comma separated list") {
-      forAll(testCases) {
-        (
-          query: String,
-          results: Seq[Work.Visible[WorkState.Indexed]],
-          clue: String
-        ) =>
-          withClue(clue) {
-            withWorksApi {
-              case (worksIndex, routes) =>
-                insertIntoElasticsearch(worksIndex, works: _*)
+      withWorksApi {
+        case (worksIndex, routes) =>
+          insertIntoElasticsearch(worksIndex, works: _*)
+
+          forAll(testCases) {
+            (
+              query: String,
+              results: Seq[Work.Visible[WorkState.Indexed]],
+              clue: String
+            ) =>
+              withClue(clue) {
                 assertJsonResponse(
                   routes,
                   s"$rootPath/works?genres.label=${URLEncoder.encode(query, "UTF-8")}"
@@ -484,16 +485,16 @@ class WorksFiltersTest
     )
 
     it("filters by subjects as a comma separated list") {
-      forAll(testCases) {
-        (
-          query: String,
-          results: Seq[Work.Visible[WorkState.Indexed]],
-          clue: String
-        ) =>
-          withClue(clue) {
-            withWorksApi {
-              case (worksIndex, routes) =>
-                insertIntoElasticsearch(worksIndex, works: _*)
+      withWorksApi {
+        case (worksIndex, routes) =>
+          insertIntoElasticsearch(worksIndex, works: _*)
+          forAll(testCases) {
+            (
+              query: String,
+              results: Seq[Work.Visible[WorkState.Indexed]],
+              clue: String
+            ) =>
+              withClue(clue) {
                 assertJsonResponse(
                   routes,
                   s"$rootPath/works?subjects.label=${URLEncoder.encode(query, "UTF-8")}"
@@ -560,16 +561,16 @@ class WorksFiltersTest
     )
 
     it("filters by contributors as a comma separated list") {
-      forAll(testCases) {
-        (
-          query: String,
-          results: Seq[Work.Visible[WorkState.Indexed]],
-          clue: String
-        ) =>
-          withClue(clue) {
-            withWorksApi {
-              case (worksIndex, routes) =>
-                insertIntoElasticsearch(worksIndex, works: _*)
+      withWorksApi {
+        case (worksIndex, routes) =>
+          insertIntoElasticsearch(worksIndex, works: _*)
+          forAll(testCases) {
+            (
+              query: String,
+              results: Seq[Work.Visible[WorkState.Indexed]],
+              clue: String
+            ) =>
+              withClue(clue) {
                 assertJsonResponse(
                   routes,
                   s"$rootPath/works?contributors.agent.label=${URLEncoder

--- a/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala
@@ -428,7 +428,7 @@ class WorksFiltersTest
                     _.state.canonicalId
                   })
                 }
-            }
+              }
           }
       }
     }
@@ -503,7 +503,7 @@ class WorksFiltersTest
                     _.state.canonicalId
                   })
                 }
-            }
+              }
           }
       }
     }
@@ -580,7 +580,7 @@ class WorksFiltersTest
                     _.state.canonicalId
                   })
                 }
-            }
+              }
           }
       }
     }

--- a/terraform/shared/elastic.tf
+++ b/terraform/shared/elastic.tf
@@ -2,7 +2,7 @@ resource "ec_deployment" "catalogue_api" {
   name = "catalogue-api"
 
   region                 = "eu-west-1"
-  version                = "7.16.2"
+  version                = "7.16.3"
   deployment_template_id = "aws-io-optimized-v2"
 
   traffic_filter = local.catalogue_ec_traffic_filter


### PR DESCRIPTION
Working with Paul this week, I've been acutely aware of how slow our Scala builds still are. This patch tries a couple of quick wins to make the builds go faster:

* Use our new c5.2xlarge instances for extra compute grunt (see https://github.com/wellcomecollection/buildkite-infrastructure/pull/1)
* Use our new sbt_wrapper image which is smaller and has better caching (see https://github.com/wellcomecollection/platform-infrastructure/pull/281)
* Tidy some tests that are obviously slow, although this test suite is already pretty heavily optimised

Previously these tests took ~9m from a cold start, now it's ~5m.

For https://github.com/wellcomecollection/platform/issues/5359