### PR TITLE
Set up an API that doesn't need CCR

### DIFF
--- a/.sbt_metadata/snapshot_generator.json
+++ b/.sbt_metadata/snapshot_generator.json
@@ -2,6 +2,7 @@
   "id" : "snapshot_generator",
   "folder" : "snapshots/snapshot_generator",
   "dependencyIds" : [
-    "display"
+    "display",
+    "search_common"
   ]
 }

--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,7 @@ lazy val requests = setupProject(
 lazy val snapshot_generator = setupProject(
   project,
   "snapshots/snapshot_generator",
-  localDependencies = Seq(display),
+  localDependencies = Seq(display, search_common),
   externalDependencies = CatalogueDependencies.snapshotGeneratorDependencies
 )
 

--- a/builds/build_sbt_image.sh
+++ b/builds/build_sbt_image.sh
@@ -21,4 +21,4 @@ docker build \
   "$PROJECT_DIRECTORY"
 
 mkdir -p "$ROOT/.releases"
-echo "$CURRENT_COMMIT" >> "$ROOT/.releases/$PROJECT"
+echo "$CURRENT_COMMIT" > "$ROOT/.releases/$PROJECT"

--- a/builds/publish_image_with_weco_deploy.sh
+++ b/builds/publish_image_with_weco_deploy.sh
@@ -27,7 +27,7 @@ docker run --tty --rm \
   --env AWS_PROFILE \
   --volume ~/.aws:/root/.aws \
   --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume "$DOCKER_CONFIG:/root/.docker" \
+  --volume "${DOCKER_CONFIG:-$HOME/.docker}:/root/.docker" \
   --volume "$ROOT:$ROOT" \
   --workdir "$ROOT" \
   "$ECR_REGISTRY/$WECO_DEPLOY_IMAGE" \

--- a/bump_internal_model.py
+++ b/bump_internal_model.py
@@ -39,9 +39,9 @@ def get_date_from_elastic_config():
 
 def get_version_from_es_pipeline(session, date):
     sm = session.client("secretsmanager")
-    host = sm.get_secret_value(SecretId=f"elasticsearch/pipeline_storage_{date}/public_host")[
-        "SecretString"
-    ]
+    host = sm.get_secret_value(
+        SecretId=f"elasticsearch/pipeline_storage_{date}/public_host"
+    )["SecretString"]
     username = sm.get_secret_value(
         SecretId=f"elasticsearch/pipeline_storage_{date}/catalogue_api/es_username"
     )["SecretString"]

--- a/bump_internal_model.py
+++ b/bump_internal_model.py
@@ -39,14 +39,14 @@ def get_date_from_elastic_config():
 
 def get_version_from_es_pipeline(session, date):
     sm = session.client("secretsmanager")
-    host = sm.get_secret_value(SecretId="elasticsearch/catalogue_api/public_host")[
+    host = sm.get_secret_value(SecretId=f"elasticsearch/pipeline_storage_{date}/public_host")[
         "SecretString"
     ]
     username = sm.get_secret_value(
-        SecretId="elasticsearch/catalogue_api/search/username"
+        SecretId=f"elasticsearch/pipeline_storage_{date}/catalogue_api/es_username"
     )["SecretString"]
     password = sm.get_secret_value(
-        SecretId="elasticsearch/catalogue_api/search/password"
+        SecretId=f"elasticsearch/pipeline_storage_{date}/catalogue_api/es_password"
     )["SecretString"]
 
     index = f"works-indexed-{date}"

--- a/common/display/src/main/scala/weco/catalogue/display_model/ElasticConfig.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/ElasticConfig.scala
@@ -12,31 +12,7 @@ case class ElasticConfig(
 trait ElasticConfigBase {
   // We use this to share config across API applications
   // i.e. The API and the snapshot generator.
-  //
-  // We have two Elasticsearch clusters we use:
-  //
-  //    - the pipeline cluster.  We create a new cluster per-pipeline, and this is
-  //      where new documents are written by the ingestor.
-  //    - the API cluster.  We have a single such cluster, and it gets updates from
-  //      the pipeline cluster using cross-cluster-replication (CCR).
-  //
-  // Generally we use the same index name in the pipeline cluster and the API cluster,
-  // e.g.
-  //
-  //      pipeline: works-indexed-2021-08-16
-  //      api:      works-indexed-2021-08-16
-  //
-  // But sometimes we need to create new indexes within an existing pipeline,
-  // e.g. if cross-cluster replication breaks.  Then we append a suffix to the name
-  // in the API cluster, but keep the existing name in the pipeline cluster, e.g.
-  //
-  //      pipeline: works-indexed-2021-08-16
-  //      api:      works-indexed-2021-08-16a
-  //
-  // The different config allows applications to choose whether they want to read
-  // from the pipeline cluster or the API cluster.
-  val pipelineDate = "2022-03-31"
-  val suffix = ""
+  val pipelineDate = "2022-04-04"
 }
 
 object PipelineClusterElasticConfig extends ElasticConfigBase {
@@ -44,13 +20,5 @@ object PipelineClusterElasticConfig extends ElasticConfigBase {
     ElasticConfig(
       worksIndex = Index(s"works-indexed-$pipelineDate"),
       imagesIndex = Index(s"images-indexed-$pipelineDate")
-    )
-}
-
-object ApiClusterElasticConfig extends ElasticConfigBase {
-  def apply(): ElasticConfig =
-    ElasticConfig(
-      worksIndex = Index(s"works-indexed-$pipelineDate$suffix"),
-      imagesIndex = Index(s"images-indexed-$pipelineDate$suffix")
     )
 }

--- a/common/search/src/main/scala/weco/api/search/config/builders/PipelineElasticClientBuilder.scala
+++ b/common/search/src/main/scala/weco/api/search/config/builders/PipelineElasticClientBuilder.scala
@@ -48,8 +48,8 @@ object PipelineElasticClientBuilder {
   }
 
   private def getSecretString(
-                               id: String
-                             )(implicit secretsClient: SecretsManagerClient) = {
+    id: String
+  )(implicit secretsClient: SecretsManagerClient) = {
     val request =
       GetSecretValueRequest
         .builder()

--- a/common/search/src/main/scala/weco/api/search/config/builders/PipelineElasticClientBuilder.scala
+++ b/common/search/src/main/scala/weco/api/search/config/builders/PipelineElasticClientBuilder.scala
@@ -9,7 +9,7 @@ import weco.elasticsearch.ElasticClientBuilder
 object PipelineElasticClientBuilder {
 
   // We create a new pipeline cluster for every pipeline, and we want the
-  // to read from that cluster.
+  // services to read from that cluster.
   //
   // We don't want to require a Terraform plan/apply to pick up the change --
   // ElasticConfig is the single source of truth for the API index -- so instead

--- a/common/search/src/main/scala/weco/api/search/config/builders/PipelineElasticClientBuilder.scala
+++ b/common/search/src/main/scala/weco/api/search/config/builders/PipelineElasticClientBuilder.scala
@@ -1,4 +1,4 @@
-package weco.api.snapshot_generator.config.builders
+package weco.api.search.config.builders
 
 import com.sksamuel.elastic4s.ElasticClient
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
@@ -6,15 +6,15 @@ import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueReques
 import weco.catalogue.display_model.PipelineClusterElasticConfig
 import weco.elasticsearch.ElasticClientBuilder
 
-object SnapshotGeneratorElasticClientBuilder {
+object PipelineElasticClientBuilder {
 
   // We create a new pipeline cluster for every pipeline, and we want the
-  // snapshot generator to read from that cluster.
+  // to read from that cluster.
   //
   // We don't want to require a Terraform plan/apply to pick up the change --
   // ElasticConfig is the single source of truth for the API index -- so instead
-  // we let the snapshot generator decide which set of secrets to read, which
-  // in turn sets which cluster it reads from.
+  // we let the services decide which set of secrets to read, which in turn sets
+  // which cluster they readd from.
 
   def apply(): ElasticClient = {
     implicit val secretsClient: SecretsManagerClient =
@@ -48,8 +48,8 @@ object SnapshotGeneratorElasticClientBuilder {
   }
 
   private def getSecretString(
-    id: String
-  )(implicit secretsClient: SecretsManagerClient) = {
+                               id: String
+                             )(implicit secretsClient: SecretsManagerClient) = {
     val request =
       GetSecretValueRequest
         .builder()

--- a/common/search/src/main/scala/weco/api/search/config/builders/PipelineElasticClientBuilder.scala
+++ b/common/search/src/main/scala/weco/api/search/config/builders/PipelineElasticClientBuilder.scala
@@ -16,7 +16,7 @@ object PipelineElasticClientBuilder {
   // we let the services decide which set of secrets to read, which in turn sets
   // which cluster they readd from.
 
-  def apply(): ElasticClient = {
+  def apply(serviceName: String): ElasticClient = {
     implicit val secretsClient: SecretsManagerClient =
       SecretsManagerClient.builder().build()
 
@@ -32,10 +32,10 @@ object PipelineElasticClientBuilder {
       s"elasticsearch/pipeline_storage_$pipelineDate/protocol"
     )
     val username = getSecretString(
-      s"elasticsearch/pipeline_storage_$pipelineDate/snapshot_generator/es_username"
+      s"elasticsearch/pipeline_storage_$pipelineDate/$serviceName/es_username"
     )
     val password = getSecretString(
-      s"elasticsearch/pipeline_storage_$pipelineDate/snapshot_generator/es_password"
+      s"elasticsearch/pipeline_storage_$pipelineDate/$serviceName/es_password"
     )
 
     ElasticClientBuilder.create(

--- a/internal_model_tool/common.py
+++ b/internal_model_tool/common.py
@@ -30,9 +30,7 @@ def get_local_date():
         "r",
     ) as config_file:
         config_text = config_file.read()
-    date = re.findall('val pipelineDate = "(.*)"', config_text)[0]
-    suffix = re.findall('val suffix = "(.*)"', config_text)[0]
-    return date + suffix
+    return re.findall('val pipelineDate = "(.*)"', config_text)[0]
 
 
 def get_remote_latest_internal_model(session, date):
@@ -53,13 +51,13 @@ def get_secret_string(session, *, secret_id):
 
 def get_remote_meta(session, date):
     host = get_secret_string(
-        session, secret_id="elasticsearch/catalogue_api/public_host"
+        session, secret_id=f"elasticsearch/pipeline_storage_{date}/public_host"
     )
     username = get_secret_string(
-        session, secret_id="elasticsearch/catalogue_api/internal_model_tool/username"
+        session, secret_id=f"elasticsearch/pipeline_storage_{date}/catalogue_api/es_username"
     )
     password = get_secret_string(
-        session, secret_id="elasticsearch/catalogue_api/internal_model_tool/password"
+        session, secret_id=f"elasticsearch/pipeline_storage_{date}/catalogue_api/es_password"
     )
 
     index = f"works-indexed-{date}"

--- a/internal_model_tool/common.py
+++ b/internal_model_tool/common.py
@@ -54,10 +54,12 @@ def get_remote_meta(session, date):
         session, secret_id=f"elasticsearch/pipeline_storage_{date}/public_host"
     )
     username = get_secret_string(
-        session, secret_id=f"elasticsearch/pipeline_storage_{date}/catalogue_api/es_username"
+        session,
+        secret_id=f"elasticsearch/pipeline_storage_{date}/catalogue_api/es_username",
     )
     password = get_secret_string(
-        session, secret_id=f"elasticsearch/pipeline_storage_{date}/catalogue_api/es_password"
+        session,
+        secret_id=f"elasticsearch/pipeline_storage_{date}/catalogue_api/es_password",
     )
 
     index = f"works-indexed-{date}"

--- a/items/src/main/scala/weco/api/items/Main.scala
+++ b/items/src/main/scala/weco/api/items/Main.scala
@@ -3,18 +3,14 @@ package weco.api.items
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import weco.Tracing
-import weco.api.items.services.{
-  ItemUpdateService,
-  SierraItemUpdater,
-  WorkLookup
-}
-import weco.elasticsearch.typesafe.ElasticBuilder
+import weco.api.items.services.{ItemUpdateService, SierraItemUpdater, WorkLookup}
+import weco.api.search.config.builders.PipelineElasticClientBuilder
 import weco.http.typesafe.HTTPServerBuilder
 import weco.monitoring.typesafe.CloudWatchBuilder
 import weco.api.search.models.{ApiConfig, CheckModel}
 import weco.typesafe.WellcomeTypesafeApp
 import weco.typesafe.config.builders.AkkaBuilder
-import weco.catalogue.display_model.ApiClusterElasticConfig
+import weco.catalogue.display_model.PipelineClusterElasticConfig
 import weco.http.WellcomeHttpApp
 import weco.http.monitoring.HttpMetrics
 import weco.sierra.http.SierraSource
@@ -34,8 +30,8 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val apiConfig: ApiConfig = ApiConfig.build(config)
 
-    val elasticClient = ElasticBuilder.buildElasticClient(config)
-    val elasticConfig = ApiClusterElasticConfig()
+    val elasticClient = PipelineElasticClientBuilder("stacks_api")
+    val elasticConfig = PipelineClusterElasticConfig()
 
     CheckModel.checkModel(elasticConfig.worksIndex.name)(elasticClient)
 

--- a/items/src/main/scala/weco/api/items/Main.scala
+++ b/items/src/main/scala/weco/api/items/Main.scala
@@ -3,7 +3,11 @@ package weco.api.items
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import weco.Tracing
-import weco.api.items.services.{ItemUpdateService, SierraItemUpdater, WorkLookup}
+import weco.api.items.services.{
+  ItemUpdateService,
+  SierraItemUpdater,
+  WorkLookup
+}
 import weco.api.search.config.builders.PipelineElasticClientBuilder
 import weco.http.typesafe.HTTPServerBuilder
 import weco.monitoring.typesafe.CloudWatchBuilder

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object WellcomeDependencies {
     val monitoring = defaultVersion
     val storage = defaultVersion
     val elasticsearch = defaultVersion
-    val internalModel = "6403.9f8ab7df0b69b440b38d2a6bf68b606cdc16b86f"
+    val internalModel = "6425.c777dcd1a223d7656a542e36e00dd33a4d090433"
   }
 
   val internalModel: Seq[ModuleID] = library(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -160,7 +160,8 @@ object CatalogueDependencies {
       WellcomeDependencies.monitoringLibrary ++
       WellcomeDependencies.httpTypesafeLibrary ++
       ExternalDependencies.akkaHttpDependencies ++
-      ExternalDependencies.scalacsvDependencies
+      ExternalDependencies.scalacsvDependencies ++
+      ExternalDependencies.secretsDependencies
 
   val searchDependencies: Seq[ModuleID] =
     ExternalDependencies.circeOpticsDependencies
@@ -174,8 +175,7 @@ object CatalogueDependencies {
       WellcomeDependencies.elasticsearchLibrary ++
       WellcomeDependencies.elasticsearchTypesafeLibrary ++
       WellcomeDependencies.storageTypesafeLibrary ++
-      WellcomeDependencies.typesafeLibrary ++
-      ExternalDependencies.secretsDependencies
+      WellcomeDependencies.typesafeLibrary
 
   val itemsDependencies: Seq[ModuleID] =
     WellcomeDependencies.sierraTypesafeLibrary

--- a/requests/src/main/scala/weco/api/requests/Main.scala
+++ b/requests/src/main/scala/weco/api/requests/Main.scala
@@ -3,7 +3,11 @@ package weco.api.requests
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import weco.Tracing
-import weco.api.requests.services.{ItemLookup, RequestsService, SierraRequestsService}
+import weco.api.requests.services.{
+  ItemLookup,
+  RequestsService,
+  SierraRequestsService
+}
 import weco.api.search.config.builders.PipelineElasticClientBuilder
 import weco.http.typesafe.HTTPServerBuilder
 import weco.monitoring.typesafe.CloudWatchBuilder

--- a/requests/src/main/scala/weco/api/requests/Main.scala
+++ b/requests/src/main/scala/weco/api/requests/Main.scala
@@ -3,18 +3,14 @@ package weco.api.requests
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import weco.Tracing
-import weco.api.requests.services.{
-  ItemLookup,
-  RequestsService,
-  SierraRequestsService
-}
-import weco.elasticsearch.typesafe.ElasticBuilder
+import weco.api.requests.services.{ItemLookup, RequestsService, SierraRequestsService}
+import weco.api.search.config.builders.PipelineElasticClientBuilder
 import weco.http.typesafe.HTTPServerBuilder
 import weco.monitoring.typesafe.CloudWatchBuilder
 import weco.api.search.models.{ApiConfig, CheckModel}
 import weco.typesafe.WellcomeTypesafeApp
 import weco.typesafe.config.builders.AkkaBuilder
-import weco.catalogue.display_model.ApiClusterElasticConfig
+import weco.catalogue.display_model.PipelineClusterElasticConfig
 import weco.http.WellcomeHttpApp
 import weco.http.monitoring.HttpMetrics
 import weco.sierra.typesafe.SierraOauthHttpClientBuilder
@@ -34,8 +30,8 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val apiConfig: ApiConfig = ApiConfig.build(config)
 
-    val elasticClient = ElasticBuilder.buildElasticClient(config)
-    val elasticConfig = ApiClusterElasticConfig()
+    val elasticClient = PipelineElasticClientBuilder("stacks_api")
+    val elasticConfig = PipelineClusterElasticConfig()
 
     CheckModel.checkModel(elasticConfig.worksIndex.name)(elasticClient)
 

--- a/search/src/main/scala/weco/api/search/Main.scala
+++ b/search/src/main/scala/weco/api/search/Main.scala
@@ -27,7 +27,7 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val apiConfig: ApiConfig = ApiConfig.build(config)
 
-    val elasticClient = PipelineElasticClientBuilder()
+    val elasticClient = PipelineElasticClientBuilder("catalogue_api")
     val elasticConfig = PipelineClusterElasticConfig()
 
     CheckModel.checkModel(elasticConfig.worksIndex.name)(elasticClient)

--- a/search/src/main/scala/weco/api/search/Main.scala
+++ b/search/src/main/scala/weco/api/search/Main.scala
@@ -7,7 +7,7 @@ import weco.api.search.config.builders.PipelineElasticClientBuilder
 import weco.api.search.models.{ApiConfig, CheckModel, QueryConfig}
 import weco.typesafe.WellcomeTypesafeApp
 import weco.typesafe.config.builders.AkkaBuilder
-import weco.catalogue.display_model.ApiClusterElasticConfig
+import weco.catalogue.display_model.PipelineClusterElasticConfig
 import weco.http.WellcomeHttpApp
 import weco.http.monitoring.HttpMetrics
 import weco.http.typesafe.HTTPServerBuilder
@@ -28,7 +28,7 @@ object Main extends WellcomeTypesafeApp {
     implicit val apiConfig: ApiConfig = ApiConfig.build(config)
 
     val elasticClient = PipelineElasticClientBuilder()
-    val elasticConfig = ApiClusterElasticConfig()
+    val elasticConfig = PipelineClusterElasticConfig()
 
     CheckModel.checkModel(elasticConfig.worksIndex.name)(elasticClient)
     CheckModel.checkModel(elasticConfig.imagesIndex.name)(elasticClient)

--- a/search/src/main/scala/weco/api/search/Main.scala
+++ b/search/src/main/scala/weco/api/search/Main.scala
@@ -2,8 +2,8 @@ package weco.api.search
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
-import weco.elasticsearch.typesafe.ElasticBuilder
 import weco.Tracing
+import weco.api.search.config.builders.PipelineElasticClientBuilder
 import weco.api.search.models.{ApiConfig, CheckModel, QueryConfig}
 import weco.typesafe.WellcomeTypesafeApp
 import weco.typesafe.config.builders.AkkaBuilder
@@ -27,7 +27,7 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val apiConfig: ApiConfig = ApiConfig.build(config)
 
-    val elasticClient = ElasticBuilder.buildElasticClient(config)
+    val elasticClient = PipelineElasticClientBuilder()
     val elasticConfig = ApiClusterElasticConfig()
 
     CheckModel.checkModel(elasticConfig.worksIndex.name)(elasticClient)

--- a/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/Main.scala
+++ b/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/Main.scala
@@ -31,7 +31,7 @@ object Main extends WellcomeTypesafeApp {
     )
 
     implicit val elasticClient: ElasticClient =
-      PipelineElasticClientBuilder()
+      PipelineElasticClientBuilder("snapshot_generator")
 
     implicit val s3Client: AmazonS3 = S3Builder.buildS3Client
 

--- a/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/Main.scala
+++ b/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/Main.scala
@@ -4,12 +4,9 @@ import akka.actor.ActorSystem
 import com.amazonaws.services.s3.AmazonS3
 import com.sksamuel.elastic4s.ElasticClient
 import com.typesafe.config.Config
-import weco.api.snapshot_generator.config.builders.SnapshotGeneratorElasticClientBuilder
+import weco.api.search.config.builders.PipelineElasticClientBuilder
 import weco.api.snapshot_generator.models.SnapshotGeneratorConfig
-import weco.api.snapshot_generator.services.{
-  SnapshotGeneratorWorkerService,
-  SnapshotService
-}
+import weco.api.snapshot_generator.services.{SnapshotGeneratorWorkerService, SnapshotService}
 import weco.catalogue.display_model.PipelineClusterElasticConfig
 import weco.messaging.sns.NotificationMessage
 import weco.messaging.typesafe.{SNSBuilder, SQSBuilder}
@@ -34,7 +31,7 @@ object Main extends WellcomeTypesafeApp {
     )
 
     implicit val elasticClient: ElasticClient =
-      SnapshotGeneratorElasticClientBuilder()
+      PipelineElasticClientBuilder()
 
     implicit val s3Client: AmazonS3 = S3Builder.buildS3Client
 

--- a/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/Main.scala
+++ b/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/Main.scala
@@ -6,7 +6,10 @@ import com.sksamuel.elastic4s.ElasticClient
 import com.typesafe.config.Config
 import weco.api.search.config.builders.PipelineElasticClientBuilder
 import weco.api.snapshot_generator.models.SnapshotGeneratorConfig
-import weco.api.snapshot_generator.services.{SnapshotGeneratorWorkerService, SnapshotService}
+import weco.api.snapshot_generator.services.{
+  SnapshotGeneratorWorkerService,
+  SnapshotService
+}
 import weco.catalogue.display_model.PipelineClusterElasticConfig
 import weco.messaging.sns.NotificationMessage
 import weco.messaging.typesafe.{SNSBuilder, SQSBuilder}

--- a/terraform/modules/service/iam.tf
+++ b/terraform/modules/service/iam.tf
@@ -1,5 +1,5 @@
-resource "aws_iam_role_policy" "search_get_secrets" {
-  role   = module.search_api.task_role_name
+resource "aws_iam_role_policy" "service_get_secrets" {
+  role   = module.task_definition.task_role_name
   policy = data.aws_iam_policy_document.get_secrets.json
 }
 

--- a/terraform/modules/service/main.tf
+++ b/terraform/modules/service/main.tf
@@ -39,8 +39,8 @@ module "app_container_secrets_permissions" {
 module "task_definition" {
   source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.11.0"
 
-  cpu    = 1024
-  memory = 2048
+  cpu    = 512
+  memory = 1024
 
   container_definitions = [
     module.log_router_container.container_definition,

--- a/terraform/modules/stack/iam.tf
+++ b/terraform/modules/stack/iam.tf
@@ -1,0 +1,16 @@
+resource "aws_iam_role_policy" "search_get_secrets" {
+  role   = module.search_api.task_role_name
+  policy = data.aws_iam_policy_document.get_secrets.json
+}
+
+data "aws_iam_policy_document" "get_secrets" {
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = [
+      "arn:aws:secretsmanager:eu-west-1:756629837203:secret:elasticsearch/*",
+    ]
+  }
+}


### PR DESCRIPTION
The second half of https://github.com/wellcomecollection/platform/issues/5430

This gets the pieces in place for a pipeline+API that doesn't use CCR. In particular:

* The API will now select a set of secrets to use at startup and use the correct set of secrets based on `ElasticConfig`, rather than having them hard-coded in Terraform