### PR TITLE
Use generic Json objects inside the DisplayResultList type

### DIFF
--- a/search/src/main/scala/weco/api/search/json/CatalogueJsonUtil.scala
+++ b/search/src/main/scala/weco/api/search/json/CatalogueJsonUtil.scala
@@ -1,0 +1,20 @@
+package weco.api.search.json
+
+import io.circe.Json
+import io.circe.syntax._
+import weco.catalogue.display_model.models.Implicits._
+import weco.catalogue.display_model.models.{DisplayImage, DisplayWork, MultipleImagesIncludes, WorksIncludes}
+import weco.catalogue.internal_model.image.{Image, ImageState}
+import weco.catalogue.internal_model.work.{Work, WorkState}
+
+trait CatalogueJsonUtil {
+  implicit class WorkOps(w: Work.Visible[WorkState.Indexed]) {
+    def asJson(includes: WorksIncludes): Json =
+      DisplayWork(w, includes).asJson
+  }
+
+  implicit class ImageOps(im: Image[ImageState.Indexed]) {
+    def asJson(includes: MultipleImagesIncludes): Json =
+      DisplayImage(im, includes).asJson
+  }
+}

--- a/search/src/main/scala/weco/api/search/json/CatalogueJsonUtil.scala
+++ b/search/src/main/scala/weco/api/search/json/CatalogueJsonUtil.scala
@@ -3,7 +3,12 @@ package weco.api.search.json
 import io.circe.Json
 import io.circe.syntax._
 import weco.catalogue.display_model.models.Implicits._
-import weco.catalogue.display_model.models.{DisplayImage, DisplayWork, MultipleImagesIncludes, WorksIncludes}
+import weco.catalogue.display_model.models.{
+  DisplayImage,
+  DisplayWork,
+  MultipleImagesIncludes,
+  WorksIncludes
+}
 import weco.catalogue.internal_model.image.{Image, ImageState}
 import weco.catalogue.internal_model.work.{Work, WorkState}
 

--- a/search/src/main/scala/weco/api/search/rest/DisplayResultList.scala
+++ b/search/src/main/scala/weco/api/search/rest/DisplayResultList.scala
@@ -1,50 +1,51 @@
 package weco.api.search.rest
 
 import akka.http.scaladsl.model.Uri
+import io.circe.Json
 import io.circe.generic.extras.JsonKey
-import io.circe.generic.extras.semiauto.deriveConfiguredEncoder
-import io.circe.Encoder
+import io.circe.syntax._
 import weco.api.search.models._
 import weco.api.search.rest
 import weco.catalogue.display_model.models._
+import weco.catalogue.display_model.models.Implicits._
 import weco.catalogue.internal_model.image.{Image, ImageState}
 import weco.catalogue.internal_model.work.{Work, WorkState}
-import weco.http.json.DisplayJsonUtil._
 
