### PR TITLE
Move all the include-handling logic out of DisplayImage

### DIFF
--- a/common/display/src/main/scala/weco/catalogue/display_model/models/DisplayImage.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/models/DisplayImage.scala
@@ -21,7 +21,7 @@ object DisplayImage {
       id = image.id,
       thumbnail = DisplayDigitalLocation(image.state.derivedData.thumbnail),
       locations = image.locations.map(DisplayDigitalLocation(_)),
-      source = DisplayImageSource(image.source, includes = SingleImageIncludes.all),
+      source = DisplayImageSource(image.source),
       visuallySimilar = None,
       withSimilarColors = None,
       withSimilarFeatures = None

--- a/common/display/src/main/scala/weco/catalogue/display_model/models/DisplayImage.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/models/DisplayImage.scala
@@ -8,9 +8,6 @@ case class DisplayImage(
   thumbnail: DisplayDigitalLocation,
   locations: Seq[DisplayDigitalLocation],
   source: DisplayImageSource,
-  visuallySimilar: Option[Seq[DisplayImage]],
-  withSimilarColors: Option[Seq[DisplayImage]],
-  withSimilarFeatures: Option[Seq[DisplayImage]],
   @JsonKey("type") ontologyType: String = "Image"
 )
 
@@ -21,9 +18,6 @@ object DisplayImage {
       id = image.id,
       thumbnail = DisplayDigitalLocation(image.state.derivedData.thumbnail),
       locations = image.locations.map(DisplayDigitalLocation(_)),
-      source = DisplayImageSource(image.source),
-      visuallySimilar = None,
-      withSimilarColors = None,
-      withSimilarFeatures = None
+      source = DisplayImageSource(image.source)
     )
 }

--- a/common/display/src/main/scala/weco/catalogue/display_model/models/DisplayImage.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/models/DisplayImage.scala
@@ -16,15 +16,12 @@ case class DisplayImage(
 
 object DisplayImage {
 
-  def apply(
-    image: Image[ImageState.Indexed],
-    includes: ImageIncludes
-  ): DisplayImage =
+  def apply(image: Image[ImageState.Indexed]): DisplayImage =
     new DisplayImage(
       id = image.id,
       thumbnail = DisplayDigitalLocation(image.state.derivedData.thumbnail),
       locations = image.locations.map(DisplayDigitalLocation(_)),
-      source = DisplayImageSource(image.source, includes),
+      source = DisplayImageSource(image.source, includes = SingleImageIncludes.all),
       visuallySimilar = None,
       withSimilarColors = None,
       withSimilarFeatures = None

--- a/common/display/src/main/scala/weco/catalogue/display_model/models/DisplayImageSource.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/models/DisplayImageSource.scala
@@ -6,45 +6,31 @@ import weco.catalogue.internal_model.image.{ImageSource, ParentWorks}
 case class DisplayImageSource(
   id: String,
   title: Option[String],
-  contributors: Option[List[DisplayContributor]],
-  languages: Option[List[DisplayLanguage]],
-  genres: Option[List[DisplayGenre]],
+  contributors: List[DisplayContributor],
+  languages: List[DisplayLanguage],
+  genres: List[DisplayGenre],
   @JsonKey("type") ontologyType: String
 )
 
 object DisplayImageSource {
 
-  def apply(
-    imageSource: ImageSource,
-    includes: ImageIncludes
-  ): DisplayImageSource =
+  def apply(imageSource: ImageSource): DisplayImageSource =
     imageSource match {
-      case works: ParentWorks =>
-        DisplayImageSource(works, includes)
+      case works: ParentWorks => DisplayImageSource(works)
     }
 
-  def apply(parent: ParentWorks, includes: ImageIncludes): DisplayImageSource =
+  private def apply(parent: ParentWorks): DisplayImageSource =
     new DisplayImageSource(
       id = parent.id.canonicalId.underlying,
       title = parent.canonicalWork.data.title,
       contributors =
-        if (includes.`source.contributors`)
-          Some(
-            parent.canonicalWork.data.contributors
-              .map(DisplayContributor(_, includesIdentifiers = false))
-          )
-        else None,
+        parent.canonicalWork.data.contributors
+          .map { DisplayContributor(_, includesIdentifiers = false) },
       languages =
-        if (includes.`source.languages`)
-          Some(parent.canonicalWork.data.languages.map(DisplayLanguage(_)))
-        else None,
+        parent.canonicalWork.data.languages.map { DisplayLanguage(_) },
       genres =
-        if (includes.`source.genres`)
-          Some(
-            parent.canonicalWork.data.genres
-              .map(DisplayGenre(_, includesIdentifiers = false))
-          )
-        else None,
+        parent.canonicalWork.data.genres
+          .map { DisplayGenre(_, includesIdentifiers = false) },
       ontologyType = "Work"
     )
 }

--- a/common/display/src/main/scala/weco/catalogue/display_model/models/DisplayImageSource.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/models/DisplayImageSource.scala
@@ -23,14 +23,11 @@ object DisplayImageSource {
     new DisplayImageSource(
       id = parent.id.canonicalId.underlying,
       title = parent.canonicalWork.data.title,
-      contributors =
-        parent.canonicalWork.data.contributors
-          .map { DisplayContributor(_, includesIdentifiers = false) },
-      languages =
-        parent.canonicalWork.data.languages.map { DisplayLanguage(_) },
-      genres =
-        parent.canonicalWork.data.genres
-          .map { DisplayGenre(_, includesIdentifiers = false) },
+      contributors = parent.canonicalWork.data.contributors
+        .map { DisplayContributor(_, includesIdentifiers = false) },
+      languages = parent.canonicalWork.data.languages.map { DisplayLanguage(_) },
+      genres = parent.canonicalWork.data.genres
+        .map { DisplayGenre(_, includesIdentifiers = false) },
       ontologyType = "Work"
     )
 }

--- a/common/display/src/main/scala/weco/catalogue/display_model/models/ImagesIncludes.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/models/ImagesIncludes.scala
@@ -64,6 +64,6 @@ object MultipleImagesIncludes {
       `source.languages` = includes.contains(SourceLanguages),
       `source.genres` = includes.contains(SourceGenres)
     )
-  
+
   def none: MultipleImagesIncludes = MultipleImagesIncludes()
 }

--- a/common/display/src/main/scala/weco/catalogue/display_model/models/ImagesIncludes.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/models/ImagesIncludes.scala
@@ -42,16 +42,6 @@ object SingleImageIncludes {
       `source.genres` = includes.contains(SourceGenres)
     )
 
-  def all: SingleImageIncludes =
-    SingleImageIncludes(
-      visuallySimilar = true,
-      withSimilarFeatures = true,
-      withSimilarColors = true,
-      `source.contributors` = true,
-      `source.languages` = true,
-      `source.genres` = true
-    )
-
   def none: SingleImageIncludes = SingleImageIncludes()
 }
 
@@ -74,13 +64,6 @@ object MultipleImagesIncludes {
       `source.languages` = includes.contains(SourceLanguages),
       `source.genres` = includes.contains(SourceGenres)
     )
-
-  def all: MultipleImagesIncludes =
-    MultipleImagesIncludes(
-      `source.contributors` = true,
-      `source.languages` = true,
-      `source.genres` = true
-    )
-
+  
   def none: MultipleImagesIncludes = MultipleImagesIncludes()
 }

