### PR TITLE
Convert WorksServiceTest to use JSON test documents

### DIFF
--- a/search/src/test/scala/weco/api/search/fixtures/TestDocumentFixtures.scala
+++ b/search/src/test/scala/weco/api/search/fixtures/TestDocumentFixtures.scala
@@ -1,0 +1,82 @@
+package weco.api.search.fixtures
+
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.Index
+import io.circe.Json
+import org.scalatest.Suite
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.scalatest.time.{Seconds, Span}
+import weco.catalogue.internal_model.work.{Work, WorkState}
+import weco.catalogue.internal_model.Implicits._
+import weco.elasticsearch.test.fixtures.ElasticsearchFixtures
+import weco.fixtures.LocalResources
+import weco.json.JsonUtil._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success, Try}
+
+trait TestDocumentFixtures extends ElasticsearchFixtures with LocalResources {
+  this: Suite =>
+
+  val visibleWorks = (0 to 4).map(i => s"works.visible.$i")
+  val invisibleWorks = (0 to 2).map(i => s"works.invisible.$i")
+  val redirectedWorks = (0 to 1).map(i => s"works.redirected.$i")
+  val deletedWorks = (0 to 3).map(i => s"works.deleted.$i")
+
+  val works = visibleWorks ++ invisibleWorks ++ redirectedWorks ++ deletedWorks
+
+  val worksFormatBooks = (0 to 3).map(i => s"works.formats.$i.Books")
+  val worksFormatJournals = (4 to 6).map(i => s"works.formats.$i.Journals")
+  val worksFormatAudio = (7 to 8).map(i => s"works.formats.$i.Audio")
+  val worksFormatPictures = (9 to 9).map(i => s"works.formats.$i.Pictures")
+
+  val worksFormat = worksFormatBooks ++ worksFormatJournals ++ worksFormatAudio ++ worksFormatPictures
+
+  protected case class TestDocument(id: String, document: Json, work: Work[WorkState.Indexed])
+
+  def getTestDocuments(ids: Seq[String]): Seq[TestDocument] =
+    ids.map { id =>
+      val doc = Try {
+        readResource(s"test_documents/$id.json")
+      }
+        .flatMap(jsonString => fromJson[TestDocument](jsonString))
+
+      doc match {
+        case Success(d) => d
+        case Failure(err) => throw new IllegalArgumentException(s"Unable to read fixture $id: $err")
+      }
+    }
+
+  def indexTestDocuments(
+    index: Index,
+    documentIds: String*
+  ): Unit = {
+    val documents = getTestDocuments(documentIds)
+
+    val result = elasticClient.execute(
+      bulk(
+        documents.map { fixture =>
+          indexInto(index.name)
+            .id(fixture.id)
+            .doc(toJson(fixture.work).get)
+//            .doc(fixture.document.noSpaces)
+        }
+      ).refreshImmediately
+    )
+
+    // With a large number of works this can take a long time
+    // 30 seconds should be enough
+    whenReady(result, Timeout(Span(30, Seconds))) { _ =>
+      getSizeOf(index) shouldBe documents.size
+    }
+  }
+
+  private def getSizeOf(index: Index): Long =
+    elasticClient
+      .execute {
+        count(index.name)
+      }
+      .await
+      .result
+      .count
+}

--- a/search/src/test/scala/weco/api/search/fixtures/TestDocumentFixtures.scala
+++ b/search/src/test/scala/weco/api/search/fixtures/TestDocumentFixtures.scala
@@ -32,18 +32,24 @@ trait TestDocumentFixtures extends ElasticsearchFixtures with LocalResources {
 
   val worksFormat = worksFormatBooks ++ worksFormatJournals ++ worksFormatAudio ++ worksFormatPictures
 
-  protected case class TestDocument(id: String, document: Json, work: Work[WorkState.Indexed])
+  protected case class TestDocument(
+    id: String,
+    document: Json,
+    work: Work[WorkState.Indexed]
+  )
 
   def getTestDocuments(ids: Seq[String]): Seq[TestDocument] =
     ids.map { id =>
       val doc = Try {
         readResource(s"test_documents/$id.json")
-      }
-        .flatMap(jsonString => fromJson[TestDocument](jsonString))
+      }.flatMap(jsonString => fromJson[TestDocument](jsonString))
 
       doc match {
         case Success(d) => d
-        case Failure(err) => throw new IllegalArgumentException(s"Unable to read fixture $id: $err")
+        case Failure(err) =>
+          throw new IllegalArgumentException(
+            s"Unable to read fixture $id: $err"
+          )
       }
     }
 

