### PR TITLE
Query the per-pipeline clusters in the API diff tool

### DIFF
--- a/diff_tool/api_stats.py
+++ b/diff_tool/api_stats.py
@@ -69,7 +69,7 @@ def get_api_stats(session, *, api_url):
 
     search_resp = es_client.search(
         index=index_name,
-        body={"size": 0, "aggs": {"work_type": {"terms": {"field": "type"}}}}
+        body={"size": 0, "aggs": {"work_type": {"terms": {"field": "type"}}}},
     )
 
     aggregations = search_resp["aggregations"]

--- a/diff_tool/diff_tool.py
+++ b/diff_tool/diff_tool.py
@@ -103,7 +103,10 @@ class ApiDiffer:
         try:
             return (response.status_code, response.json())
         except json.JSONDecodeError:
-            print(f"Non-JSON response received from {url}:\n---\n{response.text}\n---\n", file=sys.stderr)
+            print(
+                f"Non-JSON response received from {url}:\n---\n{response.text}\n---\n",
+                file=sys.stderr,
+            )
             sys.exit(1)
 
 

--- a/diff_tool/diff_tool.py
+++ b/diff_tool/diff_tool.py
@@ -99,7 +99,7 @@ class ApiDiffer:
 
     def call_api(self, api_base):
         url = f"https://{api_base}{self.path}"
-        response = httpx.get(url, params=self.params)
+        response = httpx.get(url, params=self.params, follow_redirects=True)
         try:
             return (response.status_code, response.json())
         except json.JSONDecodeError:

--- a/diff_tool/diff_tool.py
+++ b/diff_tool/diff_tool.py
@@ -6,6 +6,7 @@ import datetime
 import difflib
 import json
 import os
+import sys
 import tempfile
 import urllib.parse
 
@@ -99,7 +100,11 @@ class ApiDiffer:
     def call_api(self, api_base):
         url = f"https://{api_base}{self.path}"
         response = httpx.get(url, params=self.params)
-        return (response.status_code, response.json())
+        try:
+            return (response.status_code, response.json())
+        except json.JSONDecodeError:
+            print(f"Non-JSON response received from {url}:\n---\n{response.text}\n---\n", file=sys.stderr)
+            sys.exit(1)
 
 
 def _display_in_console(stats, diffs):

--- a/diff_tool/diff_tool.py
+++ b/diff_tool/diff_tool.py
@@ -153,7 +153,7 @@ def _display_in_console(stats, diffs):
 @click.option("--console", is_flag=True, help="Print results in console")
 def main(routes_file, console):
     session = api_stats.get_session_with_role(
-        role_arn="arn:aws:iam::756629837203:role/catalogue-ci"
+        role_arn="arn:aws:iam::760097843905:role/platform-ci"
     )
 
     with open(routes_file) as f:


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5481

This allows the catalogue API diff tool to query the per-pipeline clusters, rather than going to the API cluster. This is the current failure in the "deploy prod" task – the diff tool is looking in the API cluster for the 2022-04-04 index, which doesn't exist there.