### PR TITLE
Port some of WorksQueryTest to the new JSON helpers

### DIFF
--- a/search/src/test/scala/weco/api/search/fixtures/TestDocumentFixtures.scala
+++ b/search/src/test/scala/weco/api/search/fixtures/TestDocumentFixtures.scala
@@ -17,7 +17,10 @@ import weco.json.JsonUtil._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success, Try}
 
-trait TestDocumentFixtures extends ElasticsearchFixtures with LocalResources with JsonHelpers {
+trait TestDocumentFixtures
+    extends ElasticsearchFixtures
+    with LocalResources
+    with JsonHelpers {
   this: Suite =>
 
   val visibleWorks = (0 to 4).map(i => s"works.visible.$i")

--- a/search/src/test/scala/weco/api/search/services/WorksServiceTest.scala
+++ b/search/src/test/scala/weco/api/search/services/WorksServiceTest.scala
@@ -3,16 +3,10 @@ package weco.api.search.services
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, EitherValues}
-import weco.api.search.JsonHelpers
-import weco.api.search.elasticsearch.{
-  DocumentNotFoundError,
-  ElasticsearchService,
-  IndexNotFoundError
-}
+import weco.api.search.elasticsearch.{DocumentNotFoundError, ElasticsearchService, IndexNotFoundError}
 import weco.api.search.fixtures.TestDocumentFixtures
 import weco.api.search.generators.SearchOptionsGenerators
 import weco.api.search.models._
-import weco.api.search.models.index.IndexedWork
 import weco.api.search.models.request.WorkAggregationRequest
 import weco.catalogue.internal_model.generators.IdentifiersGenerators
 import weco.catalogue.internal_model.identifiers.CanonicalId
@@ -29,7 +23,6 @@ class WorksServiceTest
     with Matchers
     with EitherValues
     with SearchOptionsGenerators
-    with JsonHelpers
     with IdentifiersGenerators
     with TestDocumentFixtures {
 
@@ -383,14 +376,6 @@ class WorksServiceTest
       }
     }
   }
-
-  private def getVisibleWork(id: String): IndexedWork.Visible =
-    getTestDocuments(Seq(id))
-      .map(doc => {
-        val display = getKey(doc.document, "display").get
-        IndexedWork.Visible(display)
-      })
-      .head
 
   private def assertListOrSearchResultIsCorrect(
     allWorks: Seq[String],

--- a/search/src/test/scala/weco/api/search/services/WorksServiceTest.scala
+++ b/search/src/test/scala/weco/api/search/services/WorksServiceTest.scala
@@ -3,7 +3,11 @@ package weco.api.search.services
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, EitherValues}
-import weco.api.search.elasticsearch.{DocumentNotFoundError, ElasticsearchService, IndexNotFoundError}
+import weco.api.search.elasticsearch.{
+  DocumentNotFoundError,
+  ElasticsearchService,
+  IndexNotFoundError
+}
 import weco.api.search.fixtures.TestDocumentFixtures
 import weco.api.search.generators.SearchOptionsGenerators
 import weco.api.search.models._

