### PR TITLE
Allow internal_model_tool scripts to run from anywhere

### DIFF
--- a/internal_model_tool/common.py
+++ b/internal_model_tool/common.py
@@ -7,6 +7,7 @@ from urllib.request import Request, urlopen
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
+
 def get_session(*, role_arn):
     sts_client = boto3.client("sts")
     assumed_role_object = sts_client.assume_role(
@@ -22,7 +23,10 @@ def get_session(*, role_arn):
 
 def get_local_date():
     with open(
-        os.path.join(HERE, "../common/display/src/main/scala/weco/catalogue/display_model/ElasticConfig.scala"),
+        os.path.join(
+            HERE,
+            "../common/display/src/main/scala/weco/catalogue/display_model/ElasticConfig.scala",
+        ),
         "r",
     ) as config_file:
         config_text = config_file.read()
@@ -89,4 +93,6 @@ def set_local_internal_model(latest_version):
             else:
                 out_file.write(line)
     if not line_set:
-        raise ValueError(f"{dependencies_path} did not contain an internalModel line as expected")
+        raise ValueError(
+            f"{dependencies_path} did not contain an internalModel line as expected"
+        )

--- a/internal_model_tool/common.py
+++ b/internal_model_tool/common.py
@@ -73,7 +73,7 @@ def get_remote_meta(session, date):
 
 
 def get_local_internal_model():
-    with open(os.path.join(HERE, "../project/Dependencies.scala", "r")) as deps_file:
+    with open(os.path.join(HERE, "../project/Dependencies.scala"), "r") as deps_file:
         config_text = deps_file.read()
     model_version = re.findall('val internalModel = "(.*)"', config_text)[0]
     return model_version


### PR DESCRIPTION
When I ran bump.py recently, I was momentarily confused by it reporting it couldn't find a file.
This was because I was running it from the project root, rather than inside the internal_model_tool directory.

This change allows you to run this script from any location, as it looks for the relevant files relative to the script, not the current working directory.

I also added a check to ensure that it only succeeds if it finds the right line to update.  Previously, it would have succeeded even if that line is absent and it didn't update anything.