### PR TITLE
fix wording of error messages for expired and self registered accounts

### DIFF
--- a/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
@@ -62,7 +62,7 @@ trait CreateRequest extends CustomDirectives with ErrorDirectives with Logging {
         (
           StatusCodes.Forbidden,
           Some(
-            s"Your account needs to be upgraded before you can make requests. Please contact library enquiries for assistance"
+            s"Your account needs to be upgraded before you can make requests. Please contact Library Enquiries (library@wellcomecollection.org)."
           )
         )
 
@@ -90,7 +90,7 @@ trait CreateRequest extends CustomDirectives with ErrorDirectives with Logging {
         (
           StatusCodes.Forbidden,
           Some(
-            "Your account has expired, and you're no longer able to request items. To renew your account, please <a href=\"library@wellcomecollection.org\">contact the library team</a>."
+            "Your account has expired, and you're no longer able to request items. To renew your account, please contact Library Enquiries (library@wellcomecollection.org)."
           )
         )
 

--- a/requests/src/test/scala/weco/api/requests/RequestingScenarioTest.scala
+++ b/requests/src/test/scala/weco/api/requests/RequestingScenarioTest.scala
@@ -1184,7 +1184,7 @@ class RequestingScenarioTest
                |  "errorType": "http",
                |  "httpStatus": 403,
                |  "label": "Forbidden",
-               |  "description": "Your account has expired, and you're no longer able to request items. To renew your account, please <a href=\\\"library@wellcomecollection.org\\\">contact the library team</a>."
+               |  "description": "Your account has expired, and you're no longer able to request items. To renew your account, please contact Library Enquiries (library@wellcomecollection.org)."
                |}
                |""".stripMargin
           )
@@ -1272,7 +1272,7 @@ class RequestingScenarioTest
                |  "errorType": "http",
                |  "httpStatus": 403,
                |  "label": "Forbidden",
-               |  "description": "Your account needs to be upgraded before you can make requests. Please contact library enquiries for assistance"
+               |  "description": "Your account needs to be upgraded before you can make requests. Please contact Library Enquiries (library@wellcomecollection.org)."
                |}
                |""".stripMargin
           )


### PR DESCRIPTION
The error message for library patrons with expired accounts needed to be updated as per discussion In ticket #7451 https://github.com/wellcomecollection/wellcomecollection.org/issues/7451. We also needed to update the wording for the error messages that appear when a self registered patron tries to request items.

Now both error messages contain reference to contacting library enquiries. 