-case class DisplayResultList[DisplayResult, DisplayAggs](
+case class DisplayResultList[DisplayAggs](
   @JsonKey("type") ontologyType: String = "ResultList",
   pageSize: Int,
   totalPages: Int,
   totalResults: Int,
-  results: List[DisplayResult],
+  results: List[Json],
   prevPage: Option[String] = None,
   nextPage: Option[String] = None,
   aggregations: Option[DisplayAggs] = None
 )
 
 object DisplayResultList {
-  implicit def encoder[R: Encoder, A: Encoder]
-    : Encoder[DisplayResultList[R, A]] = deriveConfiguredEncoder
-
   def apply(
     resultList: ResultList[Work.Visible[WorkState.Indexed], WorkAggregations],
     searchOptions: SearchOptions[_, WorkAggregationRequest, _],
     includes: WorksIncludes,
     requestUri: Uri
-  ): DisplayResultList[DisplayWork, DisplayWorkAggregations] =
+  ): DisplayResultList[DisplayWorkAggregations] =
     rest.PaginationResponse(resultList, searchOptions, requestUri) match {
-      case PaginationResponse(totalPages, prevPage, nextPage) =>
+      case PaginationResponse(totalPages, prevPage, nextPage) => {
+        val results = resultList.results.map(DisplayWork(_, includes))
+          .map(_.asJson)
+
         DisplayResultList(
           pageSize = searchOptions.pageSize,
           totalPages = totalPages,
           totalResults = resultList.totalResults,
-          results = resultList.results.map(DisplayWork(_, includes)),
+          results = results,
           prevPage = prevPage,
           nextPage = nextPage,
           aggregations = resultList.aggregations.map(
             DisplayWorkAggregations.apply(_, searchOptions.aggregations)
           )
         )
+      }
     }
 
   def apply(
@@ -52,18 +53,22 @@ object DisplayResultList {
     searchOptions: SearchOptions[_, _, _],
     includes: MultipleImagesIncludes,
     requestUri: Uri
-  ): DisplayResultList[DisplayImage, DisplayImageAggregations] =
+  ): DisplayResultList[DisplayImageAggregations] =
     rest.PaginationResponse(resultList, searchOptions, requestUri) match {
-      case PaginationResponse(totalPages, prevPage, nextPage) =>
+      case PaginationResponse(totalPages, prevPage, nextPage) => {
+        val results = resultList.results.map(DisplayImage(_, includes))
+          .map(_.asJson)
+
         DisplayResultList(
           pageSize = searchOptions.pageSize,
           totalPages = totalPages,
           totalResults = resultList.totalResults,
-          results = resultList.results.map(DisplayImage(_, includes)),
+          results = results,
           prevPage = prevPage,
           nextPage = nextPage,
           aggregations =
             resultList.aggregations.map(DisplayImageAggregations.apply)
         )
+      }
     }
 }

--- a/search/src/main/scala/weco/api/search/rest/DisplayResultList.scala
+++ b/search/src/main/scala/weco/api/search/rest/DisplayResultList.scala
@@ -3,11 +3,10 @@ package weco.api.search.rest
 import akka.http.scaladsl.model.Uri
 import io.circe.Json
 import io.circe.generic.extras.JsonKey
-import io.circe.syntax._
+import weco.api.search.json.CatalogueJsonUtil
 import weco.api.search.models._
 import weco.api.search.rest
 import weco.catalogue.display_model.models._
-import weco.catalogue.display_model.models.Implicits._
 import weco.catalogue.internal_model.image.{Image, ImageState}
 import weco.catalogue.internal_model.work.{Work, WorkState}
 
@@ -22,7 +21,7 @@ case class DisplayResultList[DisplayAggs](
   aggregations: Option[DisplayAggs] = None
 )
 
