### PR TITLE
Finish porting the works API tests to the new style

### DIFF
--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.0.json
@@ -1,0 +1,231 @@
+{
+  "description" : "examples for the works filtered aggregations tests",
+  "createdAt" : "2022-05-10T09:25:20.138Z",
+  "id" : "m6hdh9ay",
+  "document" : {
+    "debug" : {
+      "source" : {
+        "identifier" : {
+          "identifierType" : {
+            "id" : "calm-record-id"
+          },
+          "ontologyType" : "Work",
+          "value" : "yPhOdmV5Gs"
+        },
+        "version" : 51,
+        "modifiedTime" : "2022-05-03T22:07:02Z"
+      },
+      "mergedTime" : "2022-05-03T22:07:02Z",
+      "indexedTime" : "2022-05-10T09:25:20.138Z",
+      "redirectSources" : [
+      ]
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "calm-record-id"
+        },
+        "ontologyType" : "Work",
+        "value" : "yPhOdmV5Gs"
+      },
+      "canonicalId" : "m6hdh9ay",
+      "mergedTime" : "2022-05-03T22:07:02Z",
+      "sourceModifiedTime" : "2022-05-03T22:07:02Z",
+      "indexedTime" : "2022-05-10T09:25:20.138Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "data" : {
+      "title" : "rats",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "a",
+        "label" : "Books"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "bak",
+          "label" : "Bashkir"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "display" : {
+      "id" : "m6hdh9ay",
+      "title" : "rats",
+      "alternativeTitles" : [
+      ],
+      "workType" : {
+        "id" : "a",
+        "label" : "Books",
+        "type" : "Format"
+      },
+      "contributors" : [
+      ],
+      "identifiers" : [
+        {
+          "identifierType" : {
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
+            "type" : "IdentifierType"
+          },
+          "value" : "yPhOdmV5Gs",
+          "type" : "Identifier"
+        }
+      ],
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "availabilities" : [
+      ],
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "bak",
+          "label" : "Bashkir",
+          "type" : "Language"
+        }
+      ],
+      "notes" : [
+      ],
+      "images" : [
+      ],
+      "parts" : [
+      ],
+      "partOf" : [
+      ],
+      "precededBy" : [
+      ],
+      "succeededBy" : [
+      ],
+      "type" : "Work"
+    },
+    "type" : "Visible"
+  },
+  "work" : {
+    "version" : 51,
+    "data" : {
+      "title" : "rats",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "a",
+        "label" : "Books"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "bak",
+          "label" : "Bashkir"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "calm-record-id"
+        },
+        "ontologyType" : "Work",
+        "value" : "yPhOdmV5Gs"
+      },
+      "canonicalId" : "m6hdh9ay",
+      "mergedTime" : "2022-05-03T22:07:02Z",
+      "sourceModifiedTime" : "2022-05-03T22:07:02Z",
+      "indexedTime" : "2022-05-10T09:25:20.138Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "redirectSources" : [
+    ],
+    "type" : "Visible"
+  }
+}

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.1.json
@@ -1,0 +1,231 @@
+{
+  "description" : "examples for the works filtered aggregations tests",
+  "createdAt" : "2022-05-10T09:25:20.139Z",
+  "id" : "hvvxa3dc",
+  "document" : {
+    "debug" : {
+      "source" : {
+        "identifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "580nNPfAWz"
+        },
+        "version" : 59,
+        "modifiedTime" : "2022-04-16T10:01:21Z"
+      },
+      "mergedTime" : "2022-04-16T10:01:21Z",
+      "indexedTime" : "2022-05-10T09:25:20.138Z",
+      "redirectSources" : [
+      ]
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "sierra-system-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "580nNPfAWz"
+      },
+      "canonicalId" : "hvvxa3dc",
+      "mergedTime" : "2022-04-16T10:01:21Z",
+      "sourceModifiedTime" : "2022-04-16T10:01:21Z",
+      "indexedTime" : "2022-05-10T09:25:20.138Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "data" : {
+      "title" : "capybara",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "d",
+        "label" : "Journals"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "mar",
+          "label" : "Marathi"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "display" : {
+      "id" : "hvvxa3dc",
+      "title" : "capybara",
+      "alternativeTitles" : [
+      ],
+      "workType" : {
+        "id" : "d",
+        "label" : "Journals",
+        "type" : "Format"
+      },
+      "contributors" : [
+      ],
+      "identifiers" : [
+        {
+          "identifierType" : {
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
+            "type" : "IdentifierType"
+          },
+          "value" : "580nNPfAWz",
+          "type" : "Identifier"
+        }
+      ],
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "availabilities" : [
+      ],
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "mar",
+          "label" : "Marathi",
+          "type" : "Language"
+        }
+      ],
+      "notes" : [
+      ],
+      "images" : [
+      ],
+      "parts" : [
+      ],
+      "partOf" : [
+      ],
+      "precededBy" : [
+      ],
+      "succeededBy" : [
+      ],
+      "type" : "Work"
+    },
+    "type" : "Visible"
+  },
+  "work" : {
+    "version" : 59,
+    "data" : {
+      "title" : "capybara",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "d",
+        "label" : "Journals"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "mar",
+          "label" : "Marathi"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "sierra-system-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "580nNPfAWz"
+      },
+      "canonicalId" : "hvvxa3dc",
+      "mergedTime" : "2022-04-16T10:01:21Z",
+      "sourceModifiedTime" : "2022-04-16T10:01:21Z",
+      "indexedTime" : "2022-05-10T09:25:20.139Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "redirectSources" : [
+    ],
+    "type" : "Visible"
+  }
+}

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.2.json
@@ -1,0 +1,231 @@
+{
+  "description" : "examples for the works filtered aggregations tests",
+  "createdAt" : "2022-05-10T09:25:20.139Z",
+  "id" : "v6hxtq4m",
+  "document" : {
+    "debug" : {
+      "source" : {
+        "identifier" : {
+          "identifierType" : {
+            "id" : "miro-image-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "fnYmrG23dz"
+        },
+        "version" : 82,
+        "modifiedTime" : "2022-04-19T17:15:20Z"
+      },
+      "mergedTime" : "2022-04-19T17:15:20Z",
+      "indexedTime" : "2022-05-10T09:25:20.139Z",
+      "redirectSources" : [
+      ]
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "miro-image-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "fnYmrG23dz"
+      },
+      "canonicalId" : "v6hxtq4m",
+      "mergedTime" : "2022-04-19T17:15:20Z",
+      "sourceModifiedTime" : "2022-04-19T17:15:20Z",
+      "indexedTime" : "2022-05-10T09:25:20.139Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "data" : {
+      "title" : "tapirs",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "k",
+        "label" : "Pictures"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "que",
+          "label" : "Quechua"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "display" : {
+      "id" : "v6hxtq4m",
+      "title" : "tapirs",
+      "alternativeTitles" : [
+      ],
+      "workType" : {
+        "id" : "k",
+        "label" : "Pictures",
+        "type" : "Format"
+      },
+      "contributors" : [
+      ],
+      "identifiers" : [
+        {
+          "identifierType" : {
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
+            "type" : "IdentifierType"
+          },
+          "value" : "fnYmrG23dz",
+          "type" : "Identifier"
+        }
+      ],
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "availabilities" : [
+      ],
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "que",
+          "label" : "Quechua",
+          "type" : "Language"
+        }
+      ],
+      "notes" : [
+      ],
+      "images" : [
+      ],
+      "parts" : [
+      ],
+      "partOf" : [
+      ],
+      "precededBy" : [
+      ],
+      "succeededBy" : [
+      ],
+      "type" : "Work"
+    },
+    "type" : "Visible"
+  },
+  "work" : {
+    "version" : 82,
+    "data" : {
+      "title" : "tapirs",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "k",
+        "label" : "Pictures"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "que",
+          "label" : "Quechua"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "miro-image-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "fnYmrG23dz"
+      },
+      "canonicalId" : "v6hxtq4m",
+      "mergedTime" : "2022-04-19T17:15:20Z",
+      "sourceModifiedTime" : "2022-04-19T17:15:20Z",
+      "indexedTime" : "2022-05-10T09:25:20.139Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "redirectSources" : [
+    ],
+    "type" : "Visible"
+  }
+}

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.3.json
@@ -1,0 +1,231 @@
+{
+  "description" : "examples for the works filtered aggregations tests",
+  "createdAt" : "2022-05-10T09:25:20.139Z",
+  "id" : "lthdeniu",
+  "document" : {
+    "debug" : {
+      "source" : {
+        "identifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "Oz1fY94Zzr"
+        },
+        "version" : 6,
+        "modifiedTime" : "2022-04-21T14:22:27Z"
+      },
+      "mergedTime" : "2022-04-21T14:22:27Z",
+      "indexedTime" : "2022-05-10T09:25:20.139Z",
+      "redirectSources" : [
+      ]
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "sierra-system-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "Oz1fY94Zzr"
+      },
+      "canonicalId" : "lthdeniu",
+      "mergedTime" : "2022-04-21T14:22:27Z",
+      "sourceModifiedTime" : "2022-04-21T14:22:27Z",
+      "indexedTime" : "2022-05-10T09:25:20.139Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "data" : {
+      "title" : "rats",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "i",
+        "label" : "Audio"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "bak",
+          "label" : "Bashkir"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "display" : {
+      "id" : "lthdeniu",
+      "title" : "rats",
+      "alternativeTitles" : [
+      ],
+      "workType" : {
+        "id" : "i",
+        "label" : "Audio",
+        "type" : "Format"
+      },
+      "contributors" : [
+      ],
+      "identifiers" : [
+        {
+          "identifierType" : {
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
+            "type" : "IdentifierType"
+          },
+          "value" : "Oz1fY94Zzr",
+          "type" : "Identifier"
+        }
+      ],
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "availabilities" : [
+      ],
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "bak",
+          "label" : "Bashkir",
+          "type" : "Language"
+        }
+      ],
+      "notes" : [
+      ],
+      "images" : [
+      ],
+      "parts" : [
+      ],
+      "partOf" : [
+      ],
+      "precededBy" : [
+      ],
+      "succeededBy" : [
+      ],
+      "type" : "Work"
+    },
+    "type" : "Visible"
+  },
+  "work" : {
+    "version" : 6,
+    "data" : {
+      "title" : "rats",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "i",
+        "label" : "Audio"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "bak",
+          "label" : "Bashkir"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "sierra-system-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "Oz1fY94Zzr"
+      },
+      "canonicalId" : "lthdeniu",
+      "mergedTime" : "2022-04-21T14:22:27Z",
+      "sourceModifiedTime" : "2022-04-21T14:22:27Z",
+      "indexedTime" : "2022-05-10T09:25:20.139Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "redirectSources" : [
+    ],
+    "type" : "Visible"
+  }
+}

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.4.json
@@ -1,0 +1,231 @@
+{
+  "description" : "examples for the works filtered aggregations tests",
+  "createdAt" : "2022-05-10T09:25:20.139Z",
+  "id" : "s5auwvxu",
+  "document" : {
+    "debug" : {
+      "source" : {
+        "identifier" : {
+          "identifierType" : {
+            "id" : "miro-image-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "u7aRU7LCiT"
+        },
+        "version" : 8,
+        "modifiedTime" : "2022-06-02T10:28:40Z"
+      },
+      "mergedTime" : "2022-06-02T10:28:40Z",
+      "indexedTime" : "2022-05-10T09:25:20.139Z",
+      "redirectSources" : [
+      ]
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "miro-image-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "u7aRU7LCiT"
+      },
+      "canonicalId" : "s5auwvxu",
+      "mergedTime" : "2022-06-02T10:28:40Z",
+      "sourceModifiedTime" : "2022-06-02T10:28:40Z",
+      "indexedTime" : "2022-05-10T09:25:20.139Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "data" : {
+      "title" : "capybara",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "a",
+        "label" : "Books"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "bak",
+          "label" : "Bashkir"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "display" : {
+      "id" : "s5auwvxu",
+      "title" : "capybara",
+      "alternativeTitles" : [
+      ],
+      "workType" : {
+        "id" : "a",
+        "label" : "Books",
+        "type" : "Format"
+      },
+      "contributors" : [
+      ],
+      "identifiers" : [
+        {
+          "identifierType" : {
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
+            "type" : "IdentifierType"
+          },
+          "value" : "u7aRU7LCiT",
+          "type" : "Identifier"
+        }
+      ],
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "availabilities" : [
+      ],
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "bak",
+          "label" : "Bashkir",
+          "type" : "Language"
+        }
+      ],
+      "notes" : [
+      ],
+      "images" : [
+      ],
+      "parts" : [
+      ],
+      "partOf" : [
+      ],
+      "precededBy" : [
+      ],
+      "succeededBy" : [
+      ],
+      "type" : "Work"
+    },
+    "type" : "Visible"
+  },
+  "work" : {
+    "version" : 8,
+    "data" : {
+      "title" : "capybara",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "a",
+        "label" : "Books"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "bak",
+          "label" : "Bashkir"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "miro-image-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "u7aRU7LCiT"
+      },
+      "canonicalId" : "s5auwvxu",
+      "mergedTime" : "2022-06-02T10:28:40Z",
+      "sourceModifiedTime" : "2022-06-02T10:28:40Z",
+      "indexedTime" : "2022-05-10T09:25:20.139Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "redirectSources" : [
+    ],
+    "type" : "Visible"
+  }
+}

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.5.json
@@ -1,0 +1,231 @@
+{
+  "description" : "examples for the works filtered aggregations tests",
+  "createdAt" : "2022-05-10T09:25:20.140Z",
+  "id" : "69xyhqdq",
+  "document" : {
+    "debug" : {
+      "source" : {
+        "identifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "LX5AiO63s6"
+        },
+        "version" : 32,
+        "modifiedTime" : "2022-05-20T09:20:02Z"
+      },
+      "mergedTime" : "2022-05-20T09:20:02Z",
+      "indexedTime" : "2022-05-10T09:25:20.139Z",
+      "redirectSources" : [
+      ]
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "sierra-system-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "LX5AiO63s6"
+      },
+      "canonicalId" : "69xyhqdq",
+      "mergedTime" : "2022-05-20T09:20:02Z",
+      "sourceModifiedTime" : "2022-05-20T09:20:02Z",
+      "indexedTime" : "2022-05-10T09:25:20.139Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "data" : {
+      "title" : "tapirs",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "a",
+        "label" : "Books"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "bak",
+          "label" : "Bashkir"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "display" : {
+      "id" : "69xyhqdq",
+      "title" : "tapirs",
+      "alternativeTitles" : [
+      ],
+      "workType" : {
+        "id" : "a",
+        "label" : "Books",
+        "type" : "Format"
+      },
+      "contributors" : [
+      ],
+      "identifiers" : [
+        {
+          "identifierType" : {
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
+            "type" : "IdentifierType"
+          },
+          "value" : "LX5AiO63s6",
+          "type" : "Identifier"
+        }
+      ],
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "availabilities" : [
+      ],
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "bak",
+          "label" : "Bashkir",
+          "type" : "Language"
+        }
+      ],
+      "notes" : [
+      ],
+      "images" : [
+      ],
+      "parts" : [
+      ],
+      "partOf" : [
+      ],
+      "precededBy" : [
+      ],
+      "succeededBy" : [
+      ],
+      "type" : "Work"
+    },
+    "type" : "Visible"
+  },
+  "work" : {
+    "version" : 32,
+    "data" : {
+      "title" : "tapirs",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "a",
+        "label" : "Books"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "bak",
+          "label" : "Bashkir"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "sierra-system-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "LX5AiO63s6"
+      },
+      "canonicalId" : "69xyhqdq",
+      "mergedTime" : "2022-05-20T09:20:02Z",
+      "sourceModifiedTime" : "2022-05-20T09:20:02Z",
+      "indexedTime" : "2022-05-10T09:25:20.140Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "redirectSources" : [
+    ],
+    "type" : "Visible"
+  }
+}

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.6.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.6.json
@@ -1,0 +1,231 @@
+{
+  "description" : "examples for the works filtered aggregations tests",
+  "createdAt" : "2022-05-10T09:25:20.140Z",
+  "id" : "ezcyfqlb",
+  "document" : {
+    "debug" : {
+      "source" : {
+        "identifier" : {
+          "identifierType" : {
+            "id" : "calm-record-id"
+          },
+          "ontologyType" : "Work",
+          "value" : "DZSkVVbac8"
+        },
+        "version" : 70,
+        "modifiedTime" : "2022-05-14T21:42:46Z"
+      },
+      "mergedTime" : "2022-05-14T21:42:46Z",
+      "indexedTime" : "2022-05-10T09:25:20.140Z",
+      "redirectSources" : [
+      ]
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "calm-record-id"
+        },
+        "ontologyType" : "Work",
+        "value" : "DZSkVVbac8"
+      },
+      "canonicalId" : "ezcyfqlb",
+      "mergedTime" : "2022-05-14T21:42:46Z",
+      "sourceModifiedTime" : "2022-05-14T21:42:46Z",
+      "indexedTime" : "2022-05-10T09:25:20.140Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "data" : {
+      "title" : "rats",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "d",
+        "label" : "Journals"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "que",
+          "label" : "Quechua"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "display" : {
+      "id" : "ezcyfqlb",
+      "title" : "rats",
+      "alternativeTitles" : [
+      ],
+      "workType" : {
+        "id" : "d",
+        "label" : "Journals",
+        "type" : "Format"
+      },
+      "contributors" : [
+      ],
+      "identifiers" : [
+        {
+          "identifierType" : {
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
+            "type" : "IdentifierType"
+          },
+          "value" : "DZSkVVbac8",
+          "type" : "Identifier"
+        }
+      ],
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "availabilities" : [
+      ],
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "que",
+          "label" : "Quechua",
+          "type" : "Language"
+        }
+      ],
+      "notes" : [
+      ],
+      "images" : [
+      ],
+      "parts" : [
+      ],
+      "partOf" : [
+      ],
+      "precededBy" : [
+      ],
+      "succeededBy" : [
+      ],
+      "type" : "Work"
+    },
+    "type" : "Visible"
+  },
+  "work" : {
+    "version" : 70,
+    "data" : {
+      "title" : "rats",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "d",
+        "label" : "Journals"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "que",
+          "label" : "Quechua"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "calm-record-id"
+        },
+        "ontologyType" : "Work",
+        "value" : "DZSkVVbac8"
+      },
+      "canonicalId" : "ezcyfqlb",
+      "mergedTime" : "2022-05-14T21:42:46Z",
+      "sourceModifiedTime" : "2022-05-14T21:42:46Z",
+      "indexedTime" : "2022-05-10T09:25:20.140Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "redirectSources" : [
+    ],
+    "type" : "Visible"
+  }
+}

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.7.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.7.json
@@ -1,0 +1,231 @@
+{
+  "description" : "examples for the works filtered aggregations tests",
+  "createdAt" : "2022-05-10T09:25:20.140Z",
+  "id" : "npfh1czk",
+  "document" : {
+    "debug" : {
+      "source" : {
+        "identifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "7ts9VeAfYG"
+        },
+        "version" : 1,
+        "modifiedTime" : "2022-04-20T07:34:38Z"
+      },
+      "mergedTime" : "2022-04-20T07:34:38Z",
+      "indexedTime" : "2022-05-10T09:25:20.140Z",
+      "redirectSources" : [
+      ]
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "sierra-system-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "7ts9VeAfYG"
+      },
+      "canonicalId" : "npfh1czk",
+      "mergedTime" : "2022-04-20T07:34:38Z",
+      "sourceModifiedTime" : "2022-04-20T07:34:38Z",
+      "indexedTime" : "2022-05-10T09:25:20.140Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "data" : {
+      "title" : "capybara",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "a",
+        "label" : "Books"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "mar",
+          "label" : "Marathi"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "display" : {
+      "id" : "npfh1czk",
+      "title" : "capybara",
+      "alternativeTitles" : [
+      ],
+      "workType" : {
+        "id" : "a",
+        "label" : "Books",
+        "type" : "Format"
+      },
+      "contributors" : [
+      ],
+      "identifiers" : [
+        {
+          "identifierType" : {
+            "id" : "sierra-system-number",
+            "label" : "Sierra system number",
+            "type" : "IdentifierType"
+          },
+          "value" : "7ts9VeAfYG",
+          "type" : "Identifier"
+        }
+      ],
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "availabilities" : [
+      ],
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "mar",
+          "label" : "Marathi",
+          "type" : "Language"
+        }
+      ],
+      "notes" : [
+      ],
+      "images" : [
+      ],
+      "parts" : [
+      ],
+      "partOf" : [
+      ],
+      "precededBy" : [
+      ],
+      "succeededBy" : [
+      ],
+      "type" : "Work"
+    },
+    "type" : "Visible"
+  },
+  "work" : {
+    "version" : 1,
+    "data" : {
+      "title" : "capybara",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "a",
+        "label" : "Books"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "mar",
+          "label" : "Marathi"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "sierra-system-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "7ts9VeAfYG"
+      },
+      "canonicalId" : "npfh1czk",
+      "mergedTime" : "2022-04-20T07:34:38Z",
+      "sourceModifiedTime" : "2022-04-20T07:34:38Z",
+      "indexedTime" : "2022-05-10T09:25:20.140Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "redirectSources" : [
+    ],
+    "type" : "Visible"
+  }
+}

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.8.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.8.json
@@ -1,0 +1,231 @@
+{
+  "description" : "examples for the works filtered aggregations tests",
+  "createdAt" : "2022-05-10T09:25:20.140Z",
+  "id" : "elheubhh",
+  "document" : {
+    "debug" : {
+      "source" : {
+        "identifier" : {
+          "identifierType" : {
+            "id" : "miro-image-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "grNNX4MZCl"
+        },
+        "version" : 83,
+        "modifiedTime" : "2022-05-26T14:23:30Z"
+      },
+      "mergedTime" : "2022-05-26T14:23:30Z",
+      "indexedTime" : "2022-05-10T09:25:20.140Z",
+      "redirectSources" : [
+      ]
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "miro-image-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "grNNX4MZCl"
+      },
+      "canonicalId" : "elheubhh",
+      "mergedTime" : "2022-05-26T14:23:30Z",
+      "sourceModifiedTime" : "2022-05-26T14:23:30Z",
+      "indexedTime" : "2022-05-10T09:25:20.140Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "data" : {
+      "title" : "tapirs",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "d",
+        "label" : "Journals"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "que",
+          "label" : "Quechua"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "display" : {
+      "id" : "elheubhh",
+      "title" : "tapirs",
+      "alternativeTitles" : [
+      ],
+      "workType" : {
+        "id" : "d",
+        "label" : "Journals",
+        "type" : "Format"
+      },
+      "contributors" : [
+      ],
+      "identifiers" : [
+        {
+          "identifierType" : {
+            "id" : "miro-image-number",
+            "label" : "Miro image number",
+            "type" : "IdentifierType"
+          },
+          "value" : "grNNX4MZCl",
+          "type" : "Identifier"
+        }
+      ],
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "availabilities" : [
+      ],
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "que",
+          "label" : "Quechua",
+          "type" : "Language"
+        }
+      ],
+      "notes" : [
+      ],
+      "images" : [
+      ],
+      "parts" : [
+      ],
+      "partOf" : [
+      ],
+      "precededBy" : [
+      ],
+      "succeededBy" : [
+      ],
+      "type" : "Work"
+    },
+    "type" : "Visible"
+  },
+  "work" : {
+    "version" : 83,
+    "data" : {
+      "title" : "tapirs",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "d",
+        "label" : "Journals"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "que",
+          "label" : "Quechua"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "miro-image-number"
+        },
+        "ontologyType" : "Work",
+        "value" : "grNNX4MZCl"
+      },
+      "canonicalId" : "elheubhh",
+      "mergedTime" : "2022-05-26T14:23:30Z",
+      "sourceModifiedTime" : "2022-05-26T14:23:30Z",
+      "indexedTime" : "2022-05-10T09:25:20.140Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "redirectSources" : [
+    ],
+    "type" : "Visible"
+  }
+}

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.9.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.9.json
@@ -1,0 +1,231 @@
+{
+  "description" : "examples for the works filtered aggregations tests",
+  "createdAt" : "2022-05-10T09:25:20.140Z",
+  "id" : "wtgio1hu",
+  "document" : {
+    "debug" : {
+      "source" : {
+        "identifier" : {
+          "identifierType" : {
+            "id" : "calm-record-id"
+          },
+          "ontologyType" : "Work",
+          "value" : "zx3mO0u9h1"
+        },
+        "version" : 62,
+        "modifiedTime" : "2022-05-09T14:29:29Z"
+      },
+      "mergedTime" : "2022-05-09T14:29:29Z",
+      "indexedTime" : "2022-05-10T09:25:20.140Z",
+      "redirectSources" : [
+      ]
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "calm-record-id"
+        },
+        "ontologyType" : "Work",
+        "value" : "zx3mO0u9h1"
+      },
+      "canonicalId" : "wtgio1hu",
+      "mergedTime" : "2022-05-09T14:29:29Z",
+      "sourceModifiedTime" : "2022-05-09T14:29:29Z",
+      "indexedTime" : "2022-05-10T09:25:20.140Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "data" : {
+      "title" : "rats",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "i",
+        "label" : "Audio"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "che",
+          "label" : "Chechen"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "display" : {
+      "id" : "wtgio1hu",
+      "title" : "rats",
+      "alternativeTitles" : [
+      ],
+      "workType" : {
+        "id" : "i",
+        "label" : "Audio",
+        "type" : "Format"
+      },
+      "contributors" : [
+      ],
+      "identifiers" : [
+        {
+          "identifierType" : {
+            "id" : "calm-record-id",
+            "label" : "Calm RecordIdentifier",
+            "type" : "IdentifierType"
+          },
+          "value" : "zx3mO0u9h1",
+          "type" : "Identifier"
+        }
+      ],
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "availabilities" : [
+      ],
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "che",
+          "label" : "Chechen",
+          "type" : "Language"
+        }
+      ],
+      "notes" : [
+      ],
+      "images" : [
+      ],
+      "parts" : [
+      ],
+      "partOf" : [
+      ],
+      "precededBy" : [
+      ],
+      "succeededBy" : [
+      ],
+      "type" : "Work"
+    },
+    "type" : "Visible"
+  },
+  "work" : {
+    "version" : 62,
+    "data" : {
+      "title" : "rats",
+      "otherIdentifiers" : [
+      ],
+      "alternativeTitles" : [
+      ],
+      "format" : {
+        "id" : "i",
+        "label" : "Audio"
+      },
+      "description" : null,
+      "physicalDescription" : null,
+      "lettering" : null,
+      "createdDate" : null,
+      "subjects" : [
+      ],
+      "genres" : [
+      ],
+      "contributors" : [
+      ],
+      "thumbnail" : null,
+      "production" : [
+      ],
+      "languages" : [
+        {
+          "id" : "che",
+          "label" : "Chechen"
+        }
+      ],
+      "edition" : null,
+      "notes" : [
+      ],
+      "duration" : null,
+      "items" : [
+      ],
+      "holdings" : [
+      ],
+      "collectionPath" : null,
+      "referenceNumber" : null,
+      "imageData" : [
+      ],
+      "workType" : "Standard"
+    },
+    "state" : {
+      "sourceIdentifier" : {
+        "identifierType" : {
+          "id" : "calm-record-id"
+        },
+        "ontologyType" : "Work",
+        "value" : "zx3mO0u9h1"
+      },
+      "canonicalId" : "wtgio1hu",
+      "mergedTime" : "2022-05-09T14:29:29Z",
+      "sourceModifiedTime" : "2022-05-09T14:29:29Z",
+      "indexedTime" : "2022-05-10T09:25:20.140Z",
+      "availabilities" : [
+      ],
+      "derivedData" : {
+        "contributorAgents" : [
+        ]
+      },
+      "relations" : {
+        "ancestors" : [
+        ],
+        "children" : [
+        ],
+        "siblingsPreceding" : [
+        ],
+        "siblingsSucceeding" : [
+        ]
+      }
+    },
+    "redirectSources" : [
+    ],
+    "type" : "Visible"
+  }
+}

