### PR TITLE
Hard-code an empty JSON result from the API

### DIFF
--- a/search/src/test/scala/weco/api/search/ApiTestBase.scala
+++ b/search/src/test/scala/weco/api/search/ApiTestBase.scala
@@ -13,11 +13,15 @@ trait ApiTestBase extends ApiFixture {
   val rootPath: String = ""
 
   def emptyJsonResult: String =
-    s"""
-       |{
-       |  ${resultList(totalPages = 0, totalResults = 0)},
-       |  "results": []
-       |}""".stripMargin
+    """
+      |{
+      |  "type": "ResultList",
+      |  "pageSize": 10,
+      |  "totalPages": 0,
+      |  "totalResults": 0,
+      |  "results": []
+      |}
+      |""".stripMargin
 
   def badRequest(description: String) =
     s"""{


### PR DESCRIPTION
A tiny piece spun out of #399 in the style of the new tests.