--- a/search/src/test/scala/weco/api/search/services/WorksServiceTest.scala
+++ b/search/src/test/scala/weco/api/search/services/WorksServiceTest.scala
@@ -1,49 +1,23 @@
 package weco.api.search.services
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
-import com.sksamuel.elastic4s.Index
-import org.scalatest.{Assertion, EitherValues}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.catalogue.internal_model.work.generators.{
-  ItemsGenerators,
-  WorkGenerators
-}
-import weco.catalogue.internal_model.Implicits._
+import org.scalatest.{Assertion, EitherValues}
+import weco.api.search.JsonHelpers
+import weco.api.search.elasticsearch.{DocumentNotFoundError, ElasticsearchService, IndexNotFoundError}
+import weco.api.search.fixtures.TestDocumentFixtures
+import weco.api.search.generators.SearchOptionsGenerators
 import weco.api.search.models._
-import weco.catalogue.internal_model.index.IndexFixtures
-import weco.api.search.elasticsearch.{
-  DocumentNotFoundError,
-  ElasticsearchService,
-  IndexNotFoundError
-}
-import weco.api.search.generators.{PeriodGenerators, SearchOptionsGenerators}
 import weco.api.search.models.index.IndexedWork
 import weco.api.search.models.request.WorkAggregationRequest
-import weco.api.search.models.{
-  Aggregation,
-  AggregationBucket,
-  DateRangeFilter,
-  FormatFilter,
-  ItemLocationTypeIdFilter,
-  SearchQuery,
-  WorkAggregations,
-  WorkSearchOptions
-}
-import weco.catalogue.internal_model.identifiers.IdState
-import weco.catalogue.internal_model.locations.{
-  DigitalLocationType,
-  LocationType,
-  PhysicalLocationType
-}
-import weco.catalogue.internal_model.work.{Item, Work}
-import weco.catalogue.internal_model.work.Format._
-import weco.catalogue.internal_model.work.WorkState.Indexed
+import weco.catalogue.internal_model.generators.IdentifiersGenerators
+import weco.catalogue.internal_model.identifiers.CanonicalId
+import weco.catalogue.internal_model.index.IndexFixtures
+import weco.catalogue.internal_model.work.Format
 
-import scala.util.Random
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class WorksServiceTest
     extends AnyFunSpec
@@ -51,9 +25,9 @@ class WorksServiceTest
     with Matchers
     with EitherValues
     with SearchOptionsGenerators