--- a/search/src/test/scala/weco/api/search/services/AggregationsTest.scala
+++ b/search/src/test/scala/weco/api/search/services/AggregationsTest.scala
@@ -93,7 +93,31 @@ class AggregationsTest
           aggs.format should not be empty
           val buckets = aggs.format.get.buckets
           buckets.length shouldBe works.length
-          buckets.map(_.data.label) should contain theSameElementsAs List("Books", "Manuscripts", "Music", "Journals", "Maps", "E-videos", "Videos", "Archives and manuscripts", "Audio", "E-journals", "Pictures", "Ephemera", "CD-Roms", "Film", "Mixed materials", "Digital Images", "3-D Objects", "E-sound", "Standing order", "E-books", "Student dissertations", "Manuscripts", "Web sites")
+          buckets.map(_.data.label) should contain theSameElementsAs List(
+            "Books",
+            "Manuscripts",
+            "Music",
+            "Journals",
+            "Maps",
+            "E-videos",
+            "Videos",
+            "Archives and manuscripts",
+            "Audio",
+            "E-journals",
+            "Pictures",
+            "Ephemera",
+            "CD-Roms",
+            "Film",
+            "Mixed materials",
+            "Digital Images",
+            "3-D Objects",
+            "E-sound",
+            "Standing order",
+            "E-books",
+            "Student dissertations",
+            "Manuscripts",
+            "Web sites"
+          )
         }
       }
     }
