### PR TITLE
Fix newlines in query description

### DIFF
--- a/search/src/main/scala/weco/api/search/swagger/SwaggerDocs.scala
+++ b/search/src/main/scala/weco/api/search/swagger/SwaggerDocs.scala
@@ -568,7 +568,7 @@ trait MultipleWorksSwagger {
         name = "query",
         in = ParameterIn.QUERY,
         description =
-          """Full-text search query, which will OR supplied terms by default.\n\nThe following special characters can be used to change the search behaviour:\n\n- \" wraps a number of tokens to signify a phrase for searching\n\nTo search for any of these special characters, they should be escaped with \.""",
+          "Full-text search query, which will OR supplied terms by default.\n\nThe following special characters can be used to change the search behaviour:\n\n- \" wraps a number of tokens to signify a phrase for searching\n\nTo search for any of these special characters, they should be escaped with \\.",
         required = false
       ),
       new Parameter(


### PR DESCRIPTION
I spotted that escaped newlines were popping up in the Swagger docs. 

<img width="1157" alt="Screenshot 2022-02-11 at 16 30 12" src="https://user-images.githubusercontent.com/64621/153630307-8df2e6a3-9cce-4afb-837c-fd0cbf506d8b.png">