--- a/search/src/test/scala/weco/api/search/works/WorksFilteredAggregationsTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksFilteredAggregationsTest.scala
@@ -62,8 +62,9 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
             Status.OK -> s"""
             {
               ${resultList(
-                              totalResults =
-                                aggregatedWorks.count(_.data.format.get == Books)
+                              totalResults = aggregatedWorks.count(
+                                _.data.format.get == Books
+                              )
                             )},
               "aggregations": {
                 "type" : "Aggregations",
@@ -107,8 +108,9 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
             Status.OK -> s"""
             {
               ${resultList(
-                              totalResults =
-                                aggregatedWorks.count(_.data.format.get == Books)
+                              totalResults = aggregatedWorks.count(
+                                _.data.format.get == Books
+                              )
                             )},
               "aggregations": {
                 "type" : "Aggregations",

--- a/search/src/test/scala/weco/api/search/works/WorksFilteredAggregationsTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksFilteredAggregationsTest.scala
@@ -28,7 +28,7 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
    * | che / Chechen | 1     |
    *
    */
-  val works: List[Work.Visible[WorkState.Indexed]] = List(
+  val aggregatedWorks: List[Work.Visible[WorkState.Indexed]] = List(
     (Books, bashkir, "rats"), // a
     (Journals, marathi, "capybara"), // d
     (Pictures, quechua, "tapirs"), // k
@@ -53,7 +53,7 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
     it("when those filters do not have a paired aggregation present") {
       withWorksApi {
         case (worksIndex, routes) =>
-          insertIntoElasticsearch(worksIndex, works: _*)
+          insertIntoElasticsearch(worksIndex, aggregatedWorks: _*)
           assertJsonResponse(
             routes,
             // We expect to see the language buckets for only the works with workType=a
@@ -63,7 +63,7 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
             {
               ${resultList(
                               totalResults =
-                                works.count(_.data.format.get == Books)
+                                aggregatedWorks.count(_.data.format.get == Books)
                             )},
               "aggregations": {
                 "type" : "Aggregations",
@@ -83,7 +83,7 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
                   ]
                 }
               },
-              "results": [${works
+              "results": [${aggregatedWorks
                               .filter(_.data.format.get == Books)
                               .sortBy { _.state.canonicalId }
                               .map(workResponse)
@@ -97,7 +97,7 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
     it("when those filters do have a paired aggregation present") {
       withWorksApi {
         case (worksIndex, routes) =>
-          insertIntoElasticsearch(worksIndex, works: _*)
+          insertIntoElasticsearch(worksIndex, aggregatedWorks: _*)
           assertJsonResponse(
             routes,
             // We expect to see the language buckets for only the works with workType=a
@@ -108,7 +108,7 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
             {
               ${resultList(
                               totalResults =
-                                works.count(_.data.format.get == Books)
+                                aggregatedWorks.count(_.data.format.get == Books)
                             )},
               "aggregations": {
                 "type" : "Aggregations",
@@ -153,7 +153,7 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
                   ]
                 }
               },
-              "results": [${works
+              "results": [${aggregatedWorks
                               .filter(_.data.format.get == Books)
                               .sortBy { _.state.canonicalId }
                               .map(workResponse)
@@ -167,7 +167,7 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
     it("but still returns empty buckets if their paired filter is present") {
       withWorksApi {
         case (worksIndex, routes) =>
-          insertIntoElasticsearch(worksIndex, works: _*)
+          insertIntoElasticsearch(worksIndex, aggregatedWorks: _*)
           assertJsonResponse(
             routes,
             // We expect to see the workType buckets for worktype i/Audio, because that
@@ -217,7 +217,7 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
   it("applies the search query to aggregations paired with an applied filter") {
     withWorksApi {
       case (worksIndex, routes) =>
-        insertIntoElasticsearch(worksIndex, works: _*)
+        insertIntoElasticsearch(worksIndex, aggregatedWorks: _*)
         assertJsonResponse(
           routes,
           s"$rootPath/works?query=rats&workType=a&aggregations=workType"
@@ -225,7 +225,7 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
           Status.OK -> s"""
             {
               ${resultList(
-                            totalResults = works
+                            totalResults = aggregatedWorks
                               .filter(_.data.format.get == Books)
                               .count(_.data.title.contains("rats"))
                           )},
@@ -257,7 +257,7 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
                   ]
                 }
               },
-              "results": [${works
+              "results": [${aggregatedWorks
                             .filter(_.data.format.get == Books)
                             .filter(_.data.title.contains("rats"))
                             .sortBy { _.state.canonicalId }
@@ -272,7 +272,7 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
   it("filters results but not aggregations paired with an applied filter") {
     withWorksApi {
       case (worksIndex, routes) =>
-        insertIntoElasticsearch(worksIndex, works: _*)
+        insertIntoElasticsearch(worksIndex, aggregatedWorks: _*)
         assertJsonResponse(
           routes,
           s"$rootPath/works?workType=a&aggregations=workType"
@@ -281,7 +281,7 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
             {
               ${resultList(
                             totalResults =
-                              works.count(_.data.format.get == Books)
+                              aggregatedWorks.count(_.data.format.get == Books)
                           )},
               "aggregations": {
                 "type" : "Aggregations",
@@ -311,7 +311,7 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
                   ]
                 }
               },
-              "results": [${works
+              "results": [${aggregatedWorks
                             .filter(_.data.format.get == Books)
                             .sortBy { _.state.canonicalId }
                             .map(workResponse)


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5449

I've missed a few tests where I don't have corresponding fixtures yet, but this still gets another chunk of the tests sorted.