@@ -113,7 +137,31 @@ class AggregationsTest
         whenReady(aggregationQuery(index, searchOptions)) { aggs =>
           val buckets = aggs.format.get.buckets
           buckets.length shouldBe works.length
-          buckets.map(_.data.label) should contain theSameElementsAs List("Books", "Manuscripts", "Music", "Journals", "Maps", "E-videos", "Videos", "Archives and manuscripts", "Audio", "E-journals", "Pictures", "Ephemera", "CD-Roms", "Film", "Mixed materials", "Digital Images", "3-D Objects", "E-sound", "Standing order", "E-books", "Student dissertations", "Manuscripts", "Web sites")
+          buckets.map(_.data.label) should contain theSameElementsAs List(
+            "Books",
+            "Manuscripts",
+            "Music",
+            "Journals",
+            "Maps",
+            "E-videos",
+            "Videos",
+            "Archives and manuscripts",
+            "Audio",
+            "E-journals",
+            "Pictures",
+            "Ephemera",
+            "CD-Roms",
+            "Film",
+            "Mixed materials",
+            "Digital Images",
+            "3-D Objects",
+            "E-sound",
+            "Standing order",
+            "E-books",
+            "Student dissertations",
+            "Manuscripts",
+            "Web sites"
+          )
         }
       }
     }

