### PR TITLE
Use the per-pipeline cluster for the snapshot reporter

### DIFF
--- a/snapshots/snapshot_reporter/README.md
+++ b/snapshots/snapshot_reporter/README.md
@@ -1,0 +1,9 @@
+To upload a new Lambda deployment package:
+
+```console
+pip3 install --target ./src -r requirements.txt
+cd src/
+zip -r ../snapshot_reporter.zip .
+cd ..
+AWS_PROFILE=catalogue-dev aws s3 cp snapshot_reporter.zip s3://wellcomecollection-catalogue-infra-delta/lambdas/snapshots/snapshot_reporter.zip
+```

--- a/snapshots/terraform/stack/snapshot_reporter/iam.tf
+++ b/snapshots/terraform/stack/snapshot_reporter/iam.tf
@@ -5,7 +5,9 @@ data "aws_iam_policy_document" "read_secrets" {
     ]
 
     resources = [
-      for _, secret in data.aws_secretsmanager_secret_version.secrets : secret.arn
+      "arn:aws:secretsmanager:eu-west-1:756629837203:secret:${local.elastic_secret_id}*",
+      "arn:aws:secretsmanager:eu-west-1:756629837203:secret:${local.slack_secret_id}*",
+      "arn:aws:secretsmanager:eu-west-1:756629837203:secret:elasticsearch/*",
     ]
   }
 }

--- a/snapshots/terraform/stack/snapshot_reporter/locals.tf
+++ b/snapshots/terraform/stack/snapshot_reporter/locals.tf
@@ -1,18 +1,4 @@
-data "aws_secretsmanager_secret_version" "secrets" {
-  for_each = toset(local.secrets)
-
-  secret_id = each.key
-}
-
 locals {
   elastic_secret_id = "catalogue/snapshots/read_user"
   slack_secret_id   = "snapshot_reporter/slack_webhook"
-
-  secrets = [
-    local.elastic_secret_id,
-    local.slack_secret_id,
-    "elasticsearch/catalogue_api/search/username",
-    "elasticsearch/catalogue_api/search/password",
-    "elasticsearch/catalogue_api/public_host",
-  ]
 }


### PR DESCRIPTION
A straggling bug from https://github.com/wellcomecollection/platform/issues/5430

The snapshot reporter queries the API index to find out how many works have been indexed in the last 24 hours; if there aren't any, that may be a sign something has gone wrong. Unfortunately it was looking for the CCR'd index in the API cluster, which doesn't exist for the 04-04 index we're now using, so it was failing.

It might be nice to add another undocumented API endpoint for this (a la https://github.com/wellcomecollection/platform/issues/5483), but in the meantime this patch updates it to pick the right Elasticsearch cluster and count works there.