-    with ItemsGenerators
-    with WorkGenerators
-    with PeriodGenerators {
+    with JsonHelpers
+    with IdentifiersGenerators
+    with TestDocumentFixtures {
 
   val worksService = new WorksService(
     elasticsearchService = new ElasticsearchService(elasticClient)
@@ -63,12 +37,10 @@ class WorksServiceTest
 
   describe("listOrSearch") {
     it("gets records in Elasticsearch") {
-      val works = indexedWorks(count = 2)
-
       assertListOrSearchResultIsCorrect(
         allWorks = works,
-        expectedWorks = works,
-        expectedTotalResults = 2
+        expectedWorks = visibleWorks,
+        expectedTotalResults = visibleWorks.length
       )
     }
 
@@ -82,52 +54,29 @@ class WorksServiceTest
 
     it("returns an empty result set when asked for a page that does not exist") {
       assertListOrSearchResultIsCorrect(
-        allWorks = indexedWorks(count = 3),
+        allWorks = visibleWorks,
         expectedWorks = Seq(),
-        expectedTotalResults = 3,
+        expectedTotalResults = visibleWorks.length,
         worksSearchOptions = createWorksSearchOptionsWith(pageNumber = 4)
       )
     }
 
-    it("does not list invisible works") {
-      val visibleWorks = indexedWorks(count = 3)
-      val invisibleWorks = indexedWorks(count = 3).map { _.invisible() }
-
-      assertListOrSearchResultIsCorrect(
-        allWorks = visibleWorks ++ invisibleWorks,
-        expectedWorks = visibleWorks,
-        expectedTotalResults = visibleWorks.size,
-        worksSearchOptions = createWorksSearchOptions
-      )
-    }
-
     it("filters records by format") {
-      val work1 = indexedWork().format(ManuscriptsAsian)
-      val work2 = indexedWork().format(ManuscriptsAsian)
-      val workWithWrongFormat = indexedWork().format(CDRoms)
-
       assertListOrSearchResultIsCorrect(
-        allWorks = Seq(work1, work2, workWithWrongFormat),
-        expectedWorks = Seq(work1, work2),
-        expectedTotalResults = 2,
+        allWorks = worksFormat,
+        expectedWorks = worksFormatBooks,
+        expectedTotalResults = worksFormatBooks.length,
         worksSearchOptions = createWorksSearchOptionsWith(
-          filters = List(FormatFilter(Seq("b")))
+          filters = List(FormatFilter(Seq("a")))
         )
       )
-    }
-
-    it("filters records by multiple formats") {
-      val work1 = indexedWork().format(ManuscriptsAsian)
-      val work2 = indexedWork().format(ManuscriptsAsian)
-      val work3 = indexedWork().format(Books)
-      val workWithWrongFormat = indexedWork().format(CDRoms)
 
       assertListOrSearchResultIsCorrect(
-        allWorks = Seq(work1, work2, work3, workWithWrongFormat),
-        expectedWorks = Seq(work1, work2, work3),
-        expectedTotalResults = 3,
+        allWorks = worksFormat,
+        expectedWorks = worksFormatBooks ++ worksFormatAudio,
+        expectedTotalResults = worksFormatBooks.length + worksFormatAudio.length,
         worksSearchOptions = createWorksSearchOptionsWith(
-          filters = List(FormatFilter(List("b", "a")))
+          filters = List(FormatFilter(Seq("a", "i")))
         )
       )
     }
@@ -149,11 +98,8 @@ class WorksServiceTest
     }
 
     it("only finds results that match a query if doing a full-text search") {
-      val workDodo = indexedWork().title("A drawing of a dodo")
-      val workMouse = indexedWork().title("A mezzotint of a mouse")
-
       assertListOrSearchResultIsCorrect(
-        allWorks = List(workDodo, workMouse),
+        allWorks = List("work-title-dodo", "work-title-mouse"),
         expectedWorks = List(),
         expectedTotalResults = 0,
         worksSearchOptions =
@@ -161,8 +107,8 @@ class WorksServiceTest
       )
 
       assertListOrSearchResultIsCorrect(
-        allWorks = List(workDodo, workMouse),
-        expectedWorks = List(workDodo),
+        allWorks = List("work-title-dodo", "work-title-mouse"),
+        expectedWorks = List("work-title-dodo"),
         expectedTotalResults = 1,
         worksSearchOptions =
           createWorksSearchOptionsWith(searchQuery = Some(SearchQuery("dodo")))
@@ -170,206 +116,68 @@ class WorksServiceTest
     }
 
     it("doesn't throw an exception if passed an invalid query string") {
-      val workEmu = indexedWork().title("An etching of an emu")
-
       // unmatched quotes are a lexical error in the Elasticsearch parser
       assertListOrSearchResultIsCorrect(
-        allWorks = List(workEmu),
-        expectedWorks = List(workEmu),
+        allWorks = List("work-title-dodo"),
+        expectedWorks = List("work-title-dodo"),
         expectedTotalResults = 1,
         worksSearchOptions = createWorksSearchOptionsWith(
-          searchQuery = Some(SearchQuery("emu \""))
+          searchQuery = Some(SearchQuery("dodo \""))
         )
       )
     }
 
-    it("returns results in consistent sort order") {
-      val title =
-        s"ABBA ${Random.alphanumeric.filterNot(_.equals('A')) take 10 mkString}"
-
-      // We have a secondary sort on canonicalId in ElasticsearchService.
-      // Since every work has the same title, we expect them to be returned in
-      // ID order when we search for "A".
-      val works = (1 to 5)
-        .map { _ =>
-          indexedWork().title(title)
-        }
-        .sortBy(_.state.canonicalId)
-
-      assertListOrSearchResultIsCorrect(
-        allWorks = works,
-        expectedWorks = works,
-        expectedTotalResults = works.size,
-        worksSearchOptions =
-          createWorksSearchOptionsWith(searchQuery = Some(SearchQuery("abba")))
-      )
-    }
-
     it("returns everything if we ask for a limit > result size") {
-      val works = indexedWorks(count = 10)
-
       assertListOrSearchResultIsCorrect(
-        allWorks = works,
-        expectedWorks = works.sortBy(_.state.canonicalId),
-        expectedTotalResults = works.size,
+        allWorks = visibleWorks,
+        expectedWorks = visibleWorks,
+        expectedTotalResults = visibleWorks.size,
         worksSearchOptions = createWorksSearchOptionsWith(
-          pageSize = works.length + 1
+          pageSize = visibleWorks.length + 1
         )
       )
     }
 
     it("returns a page from the beginning of the result set") {
-      val works = indexedWorks(count = 10)
-
       assertListOrSearchResultIsCorrect(
-        allWorks = works,
-        expectedWorks = works.sortBy(_.state.canonicalId).slice(0, 4),
-        expectedTotalResults = works.size,
-        worksSearchOptions = createWorksSearchOptionsWith(pageSize = 4)
+        allWorks = visibleWorks,
+        expectedWorks = visibleWorks.slice(0, 2),
+        expectedTotalResults = visibleWorks.size,
+        worksSearchOptions = createWorksSearchOptionsWith(
+          pageSize = 2
+        )
       )
     }
 
     it("returns a page from halfway through the result set") {
-      val works = indexedWorks(count = 10)
-
       assertListOrSearchResultIsCorrect(
-        allWorks = works,
-        expectedWorks = works.sortBy(_.state.canonicalId).slice(4, 8),
-        expectedTotalResults = works.size,
-        worksSearchOptions =
-          createWorksSearchOptionsWith(pageSize = 4, pageNumber = 2)
+        allWorks = visibleWorks,
+        expectedWorks = visibleWorks.slice(2, 4),
+        expectedTotalResults = visibleWorks.size,
+        worksSearchOptions = createWorksSearchOptionsWith(
+          pageSize = 2, pageNumber = 2
+        )
       )
     }
 
     it("returns a page from the end of the result set") {
-      val works = indexedWorks(count = 10)
-
       assertListOrSearchResultIsCorrect(
-        allWorks = works,
-        expectedWorks = works.sortBy(_.state.canonicalId).slice(7, 10),
-        expectedTotalResults = works.size,
+        allWorks = visibleWorks,
+        expectedWorks = visibleWorks.slice(4, 6),
+        expectedTotalResults = visibleWorks.size,
         worksSearchOptions = createWorksSearchOptionsWith(
-          pageSize = 7,
-          pageNumber = 2
+          pageSize = 2, pageNumber = 3
         )
       )
     }
 
     it("returns an empty page if asked for a limit > result size") {
-      val works = indexedWorks(count = 10)
-
       assertListOrSearchResultIsCorrect(
-        allWorks = works,
-        expectedWorks = List(),
-        expectedTotalResults = works.size,
+        allWorks = visibleWorks,
+        expectedWorks = Seq(),
+        expectedTotalResults = visibleWorks.size,
         worksSearchOptions = createWorksSearchOptionsWith(
-          pageSize = 1,
-          pageNumber = works.length * 2
-        )
-      )
-    }
-
-    it("filters list results by format") {
-      val work1 = indexedWork().format(ManuscriptsAsian)
-      val work2 = indexedWork().format(ManuscriptsAsian)
-      val workWithWrongFormat = indexedWork().format(CDRoms)
-
-      assertListOrSearchResultIsCorrect(
-        allWorks = List(work1, work2, workWithWrongFormat),
-        expectedWorks = List(work1, work2),
-        expectedTotalResults = 2,
-        worksSearchOptions = createWorksSearchOptionsWith(
-          filters = List(FormatFilter(Seq(ManuscriptsAsian.id)))
-        )
-      )
-    }
-
-    it("filters list results with multiple formats") {
-      val work1 = indexedWork().format(ManuscriptsAsian)
-      val work2 = indexedWork().format(ManuscriptsAsian)
-      val work3 = indexedWork().format(Books)
-      val workWithWrongFormat = indexedWork().format(CDRoms)
-
-      assertListOrSearchResultIsCorrect(
-        allWorks = List(work1, work2, work3, workWithWrongFormat),
-        expectedWorks = List(work1, work2, work3),
-        expectedTotalResults = 3,
-        worksSearchOptions = createWorksSearchOptionsWith(
-          filters = List(FormatFilter(List(ManuscriptsAsian.id, Books.id)))
-        )
-      )
-    }
-
-    it("filters results by item locationType") {
-      val work = indexedWork()
-        .title("Tumbling tangerines")
-        .items(
-          List(
-            createItemWithLocationType(LocationType.IIIFImageAPI),
-            createItemWithLocationType(LocationType.ClosedStores)
-          )
-        )
-
-      val notMatchingWork = indexedWork()
-        .title("Tumbling tangerines")
-        .items(
-          List(
-            createItemWithLocationType(LocationType.ClosedStores)
-          )
-        )
-
-      assertListOrSearchResultIsCorrect(
-        allWorks = List(work, notMatchingWork),
-        expectedWorks = List(work),
-        expectedTotalResults = 1,
-        worksSearchOptions = createWorksSearchOptionsWith(
-          searchQuery = Some(SearchQuery("tangerines")),
-          filters =
-            List(ItemLocationTypeIdFilter(Seq(LocationType.IIIFImageAPI.id)))
-        )
-      )
-    }
-
-    it("filters results by multiple item locationTypes") {
-      val work =
-        indexedWork()
-          .title("Tumbling tangerines")
-          .items(
-            List(
-              createItemWithLocationType(LocationType.IIIFImageAPI),
-              createItemWithLocationType(LocationType.ClosedStores)
-            )
-          )
-
-      val notMatchingWork =
-        indexedWork()
-          .title("Tumbling tangerines")
-          .items(
-            List(
-              createItemWithLocationType(LocationType.ClosedStores)
-            )
-          )
-
-      val work2 =
-        indexedWork()
-          .title("Tumbling tangerines")
-          .items(
-            List(
-              createItemWithLocationType(LocationType.OpenShelves)
-            )
-          )
-
-      assertListOrSearchResultIsCorrect(
-        allWorks = List(work, notMatchingWork, work2),
-        expectedWorks = List(work, work2),
-        expectedTotalResults = 2,
-        worksSearchOptions = createWorksSearchOptionsWith(
-          searchQuery = Some(SearchQuery("tangerines")),
-          filters = List(
-            ItemLocationTypeIdFilter(
-              Seq(LocationType.IIIFImageAPI.id, LocationType.OpenShelves.id)
-            )
-          )
+          pageSize = visibleWorks.size * 2, pageNumber = 2
         )
       )
     }
@@ -377,14 +185,9 @@ class WorksServiceTest
 
   describe("simple query string syntax") {
     it("uses only PHRASE simple query syntax") {
-      val work = indexedWork()
-        .title(
-          "+a -title | with (all the simple) query~4 syntax operators in it*"
-        )
-
       assertListOrSearchResultIsCorrect(
-        allWorks = List(work),
-        expectedWorks = List(work),
+        allWorks = List("works.title-query-syntax"),
+        expectedWorks = List("works.title-query-syntax"),
         expectedTotalResults = 1,
         worksSearchOptions = createWorksSearchOptionsWith(
           searchQuery = Some(
@@ -399,12 +202,10 @@ class WorksServiceTest
     it(
       "doesn't throw a too_many_clauses exception when passed a query that creates too many clauses"
     ) {
-      val work = indexedWork().title("(a b c d e) h")
-
       // This query uses precedence and would exceed the default 1024 clauses
       assertListOrSearchResultIsCorrect(
-        allWorks = List(work),
-        expectedWorks = List(work),
+        allWorks = List("works.title-query-parens"),
+        expectedWorks = List("works.title-query-parens"),
         expectedTotalResults = 1,
         worksSearchOptions = createWorksSearchOptionsWith(
           searchQuery = Some(SearchQuery("(a b c d e) h"))
@@ -413,49 +214,34 @@ class WorksServiceTest
     }
 
     it("aggregates formats") {
-      withLocalWorksIndex { _ =>
-        val work1 = indexedWork().format(Books)
-        val work2 = indexedWork().format(Books)
-        val work3 = indexedWork().format(Audio)
-        val work4 = indexedWork().format(ArchivesAndManuscripts)
-
-        val worksSearchOptions =
-          createWorksSearchOptionsWith(
-            aggregations = List(WorkAggregationRequest.Format)
-          )
-
-        val expectedAggregations = WorkAggregations(
-          Some(
-            Aggregation(
-              List(
-                AggregationBucket(data = Books, count = 2),
-                AggregationBucket(data = ArchivesAndManuscripts, count = 1),
-                AggregationBucket(data = Audio, count = 1)
-              )
+      val expectedAggregations = WorkAggregations(
+        Some(
+          Aggregation(
+            List(
+              AggregationBucket(data = Format.Books, count = 4),
+              AggregationBucket(data = Format.Journals, count = 3),
+              AggregationBucket(data = Format.Audio, count = 2),
+              AggregationBucket(data = Format.Pictures, count = 1),
             )
-          ),
-          None
-        )
+          )
+        ),
+        None
+      )
 
-        assertListOrSearchResultIsCorrect(
-          allWorks = List(work1, work2, work3, work4),
-          expectedWorks = List(work1, work2, work3, work4),
-          expectedTotalResults = 4,
-          expectedAggregations = Some(expectedAggregations),
-          worksSearchOptions = worksSearchOptions
+      assertListOrSearchResultIsCorrect(
+        allWorks = worksFormat,
+        expectedWorks = worksFormat,
+        expectedTotalResults = worksFormat.length,
+        expectedAggregations = Some(expectedAggregations),
+        worksSearchOptions = createWorksSearchOptionsWith(
+          aggregations = List(WorkAggregationRequest.Format)
         )
-      }
+      )
     }
   }
 
   describe("filter works by date") {
-    val work1709 = createWorkWithProductionEventFor(year = "1709")
-    val work1950 = createWorkWithProductionEventFor(year = "1950")
-    val work2000 = createWorkWithProductionEventFor(year = "2000")
-
-    val allWorks = Seq(work1709, work1950, work2000)
-
-    val (fromDate, toDate) = {
+    val (fromDate1900, toDate1962) = {
       val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
       (
         LocalDate.parse("01/01/1900", formatter),
@@ -465,33 +251,78 @@ class WorksServiceTest
 
     it("filters records by date range") {
       assertListOrSearchResultIsCorrect(
-        allWorks = allWorks,
-        expectedWorks = Seq(work1950),
-        expectedTotalResults = 1,
+        allWorks = Seq(
+          "work-production.1098",
+          "work-production.1900",
+          "work-production.1904",
+          "work-production.1976",
+          "work-production.2020",
+        ),
+        expectedWorks = Seq(
+          "work-production.1900",
+          "work-production.1904",
+        ),
+        expectedTotalResults = 2,
         worksSearchOptions = createWorksSearchOptionsWith(
-          filters = DateRangeFilter(Some(fromDate), Some(toDate)) :: Nil
+          filters = List(
+            DateRangeFilter(
+              fromDate = Some(fromDate1900),
+              toDate = Some(toDate1962)
+            )
+          )
         )
       )
     }
 
     it("filters records by from date") {
       assertListOrSearchResultIsCorrect(
-        allWorks = allWorks,
-        expectedWorks = Seq(work1950, work2000),
-        expectedTotalResults = 2,
+        allWorks = Seq(
+          "work-production.1098",
+          "work-production.1900",
+          "work-production.1904",
+          "work-production.1976",
+          "work-production.2020",
+        ),
+        expectedWorks = Seq(
+          "work-production.1900",
+          "work-production.1904",
+          "work-production.1976",
+          "work-production.2020",
+        ),
+        expectedTotalResults = 4,
         worksSearchOptions = createWorksSearchOptionsWith(
-          filters = DateRangeFilter(Some(fromDate), None) :: Nil
+          filters = List(
+            DateRangeFilter(
+              fromDate = Some(fromDate1900),
+              toDate = None
+            )
+          )
         )
       )
     }
 
     it("filters records by to date") {
       assertListOrSearchResultIsCorrect(
-        allWorks = allWorks,
-        expectedWorks = Seq(work1709, work1950),
-        expectedTotalResults = 2,
+        allWorks = Seq(
+          "work-production.1098",
+          "work-production.1900",
+          "work-production.1904",
+          "work-production.1976",
+          "work-production.2020",
+        ),
+        expectedWorks = Seq(
+          "work-production.1098",
+          "work-production.1900",
+          "work-production.1904",
+        ),
+        expectedTotalResults = 3,
         worksSearchOptions = createWorksSearchOptionsWith(
-          filters = DateRangeFilter(None, Some(toDate)) :: Nil
+          filters = List(
+            DateRangeFilter(
+              fromDate = None,
+              toDate = Some(toDate1962)
+            )
+          )
         )
       )
     }
@@ -500,14 +331,12 @@ class WorksServiceTest
   describe("findById") {
     it("gets a Work by id") {
       withLocalWorksIndex { index =>
-        val work = indexedWork()
+        indexTestDocuments(index, "works.visible.0")
 
-        insertIntoElasticsearch(index, work)
-
-        val future = worksService.findById(id = work.state.canonicalId)(index)
+        val future = worksService.findById(id = CanonicalId("7sjip63h"))(index)
 
         whenReady(future) {
-          _ shouldBe Right(IndexedWork(work))
+          _ shouldBe Right(getVisibleWork("works.visible.0"))
         }
       }
 
@@ -537,72 +366,33 @@ class WorksServiceTest
     }
   }
 
+  private def getVisibleWork(id: String): IndexedWork.Visible =
+    getTestDocuments(Seq(id))
+      .map(doc => {
+        val display = getKey(doc.document, "display").get
+        IndexedWork.Visible(display)
+      })
+      .head
+
   private def assertListOrSearchResultIsCorrect(
-    allWorks: Seq[Work[Indexed]],
-    expectedWorks: Seq[Work[Indexed]],
+    allWorks: Seq[String],
+    expectedWorks: Seq[String],
     expectedTotalResults: Int,
     expectedAggregations: Option[WorkAggregations] = None,
     worksSearchOptions: WorkSearchOptions = createWorksSearchOptions
   ): Assertion =
-    assertResultIsCorrect(
-      worksService.listOrSearch
-    )(
-      allWorks,
-      expectedWorks,
-      expectedTotalResults,
-      expectedAggregations,
-      worksSearchOptions
-    )
-
-  private def assertResultIsCorrect(
-    partialSearchFunction: (
-      Index,
-      WorkSearchOptions
-    ) => Future[Either[_, ResultList[IndexedWork.Visible, WorkAggregations]]]
-  )(
-    allWorks: Seq[Work[Indexed]],
-    expectedWorks: Seq[Work[Indexed]],
-    expectedTotalResults: Int,
-    expectedAggregations: Option[WorkAggregations],
-    worksSearchOptions: WorkSearchOptions
-  ): Assertion =
     withLocalWorksIndex { index =>
-      if (allWorks.nonEmpty) {
-        insertIntoElasticsearch(index, allWorks: _*)
-      }
+      indexTestDocuments(index, allWorks: _*)
 
-      val future = partialSearchFunction(index, worksSearchOptions)
+      val future = worksService.listOrSearch(index, worksSearchOptions)
 
       whenReady(future) { result =>
         result.isRight shouldBe true
 
         val works = result.right.get
-        works.results should contain theSameElementsAs expectedWorks.map(
-          IndexedWork(_)
-        )
+        works.results should contain theSameElementsAs expectedWorks.map(getVisibleWork)
         works.totalResults shouldBe expectedTotalResults
         works.aggregations shouldBe expectedAggregations
       }
     }
-
-  private def createItemWithLocationType(
-    locationType: LocationType
-  ): Item[IdState.Minted] =
-    createIdentifiedItemWith(
-      locations = List(
-        locationType match {
-          case LocationType.ClosedStores =>
-            createPhysicalLocationWith(
-              locationType = LocationType.ClosedStores,
-              label = LocationType.ClosedStores.label
-            )
-
-          case physicalLocationType: PhysicalLocationType =>
-            createPhysicalLocationWith(locationType = physicalLocationType)
-
-          case digitalLocationType: DigitalLocationType =>
-            createDigitalLocationWith(locationType = digitalLocationType)
-        }
-      )
-    )
 }

--- a/search/src/test/scala/weco/api/search/services/WorksServiceTest.scala
+++ b/search/src/test/scala/weco/api/search/services/WorksServiceTest.scala
@@ -4,7 +4,11 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, EitherValues}
 import weco.api.search.JsonHelpers
-import weco.api.search.elasticsearch.{DocumentNotFoundError, ElasticsearchService, IndexNotFoundError}
+import weco.api.search.elasticsearch.{
+  DocumentNotFoundError,
+  ElasticsearchService,
+  IndexNotFoundError
+}
 import weco.api.search.fixtures.TestDocumentFixtures
 import weco.api.search.generators.SearchOptionsGenerators
 import weco.api.search.models._
@@ -155,7 +159,8 @@ class WorksServiceTest
         expectedWorks = visibleWorks.slice(2, 4),
         expectedTotalResults = visibleWorks.size,
         worksSearchOptions = createWorksSearchOptionsWith(
-          pageSize = 2, pageNumber = 2
+          pageSize = 2,
+          pageNumber = 2
         )
       )
     }
@@ -166,7 +171,8 @@ class WorksServiceTest
         expectedWorks = visibleWorks.slice(4, 6),
         expectedTotalResults = visibleWorks.size,
         worksSearchOptions = createWorksSearchOptionsWith(
-          pageSize = 2, pageNumber = 3
+          pageSize = 2,
+          pageNumber = 3
         )
       )
     }
@@ -177,7 +183,8 @@ class WorksServiceTest
         expectedWorks = Seq(),
         expectedTotalResults = visibleWorks.size,
         worksSearchOptions = createWorksSearchOptionsWith(
-          pageSize = visibleWorks.size * 2, pageNumber = 2
+          pageSize = visibleWorks.size * 2,
+          pageNumber = 2
         )
       )
     }
@@ -218,13 +225,25 @@ class WorksServiceTest
         format = Some(
           Aggregation(
             List(
-              AggregationBucket(data = Format.Books, count = worksFormatBooks.length),
-              AggregationBucket(data = Format.Journals, count = worksFormatJournals.length),
-              AggregationBucket(data = Format.Audio, count = worksFormatAudio.length),
-              AggregationBucket(data = Format.Pictures, count = worksFormatPictures.length),
+              AggregationBucket(
+                data = Format.Books,
+                count = worksFormatBooks.length
+              ),
+              AggregationBucket(
+                data = Format.Journals,
+                count = worksFormatJournals.length
+              ),
+              AggregationBucket(
+                data = Format.Audio,
+                count = worksFormatAudio.length
+              ),
+              AggregationBucket(
+                data = Format.Pictures,
+                count = worksFormatPictures.length
+              )
             )
           )
-        ),
+        )
       )
 
       assertListOrSearchResultIsCorrect(
@@ -255,11 +274,11 @@ class WorksServiceTest
           "work-production.1900",
           "work-production.1904",
           "work-production.1976",
-          "work-production.2020",
+          "work-production.2020"
         ),
         expectedWorks = Seq(
           "work-production.1900",
-          "work-production.1904",
+          "work-production.1904"
         ),
         expectedTotalResults = 2,
         worksSearchOptions = createWorksSearchOptionsWith(
@@ -280,13 +299,13 @@ class WorksServiceTest
           "work-production.1900",
           "work-production.1904",
           "work-production.1976",
-          "work-production.2020",
+          "work-production.2020"
         ),
         expectedWorks = Seq(
           "work-production.1900",
           "work-production.1904",
           "work-production.1976",
-          "work-production.2020",
+          "work-production.2020"
         ),
         expectedTotalResults = 4,
         worksSearchOptions = createWorksSearchOptionsWith(
@@ -307,12 +326,12 @@ class WorksServiceTest
           "work-production.1900",
           "work-production.1904",
           "work-production.1976",
-          "work-production.2020",
+          "work-production.2020"
         ),
         expectedWorks = Seq(
           "work-production.1098",
           "work-production.1900",
-          "work-production.1904",
+          "work-production.1904"
         ),
         expectedTotalResults = 3,
         worksSearchOptions = createWorksSearchOptionsWith(
@@ -389,7 +408,9 @@ class WorksServiceTest
         result.isRight shouldBe true
 
         val works = result.right.get
-        works.results should contain theSameElementsAs expectedWorks.map(getVisibleWork)
+        works.results should contain theSameElementsAs expectedWorks.map(
+          getVisibleWork
+        )
         works.totalResults shouldBe expectedTotalResults
         works.aggregations shouldBe expectedAggregations
       }

--- a/search/src/test/scala/weco/api/search/services/WorksServiceTest.scala
+++ b/search/src/test/scala/weco/api/search/services/WorksServiceTest.scala
@@ -215,17 +215,16 @@ class WorksServiceTest
 
     it("aggregates formats") {
       val expectedAggregations = WorkAggregations(
-        Some(
+        format = Some(
           Aggregation(
             List(
-              AggregationBucket(data = Format.Books, count = 4),
-              AggregationBucket(data = Format.Journals, count = 3),
-              AggregationBucket(data = Format.Audio, count = 2),
-              AggregationBucket(data = Format.Pictures, count = 1),
+              AggregationBucket(data = Format.Books, count = worksFormatBooks.length),
+              AggregationBucket(data = Format.Journals, count = worksFormatJournals.length),
+              AggregationBucket(data = Format.Audio, count = worksFormatAudio.length),
+              AggregationBucket(data = Format.Pictures, count = worksFormatPictures.length),
             )
           )
         ),
-        None
       )
 
       assertListOrSearchResultIsCorrect(


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5449

I've added the JSON test documents to this repo already; this converts WorksServiceTest to start using them. Although it's still indexing against the old Elasticsearch structure, when we're ready to flip to the new index structure, this test should be relatively unchanged.

This, hopefully, is sufficiently small as to be reviewable, and look how much smaller it is! 🔥 