### PR TITLE
Move some models and helpers into search common

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/index/IndexedWork.scala
+++ b/common/search/src/main/scala/weco/api/search/models/index/IndexedWork.scala
@@ -1,15 +1,16 @@
 package weco.api.search.models.index
 
 import io.circe.Json
-import weco.api.search.json.CatalogueJsonUtil
-import weco.api.search.models.request.WorksIncludes
+import io.circe.syntax._
+import weco.catalogue.display_model.work.DisplayWork
+import weco.catalogue.display_model.Implicits._
 import weco.catalogue.internal_model.work.{Work, WorkState}
 
 sealed trait IndexedWork
 
 case class Identified(canonicalId: String)
 
-object IndexedWork extends CatalogueJsonUtil {
+object IndexedWork {
   case class Visible(display: Json) extends IndexedWork
 
   // Note: this layer of indirection is because of the current index structure,
@@ -20,18 +21,10 @@ object IndexedWork extends CatalogueJsonUtil {
   case class Invisible() extends IndexedWork
   case class Deleted() extends IndexedWork
 
-  // TODO: These are temporary methods used while we're moving the API to
-  // use the "display" field in the index; once that work is done we can
-  // delete this.
-  object Visible {
-    def apply(work: Work.Visible[WorkState.Indexed]): IndexedWork.Visible =
-      IndexedWork.Visible(work.asJson(WorksIncludes.all))
-  }
-
   def apply(work: Work[WorkState.Indexed]): IndexedWork =
     work match {
       case w: Work.Visible[WorkState.Indexed] =>
-        IndexedWork.Visible(w)
+        IndexedWork.Visible(DisplayWork(w).asJson)
 
       case w: Work.Redirected[WorkState.Indexed] =>
         IndexedWork.Redirected(

--- a/common/search/src/main/scala/weco/api/search/models/index/IndexedWork.scala
+++ b/common/search/src/main/scala/weco/api/search/models/index/IndexedWork.scala
@@ -21,10 +21,13 @@ object IndexedWork {
   case class Invisible() extends IndexedWork
   case class Deleted() extends IndexedWork
 
+  // TODO: These are temporary methods used while we're moving the API to
+  // use the "display" field in the index; once that work is done we can
+  // delete this.
   def apply(work: Work[WorkState.Indexed]): IndexedWork =
     work match {
       case w: Work.Visible[WorkState.Indexed] =>
-        IndexedWork.Visible(DisplayWork(w).asJson)
+        IndexedWork.Visible(DisplayWork(w).asJson.deepDropNullValues)
 
       case w: Work.Redirected[WorkState.Indexed] =>
         IndexedWork.Redirected(

--- a/common/search/src/test/scala/weco/api/search/fixtures/JsonHelpers.scala
+++ b/common/search/src/test/scala/weco/api/search/fixtures/JsonHelpers.scala
@@ -1,4 +1,4 @@
-package weco.api.search
+package weco.api.search.fixtures
 
 import io.circe.Json
 

--- a/common/search/src/test/scala/weco/api/search/fixtures/TestDocumentFixtures.scala
+++ b/common/search/src/test/scala/weco/api/search/fixtures/TestDocumentFixtures.scala
@@ -17,7 +17,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success, Try}
 
 trait TestDocumentFixtures
-  extends ElasticsearchFixtures
+    extends ElasticsearchFixtures
     with LocalResources
     with JsonHelpers {
   this: Suite =>
@@ -70,9 +70,9 @@ trait TestDocumentFixtures
     }
 
   def indexTestDocuments(
-                          index: Index,
-                          documentIds: String*
-                        ): Unit = {
+    index: Index,
+    documentIds: String*
+  ): Unit = {
     val documents = getTestDocuments(documentIds)
 
     val result = elasticClient.execute(
@@ -81,7 +81,7 @@ trait TestDocumentFixtures
           indexInto(index.name)
             .id(fixture.id)
             .doc(toJson(fixture.work).get)
-          //            .doc(fixture.document.noSpaces)
+        //            .doc(fixture.document.noSpaces)
         }
       ).refreshImmediately
     )

--- a/common/search/src/test/scala/weco/api/search/fixtures/TestDocumentFixtures.scala
+++ b/common/search/src/test/scala/weco/api/search/fixtures/TestDocumentFixtures.scala
@@ -6,19 +6,18 @@ import io.circe.Json
 import org.scalatest.Suite
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.time.{Seconds, Span}
-import weco.api.search.JsonHelpers
 import weco.api.search.models.index.IndexedWork
 import weco.catalogue.internal_model.work.{Work, WorkState}
-import weco.catalogue.internal_model.Implicits._
 import weco.elasticsearch.test.fixtures.ElasticsearchFixtures
 import weco.fixtures.LocalResources
 import weco.json.JsonUtil._
+import weco.catalogue.internal_model.Implicits._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success, Try}
 
 trait TestDocumentFixtures
-    extends ElasticsearchFixtures
+  extends ElasticsearchFixtures
     with LocalResources
     with JsonHelpers {
   this: Suite =>
@@ -71,9 +70,9 @@ trait TestDocumentFixtures
     }
 
   def indexTestDocuments(
-    index: Index,
-    documentIds: String*
-  ): Unit = {
+                          index: Index,
+                          documentIds: String*
+                        ): Unit = {
     val documents = getTestDocuments(documentIds)
 
     val result = elasticClient.execute(
@@ -82,7 +81,7 @@ trait TestDocumentFixtures
           indexInto(index.name)
             .id(fixture.id)
             .doc(toJson(fixture.work).get)
-//            .doc(fixture.document.noSpaces)
+          //            .doc(fixture.document.noSpaces)
         }
       ).refreshImmediately
     )

--- a/search/src/main/scala/weco/api/search/services/WorksService.scala
+++ b/search/src/main/scala/weco/api/search/services/WorksService.scala
@@ -9,7 +9,12 @@ import weco.api.search.elasticsearch.{ElasticsearchError, ElasticsearchService}
 import weco.api.search.json.CatalogueJsonUtil
 import weco.api.search.models.index.IndexedWork
 import weco.api.search.models.request.WorksIncludes
-import weco.api.search.models.{AggregationBucket, ElasticAggregations, WorkAggregations, WorkSearchOptions}
+import weco.api.search.models.{
+  AggregationBucket,
+  ElasticAggregations,
+  WorkAggregations,
+  WorkSearchOptions
+}
 import weco.catalogue.internal_model.Implicits
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/search/src/main/scala/weco/api/search/services/WorksService.scala
+++ b/search/src/main/scala/weco/api/search/services/WorksService.scala
@@ -6,13 +6,10 @@ import com.sksamuel.elastic4s.requests.searches.SearchResponse
 import com.sksamuel.elastic4s.requests.searches.aggs.TermsAggregation
 import io.circe.{Decoder, HCursor}
 import weco.api.search.elasticsearch.{ElasticsearchError, ElasticsearchService}
+import weco.api.search.json.CatalogueJsonUtil
 import weco.api.search.models.index.IndexedWork
-import weco.api.search.models.{
-  AggregationBucket,
-  ElasticAggregations,
-  WorkAggregations,
-  WorkSearchOptions
-}
+import weco.api.search.models.request.WorksIncludes
+import weco.api.search.models.{AggregationBucket, ElasticAggregations, WorkAggregations, WorkSearchOptions}
 import weco.catalogue.internal_model.Implicits
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -26,7 +23,8 @@ class WorksService(val elasticsearchService: ElasticsearchService)(
       WorkAggregations,
       WorkSearchOptions
     ]
-    with ElasticAggregations {
+    with ElasticAggregations
+    with CatalogueJsonUtil {
 
   implicit val decoder: Decoder[IndexedWork] =
     (c: HCursor) =>
@@ -36,8 +34,8 @@ class WorksService(val elasticsearchService: ElasticsearchService)(
 
   implicit val decoderV: Decoder[IndexedWork.Visible] =
     (c: HCursor) =>
-      Implicits._decWorkVisibleIndexed.apply(c).map {
-        IndexedWork.Visible(_)
+      Implicits._decWorkVisibleIndexed.apply(c).map { work =>
+        IndexedWork.Visible(work.asJson(WorksIncludes.all))
       }
 
   override protected val requestBuilder

--- a/search/src/test/scala/weco/api/search/ApiSearchTemplatesTest.scala
+++ b/search/src/test/scala/weco/api/search/ApiSearchTemplatesTest.scala
@@ -3,6 +3,7 @@ package weco.api.search
 import akka.http.scaladsl.model.ContentTypes
 import io.circe.Json
 import org.scalatest.matchers.should.Matchers
+import weco.api.search.fixtures.JsonHelpers
 import weco.api.search.works.ApiWorksTestBase
 
 class ApiSearchTemplatesTest


### PR DESCRIPTION
These are pieces we'll want to reuse in the snapshot generator.  This just moves them into the common lib so they're available in that app.

For https://github.com/wellcomecollection/platform/issues/5449