--- a/search/src/test/scala/weco/api/search/works/WorksFilteredAggregationsTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksFilteredAggregationsTest.scala
@@ -3,7 +3,8 @@ package weco.api.search.works
 import weco.api.search.models.request.WorksIncludes
 
 class WorksFilteredAggregationsTest extends ApiWorksTestBase {
-  val aggregatedWorks = (0 to 9).map(i => s"works.examples.filtered-aggregations-tests.$i")
+  val aggregatedWorks =
+    (0 to 9).map(i => s"works.examples.filtered-aggregations-tests.$i")
 
   val worksBooks =
     Seq(0, 4, 5, 7)
@@ -166,7 +167,8 @@ class WorksFilteredAggregationsTest extends ApiWorksTestBase {
             // We expect to see the workType buckets for worktype i/Audio, because that
             // has the language che/Chechen, and for a/Books, because a filter for it is
             // present
-            path = s"$rootPath/works?workType=a&languages=che&aggregations=workType"
+            path =
+              s"$rootPath/works?workType=a&languages=che&aggregations=workType"
           ) {
             Status.OK -> s"""
             {

--- a/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala
@@ -93,9 +93,11 @@ class WorksFiltersTest
   }
 
   describe("filtering works by type") {
-    val works = Seq("works.examples.different-work-types.Collection",
+    val works = Seq(
+      "works.examples.different-work-types.Collection",
       "works.examples.different-work-types.Series",
-      "works.examples.different-work-types.Section")
+      "works.examples.different-work-types.Section"
+    )
 
     it("when listing works") {
       withWorksApi {
@@ -103,7 +105,9 @@ class WorksFiltersTest
           indexTestDocuments(worksIndex, works: _*)
 
           assertJsonResponse(routes, path = s"$rootPath/works?type=Collection") {
-            Status.OK -> newWorksListResponse(ids = Seq("works.examples.different-work-types.Collection"))
+            Status.OK -> newWorksListResponse(
+              ids = Seq("works.examples.different-work-types.Collection")
+            )
           }
       }
     }
@@ -117,7 +121,12 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?type=Collection,Series"
           ) {
-            Status.OK -> newWorksListResponse(ids = Seq("works.examples.different-work-types.Collection", "works.examples.different-work-types.Series"))
+            Status.OK -> newWorksListResponse(
+              ids = Seq(
+                "works.examples.different-work-types.Collection",
+                "works.examples.different-work-types.Series"
+              )
+            )
           }
       }
     }
@@ -131,7 +140,12 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?query=rats&type=Series,Section"
           ) {
-            Status.OK -> newWorksListResponse(ids = Seq("works.examples.different-work-types.Series", "works.examples.different-work-types.Section"))
+            Status.OK -> newWorksListResponse(
+              ids = Seq(
+                "works.examples.different-work-types.Series",
+                "works.examples.different-work-types.Section"
+              )
+            )
           }
       }
     }
@@ -324,7 +338,8 @@ class WorksFiltersTest
               withClue(clue) {
                 assertJsonResponse(
                   routes,
-                  path = s"$rootPath/works?genres.label=${URLEncoder.encode(query, "UTF-8")}"
+                  path =
+                    s"$rootPath/works?genres.label=${URLEncoder.encode(query, "UTF-8")}"
                 ) {
                   Status.OK -> newWorksListResponse(expectedIds)
                 }
@@ -387,7 +402,8 @@ class WorksFiltersTest
               withClue(clue) {
                 assertJsonResponse(
                   routes,
-                  path = s"$rootPath/works?subjects.label=${URLEncoder.encode(query, "UTF-8")}"
+                  path =
+                    s"$rootPath/works?subjects.label=${URLEncoder.encode(query, "UTF-8")}"
                 ) {
                   Status.OK -> newWorksListResponse(expectedIds)
                 }
@@ -449,10 +465,8 @@ class WorksFiltersTest
               withClue(clue) {
                 assertJsonResponse(
                   routes,
-                  path = s"$rootPath/works?contributors.agent.label=${
-                    URLEncoder
-                      .encode(query, "UTF-8")
-                  }"
+                  path = s"$rootPath/works?contributors.agent.label=${URLEncoder
+                    .encode(query, "UTF-8")}"
                 ) {
                   Status.OK -> newWorksListResponse(expectedIds)
                 }
@@ -591,7 +605,8 @@ class WorksFiltersTest
   }
 
   describe("Access status filter") {
-    val works = (0 to 6).map(i => s"works.examples.access-status-filters-tests.$i")
+    val works =
+      (0 to 6).map(i => s"works.examples.access-status-filters-tests.$i")
 
     it("includes works by access status") {
       withWorksApi {
@@ -600,10 +615,13 @@ class WorksFiltersTest
 
           assertJsonResponse(
             routes,
-            path = s"$rootPath/works?items.locations.accessConditions.status=restricted,closed"
+            path =
+              s"$rootPath/works?items.locations.accessConditions.status=restricted,closed"
           ) {
             Status.OK -> newWorksListResponse(
-              ids = Seq(0, 1, 2).map(i => s"works.examples.access-status-filters-tests.$i")
+              ids = Seq(0, 1, 2).map(
+                i => s"works.examples.access-status-filters-tests.$i"
+              )
             )
           }
       }
@@ -620,10 +638,13 @@ class WorksFiltersTest
 
           assertJsonResponse(
             routes,
-            path = s"$rootPath/works?items.locations.accessConditions.status=licensed-resources"
+            path =
+              s"$rootPath/works?items.locations.accessConditions.status=licensed-resources"
           ) {
             Status.OK -> newWorksListResponse(
-              ids = Seq(5, 6).map(i => s"works.examples.access-status-filters-tests.$i")
+              ids = Seq(5, 6).map(
+                i => s"works.examples.access-status-filters-tests.$i"
+              )
             )
           }
       }
@@ -636,10 +657,13 @@ class WorksFiltersTest
 
           assertJsonResponse(
             routes,
-            path = s"$rootPath/works?items.locations.accessConditions.status=!restricted,!closed"
+            path =
+              s"$rootPath/works?items.locations.accessConditions.status=!restricted,!closed"
           ) {
             Status.OK -> newWorksListResponse(
-              ids = Seq(3, 4, 5, 6).map(i => s"works.examples.access-status-filters-tests.$i")
+              ids = Seq(3, 4, 5, 6).map(
+                i => s"works.examples.access-status-filters-tests.$i"
+              )
             )
           }
       }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5449

~This gets all the API tests passing with documents fetched from example JSON documents, not examples generated at runtime. No more test changes required!~

**Edit:** This does all the tests of the *works* API, but I haven't touched images yet.

The next two PRs will be a bonfire of code we no longer need, and then actually using the "display" field which I added… many eves and moons ago. 😅 