-object DisplayResultList {
+object DisplayResultList extends CatalogueJsonUtil {
   def apply(
     resultList: ResultList[Work.Visible[WorkState.Indexed], WorkAggregations],
     searchOptions: SearchOptions[_, WorkAggregationRequest, _],
@@ -30,22 +29,18 @@ object DisplayResultList {
     requestUri: Uri
   ): DisplayResultList[DisplayWorkAggregations] =
     rest.PaginationResponse(resultList, searchOptions, requestUri) match {
-      case PaginationResponse(totalPages, prevPage, nextPage) => {
-        val results = resultList.results.map(DisplayWork(_, includes))
-          .map(_.asJson)
-
+      case PaginationResponse(totalPages, prevPage, nextPage) =>
         DisplayResultList(
           pageSize = searchOptions.pageSize,
           totalPages = totalPages,
           totalResults = resultList.totalResults,
-          results = results,
+          results = resultList.results.map(_.asJson(includes)),
           prevPage = prevPage,
           nextPage = nextPage,
           aggregations = resultList.aggregations.map(
             DisplayWorkAggregations.apply(_, searchOptions.aggregations)
           )
         )
-      }
     }
 
   def apply(
@@ -55,20 +50,16 @@ object DisplayResultList {
     requestUri: Uri
   ): DisplayResultList[DisplayImageAggregations] =
     rest.PaginationResponse(resultList, searchOptions, requestUri) match {
-      case PaginationResponse(totalPages, prevPage, nextPage) => {
-        val results = resultList.results.map(DisplayImage(_, includes))
-          .map(_.asJson)
-
+      case PaginationResponse(totalPages, prevPage, nextPage) =>
         DisplayResultList(
           pageSize = searchOptions.pageSize,
           totalPages = totalPages,
           totalResults = resultList.totalResults,
-          results = results,
+          results = resultList.results.map(_.asJson(includes)),
           prevPage = prevPage,
           nextPage = nextPage,
           aggregations =
             resultList.aggregations.map(DisplayImageAggregations.apply)
         )
-      }
     }
 }

--- a/search/src/main/scala/weco/api/search/rest/ImagesController.scala
+++ b/search/src/main/scala/weco/api/search/rest/ImagesController.scala
@@ -26,8 +26,6 @@ class ImagesController(
     extends CustomDirectives
     with Tracing {
 
-  import DisplayResultList.encoder
-
   def singleImage(id: CanonicalId, params: SingleImageParams): Route =
     get {
       withFuture {

--- a/search/src/main/scala/weco/api/search/rest/WorksController.scala
+++ b/search/src/main/scala/weco/api/search/rest/WorksController.scala
@@ -4,10 +4,10 @@ import akka.http.scaladsl.server.Route
 import com.sksamuel.elastic4s.Index
 import weco.Tracing
 import weco.api.search.elasticsearch.{ElasticsearchError, ElasticsearchService}
+import weco.api.search.json.CatalogueJsonUtil
 import weco.api.search.models.ApiConfig
 import weco.api.search.services.WorksService
-import weco.catalogue.display_model.models.Implicits._
-import weco.catalogue.display_model.models.{DisplayWork, WorksIncludes}
+import weco.catalogue.display_model.models.WorksIncludes
 import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.catalogue.internal_model.work.Work
 import weco.catalogue.internal_model.work.WorkState.Indexed
@@ -20,6 +20,7 @@ class WorksController(
   worksIndex: Index
 )(implicit val ec: ExecutionContext)
     extends Tracing
+    with CatalogueJsonUtil
     with SingleWorkDirectives {
 
   def multipleWorks(params: MultipleWorksParams): Route =
@@ -70,9 +71,7 @@ class WorksController(
             .findById(id)(index)
             .mapVisible(
               (work: Work.Visible[Indexed]) =>
-                Future.successful(
-                  complete(DisplayWork(work, includes))
-                ),
+                Future.successful(complete(work.asJson(includes))),
               usingUserSpecifiedIndex = userSpecifiedIndex.isDefined
             )
         }

--- a/search/src/main/scala/weco/api/search/rest/WorksController.scala
+++ b/search/src/main/scala/weco/api/search/rest/WorksController.scala
@@ -21,7 +21,6 @@ class WorksController(
 )(implicit val ec: ExecutionContext)
     extends Tracing
     with SingleWorkDirectives {
-  import DisplayResultList.encoder
 
   def multipleWorks(params: MultipleWorksParams): Route =
     get {

--- a/search/src/test/scala/weco/api/search/json/CatalogueJsonUtilTest.scala
+++ b/search/src/test/scala/weco/api/search/json/CatalogueJsonUtilTest.scala
@@ -1,0 +1,54 @@
+package weco.api.search.json
+
+import io.circe.Json
+import io.circe.parser.parse
+import org.scalatest.EitherValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.matchers.{BeMatcher, MatchResult}
+import weco.catalogue.display_model.models.WorksIncludes
+import weco.catalogue.internal_model.work.generators.WorkGenerators
+
+class CatalogueJsonUtilTest extends AnyFunSpec with Matchers with EitherValues with CatalogueJsonUtil with WorkGenerators {
+  describe("WorkOps") {
+    it("serialises a work as JSON") {
+      val w = indexedWork()
+
+      val json = w.asJson(WorksIncludes.none)
+
+      val expectedJson =
+        s"""
+           |{
+           |  "id" : "${w.id}",
+           |  "title" : "${w.data.title.get}",
+           |  "alternativeTitles" : [],
+           |  "availabilities" : [],
+           |  "type" : "Work"
+           |}
+           |""".stripMargin
+
+      json shouldBe equivalentTo(expectedJson)
+    }
+  }
+
+  class JsonMatcher(right: String) extends BeMatcher[Json] {
+    def apply(left: Json): MatchResult =
+      MatchResult(
+        left.deepDropNullValues == parseObject(right).deepDropNullValues,
+        s"$left is not equivalent to $right",
+        s"$left is equivalent to $right",
+      )
+  }
+
+  def equivalentTo(right: String) =
+    new JsonMatcher(right)
+
+  def parseJson(s: String): Json =
+    parse(s.stripMargin).right.value
+
+  def parseObject(s: String): Json = {
+    val j = parseJson(s)
+    j.isObject shouldBe true
+    j
+  }
+}

--- a/search/src/test/scala/weco/api/search/json/CatalogueJsonUtilTest.scala
+++ b/search/src/test/scala/weco/api/search/json/CatalogueJsonUtilTest.scala
@@ -7,9 +7,18 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.matchers.{BeMatcher, MatchResult}
 import weco.catalogue.display_model.models.{WorkInclude, WorksIncludes}
-import weco.catalogue.internal_model.work.generators.{ItemsGenerators, WorkGenerators}
+import weco.catalogue.internal_model.work.generators.{
+  ItemsGenerators,
+  WorkGenerators
+}
 
-class CatalogueJsonUtilTest extends AnyFunSpec with Matchers with EitherValues with CatalogueJsonUtil with WorkGenerators with ItemsGenerators {
+class CatalogueJsonUtilTest
+    extends AnyFunSpec
+    with Matchers
+    with EitherValues
+    with CatalogueJsonUtil
+    with WorkGenerators
+    with ItemsGenerators {
   describe("WorkOps") {
     it("serialises a work as JSON") {
       val w = indexedWork()
@@ -107,8 +116,12 @@ class CatalogueJsonUtilTest extends AnyFunSpec with Matchers with EitherValues w
            |            "type" : "LocationType"
            |          },
            |          "url" : "${location.url}",
-           |          ${location.credit.map(c => s""""credit": "$c",""").getOrElse("")}
-           |          ${location.linkText.map(c => s""""linkText": "$c",""").getOrElse("")}
+           |          ${location.credit
+             .map(c => s""""credit": "$c",""")
+             .getOrElse("")}
+           |          ${location.linkText
+             .map(c => s""""linkText": "$c",""")
+             .getOrElse("")}
            |          "license" : {
            |            "id" : "${location.license.get.id}",
            |            "label" : "${location.license.get.label}",
@@ -138,7 +151,7 @@ class CatalogueJsonUtilTest extends AnyFunSpec with Matchers with EitherValues w
       MatchResult(
         left.deepDropNullValues == parseObject(right).deepDropNullValues,
         s"$left is not equivalent to $right",
-        s"$left is equivalent to $right",
+        s"$left is equivalent to $right"
       )
   }
 

--- a/search/src/test/scala/weco/api/search/json/CatalogueJsonUtilTest.scala
+++ b/search/src/test/scala/weco/api/search/json/CatalogueJsonUtilTest.scala
@@ -6,10 +6,10 @@ import org.scalatest.EitherValues
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.matchers.{BeMatcher, MatchResult}
-import weco.catalogue.display_model.models.WorksIncludes
-import weco.catalogue.internal_model.work.generators.WorkGenerators
+import weco.catalogue.display_model.models.{WorkInclude, WorksIncludes}
+import weco.catalogue.internal_model.work.generators.{ItemsGenerators, WorkGenerators}
 
-class CatalogueJsonUtilTest extends AnyFunSpec with Matchers with EitherValues with CatalogueJsonUtil with WorkGenerators {
+class CatalogueJsonUtilTest extends AnyFunSpec with Matchers with EitherValues with CatalogueJsonUtil with WorkGenerators with ItemsGenerators {
   describe("WorkOps") {
     it("serialises a work as JSON") {
       val w = indexedWork()
@@ -21,6 +21,108 @@ class CatalogueJsonUtilTest extends AnyFunSpec with Matchers with EitherValues w
            |{
            |  "id" : "${w.id}",
            |  "title" : "${w.data.title.get}",
+           |  "alternativeTitles" : [],
+           |  "availabilities" : [],
+           |  "type" : "Work"
+           |}
+           |""".stripMargin
+
+      json shouldBe equivalentTo(expectedJson)
+    }
+
+    it("includes identifiers") {
+      val w = indexedWork()
+      val includes = WorksIncludes(WorkInclude.Identifiers)
+
+      val json = w.asJson(includes)
+
+      val expectedJson =
+        s"""
+           |{
+           |  "id" : "${w.id}",
+           |  "title" : "${w.data.title.get}",
+           |  "identifiers": [
+           |    {
+           |      "identifierType": {
+           |        "id": "${w.sourceIdentifier.identifierType.id}",
+           |        "label": "${w.sourceIdentifier.identifierType.label}",
+           |        "type": "IdentifierType"
+           |      },
+           |      "value": "${w.sourceIdentifier.value}",
+           |      "type": "Identifier"
+           |    }
+           |  ],
+           |  "alternativeTitles" : [],
+           |  "availabilities" : [],
+           |  "type" : "Work"
+           |}
+           |""".stripMargin
+
+      json shouldBe equivalentTo(expectedJson)
+    }
+
+    it("includes identifiers on nested objects") {
+      val location = createDigitalLocation
+      val item = createIdentifiedItemWith(locations = List(location))
+      val w = indexedWork().items(List(item))
+      val includes = WorksIncludes(WorkInclude.Identifiers, WorkInclude.Items)
+
+      val json = w.asJson(includes)
+
+      val expectedJson =
+        s"""
+           |{
+           |  "id" : "${w.id}",
+           |  "title" : "${w.data.title.get}",
+           |  "identifiers": [
+           |    {
+           |      "identifierType": {
+           |        "id": "${w.sourceIdentifier.identifierType.id}",
+           |        "label": "${w.sourceIdentifier.identifierType.label}",
+           |        "type": "IdentifierType"
+           |      },
+           |      "value": "${w.sourceIdentifier.value}",
+           |      "type": "Identifier"
+           |    }
+           |  ],
+           |  "items": [
+           |    {
+           |      "id": "${item.id.canonicalId}",
+           |      "identifiers": [
+           |        {
+           |          "identifierType": {
+           |            "id": "${item.id.sourceIdentifier.identifierType.id}",
+           |            "label": "${item.id.sourceIdentifier.identifierType.label}",
+           |            "type": "IdentifierType"
+           |          },
+           |          "value": "${item.id.sourceIdentifier.value}",
+           |          "type": "Identifier"
+           |        }
+           |      ],
+           |      "locations" : [
+           |        {
+           |          "locationType" : {
+           |            "id" : "${item.locations.head.locationType.id}",
+           |            "label" : "${item.locations.head.locationType.label}",
+           |            "type" : "LocationType"
+           |          },
+           |          "url" : "${location.url}",
+           |          ${location.credit.map(c => s""""credit": "$c",""").getOrElse("")}
+           |          ${location.linkText.map(c => s""""linkText": "$c",""").getOrElse("")}
+           |          "license" : {
+           |            "id" : "${location.license.get.id}",
+           |            "label" : "${location.license.get.label}",
+           |            "url" : "${location.license.get.url}",
+           |            "type" : "License"
+           |          },
+           |          "accessConditions" : [
+           |          ],
+           |          "type" : "DigitalLocation"
+           |        }
+           |      ],
+           |      "type": "Item"
+           |    }
+           |  ],
            |  "alternativeTitles" : [],
            |  "availabilities" : [],
            |  "type" : "Work"


### PR DESCRIPTION
A step towards https://github.com/wellcomecollection/platform/issues/5449

The catalogue API changes the type we use to display result lists in the API like so:

```diff
 type DisplayResultList {
-  results: List[Work | Image]
+  results: List[Json]
 }
```

It's still using the same JSON serialisation code as before, but now it's in the CatalogueJsonUtil trait. Currently what this class does is:

```
val displayWork = DisplayWork(internalWork, includes)
val resultJson = displayWork.toJson
```

but my plan is to tweak it as follows (in a subsequent patch):

```
val displayWork = DisplayWork(internalWork, WorksIncludes.all)
val fullJson = displayWork.toJson
val resultJson = fullJson.removeFieldsBasedOn(includes)
```

This opens the door to us getting `fullJson` from an opaque field in the Elasticsearch index, rather than creating it within the API.

I'm doing this before fiddling with the pipeline because it will let me remove the include-based logic from the display library _before_ I move it into the pipeline repo.