--- a/search/src/main/scala/weco/api/search/json/CatalogueJsonUtil.scala
+++ b/search/src/main/scala/weco/api/search/json/CatalogueJsonUtil.scala
@@ -80,7 +80,7 @@ trait CatalogueJsonUtil {
           jsonObj =>
             value match {
               case Some(v) => jsonObj.add(key, v.map(DisplayImage(_)).asJson)
-              case None => jsonObj
+              case None    => jsonObj
             }
         )
       else

--- a/search/src/main/scala/weco/api/search/json/CatalogueJsonUtil.scala
+++ b/search/src/main/scala/weco/api/search/json/CatalogueJsonUtil.scala
@@ -32,7 +32,7 @@ trait CatalogueJsonUtil {
 
   implicit class ImageOps(im: Image[ImageState.Indexed]) {
     def asJson(includes: MultipleImagesIncludes): Json =
-      DisplayImage(im, includes = MultipleImagesIncludes.all).asJson
+      DisplayImage(im).asJson
         .withIncludes(includes)
 
     def asJson(
@@ -42,7 +42,7 @@ trait CatalogueJsonUtil {
       withSimilarFeatures: Option[Seq[Image[ImageState.Indexed]]]
     ): Json = {
       val baseJson =
-        DisplayImage(im, includes = SingleImageIncludes.all).asJson
+        DisplayImage(im).asJson
           .addImagesIf(
             includes.visuallySimilar,
             key = "visuallySimilar",
@@ -79,11 +79,7 @@ trait CatalogueJsonUtil {
         j.mapObject(
           jsonObj =>
             value match {
-              case Some(v) =>
-                jsonObj.add(
-                  key,
-                  v.map(DisplayImage(_, SingleImageIncludes.all)).asJson
-                )
+              case Some(v) => jsonObj.add(key, v.map(DisplayImage(_)).asJson)
               case None => jsonObj
             }
         )


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5449

This removes the `includes` from `DisplayImage` – in practice, after #390 we're always creating DisplayImage with a complete set of fields, then adding/removing them as arbitrary JSON later. We can simplify it by removing the include-based conditionals.