### PR TITLE
Read display documents from the Elasticsearch index

### DIFF
--- a/common/search/src/test/resources/fixtures/list-of-works.0.json
+++ b/common/search/src/test/resources/fixtures/list-of-works.0.json
@@ -1,0 +1,136 @@
+{
+  "description" : "one of a list of works",
+  "createdAt" : "2022-04-28T13:28:29.048Z",
+  "id" : "equ81tpb",
+  "document" : {
+    "debug" : {
+      "source" : {
+        "identifier" : {
+          "identifierType" : {
+            "id" : "miro-image-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "dgZfc8BAUa"
+        },
+        "version" : 46,
+        "modifiedTime" : "2022-03-31T19:22:48Z"
+      },
+      "mergedTime" : "2022-03-31T19:22:48Z",
+      "indexedTime" : "2022-04-28T13:28:28.506Z",
+      "redirectSources" : [
+      ]
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "miro-image-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "dgZfc8BAUa"
+      },
+      "canonicalId" : "equ81tpb",
+      "mergedTime" : "2022-03-31T19:22:48Z",
+      "sourceModifiedTime" : "2022-03-31T19:22:48Z",
+      "indexedTime" : "2022-04-28T13:28:28.506Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "data" : {
+      "title" : "title-2TWOPFt15v",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : null,
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "display" : {
+      "id" : "equ81tpb",
+      "title" : "title-2TWOPFt15v",
+      "alternativeTitles" : [
+      ],
+      "contributors" : [
+      ],
+      "identifiers" : [
+        {
+          "identifierType" : {
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
+            "type" : "IdentifierType"
+          },
+          "value" : "dgZfc8BAUa",
+          "type" : "Identifier"
+        }
+      ],
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "availabilities" : [
+      ],
+      "production" : [
+      ],
+      "languages" : [
+      ],
+      "notes" : [
+      ],
+      "images" : [
+      ],
+      "parts" : [
+      ],
+      "partOf" : [
+      ],
+      "precededBy" : [
+      ],
+      "succeededBy" : [
+      ],
+      "type" : "Work"
+    },
+    "type" : "Visible"
+  }
+}

--- a/copy_fixtures.py
+++ b/copy_fixtures.py
@@ -7,10 +7,7 @@ import shutil
 
 PIPELINE_ROOT = os.path.join(os.environ["HOME"], "repos/pipeline")
 
-prefixes = [
-    "common/internal_model/src/test/resources",
-    "fixtures",
-]
+prefixes = ["common/internal_model/src/test/resources", "fixtures"]
 
 for prefix in prefixes:
     for path in glob.glob(f"{PIPELINE_ROOT}/{prefix}/*.json"):

--- a/copy_fixtures.py
+++ b/copy_fixtures.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import glob
+import os
+import shutil
+
+
+PIPELINE_ROOT = os.path.join(os.environ["HOME"], "repos/pipeline")
+
+prefixes = [
+    "common/internal_model/src/test/resources",
+    "fixtures",
+]
+
+for prefix in prefixes:
+    for path in glob.glob(f"{PIPELINE_ROOT}/{prefix}/*.json"):
+        shutil.copyfile(
+            path,
+            os.path.join(
+                "common/search/src/test/resources/fixtures", os.path.basename(path)
+            ),
+        )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object WellcomeDependencies {
     val monitoring = defaultVersion
     val storage = defaultVersion
     val elasticsearch = defaultVersion
-    val internalModel = "6473.2d6f8b2a0f86c527f0002a49992e757f53745d3b"
+    val internalModel = "6501.59eab9b62a30c20ce8a138bb631e6c2f77418968"
   }
 
   val internalModel: Seq[ModuleID] = library(

--- a/search/src/test/scala/weco/api/search/ApiTestBase.scala
+++ b/search/src/test/scala/weco/api/search/ApiTestBase.scala
@@ -111,7 +111,10 @@ trait ApiTestBase extends ApiFixture with LocalResources {
 
       fixture match {
         case Success(f) => f
-        case Failure(err) => throw new IllegalArgumentException(s"Unable to read fixture $id: $err")
+        case Failure(err) =>
+          throw new IllegalArgumentException(
+            s"Unable to read fixture $id: $err"
+          )
       }
     }
 

--- a/search/src/test/scala/weco/api/search/ApiTestBase.scala
+++ b/search/src/test/scala/weco/api/search/ApiTestBase.scala
@@ -1,10 +1,19 @@
 package weco.api.search
 
 import akka.http.scaladsl.server.Route
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.Index
+import io.circe.Json
 import org.scalatest.Assertion
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.scalatest.time.{Seconds, Span}
 import weco.api.search.fixtures.ApiFixture
+import weco.fixtures.LocalResources
+import weco.json.JsonUtil._
 
-trait ApiTestBase extends ApiFixture {
+import scala.util.{Failure, Success, Try}
+
+trait ApiTestBase extends ApiFixture with LocalResources {
   val publicRootUri = "https://api-testing.local/catalogue/v2"
 
   // This is the path relative to which requests are made on the host,
@@ -89,4 +98,37 @@ trait ApiTestBase extends ApiFixture {
     assertJsonResponse(route, path)(
       Status.NotFound -> notFound(description = description)
     )
+
+  private case class Fixture(id: String, document: Json)
+
+  def indexFixtures(
+    index: Index,
+    fixtureIds: String*
+  ): Unit = {
+    val fixtures = fixtureIds.map { id =>
+      val fixture = Try { readResource(s"fixtures/$id.json") }
+        .flatMap(jsonString => fromJson[Fixture](jsonString))
+
+      fixture match {
+        case Success(f) => f
+        case Failure(err) => throw new IllegalArgumentException(s"Unable to read fixture $id: $err")
+      }
+    }
+
+    val result = elasticClient.execute(
+      bulk(
+        fixtures.map { fixture =>
+          indexInto(index.name)
+            .id(fixture.id)
+            .doc(fixture.document.noSpaces)
+        }
+      ).refreshImmediately
+    )
+
+    // With a large number of works this can take a long time
+    // 30 seconds should be enough
+    whenReady(result, Timeout(Span(30, Seconds))) { _ =>
+      getSizeOf(index) shouldBe fixtures.size
+    }
+  }
 }

--- a/search/src/test/scala/weco/api/search/works/WorksTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksTest.scala
@@ -13,7 +13,14 @@ class WorksTest
   it("returns a list of works") {
     withWorksApi {
       case (worksIndex, routes) =>
-        indexFixtures(worksIndex, "list-of-works.0", "list-of-works.1", "list-of-works.2", "list-of-works.3", "list-of-works.4")
+        indexFixtures(
+          worksIndex,
+          "list-of-works.0",
+          "list-of-works.1",
+          "list-of-works.2",
+          "list-of-works.3",
+          "list-of-works.4"
+        )
 
         assertJsonResponse(routes, path = s"$rootPath/works") {
           Status.OK ->

--- a/search/src/test/scala/weco/api/search/works/WorksTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksTest.scala
@@ -13,14 +13,55 @@ class WorksTest
   it("returns a list of works") {
     withWorksApi {
       case (worksIndex, routes) =>
-        val works = indexedWorks(count = 3).sortBy {
-          _.state.canonicalId
-        }
+        indexFixtures(worksIndex, "list-of-works.0", "list-of-works.1", "list-of-works.2", "list-of-works.3", "list-of-works.4")
 
-        insertIntoElasticsearch(worksIndex, works: _*)
-
-        assertJsonResponse(routes, s"$rootPath/works") {
-          Status.OK -> worksListResponse(works = works)
+        assertJsonResponse(routes, path = s"$rootPath/works") {
+          Status.OK ->
+            """
+              |{
+              |  "type": "ResultList",
+              |  "pageSize": 10,
+              |  "totalPages": 1,
+              |  "totalResults": 5,
+              |  "results": [
+              |    {
+              |      "id" : "equ81tpb",
+              |      "title" : "title-2TWOPFt15v",
+              |      "alternativeTitles" : [],
+              |      "availabilities": [],
+              |      "type" : "Work"
+              |    },
+              |    {
+              |      "id" : "jtwv1ndp",
+              |      "title" : "title-H7sjiP63hv",
+              |      "alternativeTitles" : [],
+              |      "availabilities": [],
+              |      "type": "Work"
+              |    },
+              |    {
+              |      "id" : "suihraob",
+              |      "title" : "title-2RuvBbFbQP",
+              |      "alternativeTitles" : [],
+              |      "availabilities": [],
+              |      "type": "Work"
+              |    },
+              |    {
+              |      "id" : "vbi1ii19",
+              |      "title" : "title-WjGGR8UNWu",
+              |      "alternativeTitles" : [],
+              |      "availabilities": [],
+              |      "type": "Work"
+              |    },
+              |    {
+              |      "id" : "whfyqts0",
+              |      "title" : "title-coJXQqPyux",
+              |      "alternativeTitles" : [],
+              |      "availabilities": [],
+              |      "type": "Work"
+              |    }
+              |  ]
+              |}
+              |""".stripMargin
         }
     }
   }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5449

This patch updates the API to read the `display` property of documents in the index and render that, rather than serialising the entire internal model and converting to a display model.

It uses the JSON fixtures created in https://github.com/wellcomecollection/catalogue-pipeline/pull/2082, and includes a rudimentary script for copying fixtures from one repo to another.

This patch doesn't compile, but it contains the key parts:

- `ApiTestBase.scala` has the logic for extracting fixtures and indexing them into ES. 
- `WorksTest.scala` uses this new logic, and is the first (passing) test exercising the new code path. It shows what I imagine API tests might look like when we get this working.

There's way more work to get all the API tests compiling and passing, so this is more of a sense check than a proper review. I have got them compiling in a separate branch, but this PR is really about sense checking the overall approach more than working code.