### PR TITLE
Remove some test helpers we're no longer using

### DIFF
--- a/common/display/src/test/scala/weco/catalogue/display_model/test/util/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/weco/catalogue/display_model/test/util/DisplaySerialisationTestBase.scala
@@ -145,35 +145,35 @@ trait DisplaySerialisationTestBase {
         "label": "${meeting.label}"
       }"""
 
-  def agent(agent: Agent[IdState.Minted]) =
+  private def agent(agent: Agent[IdState.Minted]) =
     s"""{
        ${identifiers(agent)}
         "type": "Agent",
         "label": "${agent.label}"
       }"""
 
-  def period(period: Period[IdState.Minted]) =
+  private def period(period: Period[IdState.Minted]) =
     s"""{
        ${identifiers(period)}
       "type": "Period",
       "label": "${period.label}"
     }"""
 
-  def place(place: Place[IdState.Minted]) =
+  private def place(place: Place[IdState.Minted]) =
     s"""{
        ${identifiers(place)}
       "type": "Place",
       "label": "${place.label}"
     }"""
 
-  def concept(concept: Concept[IdState.Minted]) =
+  private def concept(concept: Concept[IdState.Minted]) =
     s"""{
        ${identifiers(concept)}
       "type": "Concept",
       "label": "${concept.label}"
     }"""
 
-  def abstractRootConcept(
+  private def abstractRootConcept(
     abstractRootConcept: AbstractRootConcept[IdState.Minted]
   ) =
     abstractRootConcept match {
@@ -189,7 +189,7 @@ trait DisplaySerialisationTestBase {
   def concepts(concepts: List[AbstractRootConcept[IdState.Minted]]) =
     concepts.map(abstractRootConcept).mkString(",")
 
-  def subject(
+  private def subject(
     s: Subject[IdState.Minted],
     showConcepts: Boolean = true
   ): String =

--- a/common/display/src/test/scala/weco/catalogue/display_model/test/util/DisplaySerialisationTestBase.scala
+++ b/common/display/src/test/scala/weco/catalogue/display_model/test/util/DisplaySerialisationTestBase.scala
@@ -47,19 +47,6 @@ trait DisplaySerialisationTestBase {
       Json.fromString(s).noSpaces
   }
 
-  def items(items: List[Item[IdState.Minted]]) =
-    items.map(item).mkString(",")
-
-  private def item(item: Item[IdState.Minted]): String =
-    s"""
-     {
-       ${identifiers(item)}
-       "type": "Item",
-       "title": ${item.title.map(_.toJson)},
-       "locations": [${locations(item.locations)}]
-     }
-    """.tidy
-
   def locations(locations: List[Location]) =
     locations.map(location).mkString(",")
 
@@ -92,7 +79,7 @@ trait DisplaySerialisationTestBase {
        }
      """.tidy
 
-  def accessConditions(conds: List[AccessCondition]) =
+  private def accessConditions(conds: List[AccessCondition]) =
     s"[${conds.map(accessCondition).mkString(",")}]"
 
   private def accessCondition(cond: AccessCondition): String =
@@ -245,9 +232,6 @@ trait DisplaySerialisationTestBase {
   def production(production: List[ProductionEvent[IdState.Minted]]) =
     production.map(productionEvent).mkString(",")
 
-  def availabilities(availabilities: Set[Availability]) =
-    availabilities.map(availability).mkString(",")
-
   def languages(ls: List[Language]): String =
     ls.map(language).mkString(",")
 
@@ -261,15 +245,6 @@ trait DisplaySerialisationTestBase {
 
   def workImageIncludes(images: List[ImageData[IdState.Identified]]) =
     images.map(workImageInclude).mkString(",")
-
-  private def availability(availability: Availability): String =
-    s"""
-       |{
-       |  "id": "${availability.id}",
-       |  "label": "${availability.label}",
-       |  "type": "Availability"
-       |}
-       |""".stripMargin
 
   private def productionEvent(event: ProductionEvent[IdState.Minted]): String =
     s"""

--- a/search/src/test/scala/weco/api/search/works/ApiWorksTestBase.scala
+++ b/search/src/test/scala/weco/api/search/works/ApiWorksTestBase.scala
@@ -1,61 +1,24 @@
 package weco.api.search.works
 
-import com.sksamuel.elastic4s.Indexable
 import weco.api.search.ApiTestBase
 import weco.api.search.fixtures.TestDocumentFixtures
 import weco.api.search.json.CatalogueJsonUtil
 import weco.api.search.models.request.WorksIncludes
 import weco.catalogue.display_model.test.util.DisplaySerialisationTestBase
-import weco.catalogue.internal_model.Implicits._
-import weco.json.JsonUtil._
-import weco.catalogue.internal_model.work.generators._
-import weco.catalogue.internal_model.locations.DigitalLocation
-import weco.catalogue.internal_model.work.{Work, WorkType}
-import weco.catalogue.internal_model.work.WorkState.Indexed
 
 trait ApiWorksTestBase
     extends ApiTestBase
     with DisplaySerialisationTestBase
-    with WorkGenerators
-    with GenreGenerators
-    with SubjectGenerators
     with CatalogueJsonUtil
     with TestDocumentFixtures {
+//
+//  implicit object IdentifiedWorkIndexable
+//      extends Indexable[Work.Visible[Indexed]] {
+//    override def json(work: Work.Visible[Indexed]): String =
+//      toJson(work).get
+//  }
 
-  implicit object IdentifiedWorkIndexable
-      extends Indexable[Work.Visible[Indexed]] {
-    override def json(work: Work.Visible[Indexed]): String =
-      toJson(work).get
-  }
-
-  def singleWorkResult(ontologyType: String = "Work"): String =
-    s"""
-        "type": "$ontologyType"
-     """.stripMargin
-
-  def workResponse(work: Work.Visible[Indexed]): String =
-    s"""
-      | {
-      |   "id": "${work.state.canonicalId}",
-      |   "title": "${work.data.title.get}",
-      |   "availabilities": [${availabilities(work.state.availabilities)}],
-      |   "alternativeTitles": [],
-      |   "workType": ${work.data.format.map(format)},
-      |   "type": "${formatOntologyType(work.data.workType)}"
-      | }
-    """.stripMargin.tidy
-
-  def worksListResponse(works: Seq[Work.Visible[Indexed]]): String =
-    s"""
-       |{
-       |  ${resultList(totalResults = works.size)},
-       |  "results": [
-       |    ${works.map { workResponse }.mkString(",")}
-       |  ]
-       |}
-      """.stripMargin
-
-  def newWorksListResponse(
+  def worksListResponse(
     ids: Seq[String],
     includes: WorksIncludes = WorksIncludes.none,
     strictOrdering: Boolean = false
@@ -80,17 +43,4 @@ trait ApiWorksTestBase
        |}
       """.stripMargin
   }
-
-  def formatOntologyType(workType: WorkType): String =
-    workType match {
-      case WorkType.Standard   => "Work"
-      case WorkType.Collection => "Collection"
-      case WorkType.Series     => "Series"
-      case WorkType.Section    => "Section"
-    }
-
-  def hasDigitalLocations(work: Work.Visible[Indexed]): String =
-    work.data.items
-      .exists(_.locations.exists(_.isInstanceOf[DigitalLocation]))
-      .toString
 }

--- a/search/src/test/scala/weco/api/search/works/ApiWorksTestBase.scala
+++ b/search/src/test/scala/weco/api/search/works/ApiWorksTestBase.scala
@@ -11,12 +11,6 @@ trait ApiWorksTestBase
     with DisplaySerialisationTestBase
     with CatalogueJsonUtil
     with TestDocumentFixtures {
-//
-//  implicit object IdentifiedWorkIndexable
-//      extends Indexable[Work.Visible[Indexed]] {
-//    override def json(work: Work.Visible[Indexed]): String =
-//      toJson(work).get
-//  }
 
   def worksListResponse(
     ids: Seq[String],

--- a/search/src/test/scala/weco/api/search/works/WorksErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksErrorsTest.scala
@@ -332,7 +332,7 @@ class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
       "path",
       s"$rootPath/works",
       s"$rootPath/works?query=fish",
-      s"$rootPath/works/$createCanonicalId"
+      s"$rootPath/works/xyakm37j"
     )
 
     withApi { route =>

--- a/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala
@@ -21,7 +21,7 @@ class WorksFiltersTest
           path =
             s"$rootPath/works?genres.label=4fR1f4tFlV&subjects.label=ArEtlVdV0j"
         ) {
-          Status.OK -> newWorksListResponse(
+          Status.OK -> worksListResponse(
             ids = Seq("work.visible.everything.0")
           )
         }
@@ -43,7 +43,7 @@ class WorksFiltersTest
           path =
             s"$rootPath/works?items.locations.locationType=iiif-presentation,closed-stores"
         ) {
-          Status.OK -> newWorksListResponse(
+          Status.OK -> worksListResponse(
             ids = Seq(
               "work.items-with-location-types.1",
               "work.items-with-location-types.2"
@@ -63,7 +63,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?workType=k"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq("works.formats.9.Pictures")
             )
           }
@@ -79,7 +79,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?workType=k,d"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq(
                 "works.formats.4.Journals",
                 "works.formats.5.Journals",
@@ -105,7 +105,7 @@ class WorksFiltersTest
           indexTestDocuments(worksIndex, works: _*)
 
           assertJsonResponse(routes, path = s"$rootPath/works?type=Collection") {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq("works.examples.different-work-types.Collection")
             )
           }
@@ -121,7 +121,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?type=Collection,Series"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq(
                 "works.examples.different-work-types.Collection",
                 "works.examples.different-work-types.Series"
@@ -140,7 +140,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?query=rats&type=Series,Section"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq(
                 "works.examples.different-work-types.Series",
                 "works.examples.different-work-types.Section"
@@ -170,7 +170,7 @@ class WorksFiltersTest
             path =
               s"$rootPath/works?production.dates.from=1900-01-01&production.dates.to=1960-01-01"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq("work-production.1900", "work-production.1904")
             )
           }
@@ -186,7 +186,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?production.dates.from=1900-01-01"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq(
                 "work-production.1900",
                 "work-production.1904",
@@ -207,7 +207,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?production.dates.to=1960-01-01"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq(
                 "work-production.1098",
                 "work-production.1900",
@@ -250,7 +250,7 @@ class WorksFiltersTest
           indexTestDocuments(worksIndex, languageWorks: _*)
 
           assertJsonResponse(routes, path = s"$rootPath/works?languages=eng") {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq(
                 "works.languages.0.eng",
                 "works.languages.1.eng",
@@ -272,7 +272,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?languages=swe,tur"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq(
                 "works.languages.3.eng+swe",
                 "works.languages.4.eng+swe+tur",
@@ -341,7 +341,7 @@ class WorksFiltersTest
                   path =
                     s"$rootPath/works?genres.label=${URLEncoder.encode(query, "UTF-8")}"
                 ) {
-                  Status.OK -> newWorksListResponse(expectedIds)
+                  Status.OK -> worksListResponse(expectedIds)
                 }
               }
           }
@@ -405,7 +405,7 @@ class WorksFiltersTest
                   path =
                     s"$rootPath/works?subjects.label=${URLEncoder.encode(query, "UTF-8")}"
                 ) {
-                  Status.OK -> newWorksListResponse(expectedIds)
+                  Status.OK -> worksListResponse(expectedIds)
                 }
               }
           }
@@ -468,7 +468,7 @@ class WorksFiltersTest
                   path = s"$rootPath/works?contributors.agent.label=${URLEncoder
                     .encode(query, "UTF-8")}"
                 ) {
-                  Status.OK -> newWorksListResponse(expectedIds)
+                  Status.OK -> worksListResponse(expectedIds)
                 }
               }
           }
@@ -486,7 +486,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?items.locations.license=cc-by"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq(
                 "works.items-with-licenses.0",
                 "works.items-with-licenses.1",
@@ -506,7 +506,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?items.locations.license=cc-by,cc-by-nc"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq(
                 "works.items-with-licenses.0",
                 "works.items-with-licenses.1",
@@ -529,7 +529,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?identifiers=cQYSxE7gRG"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq("work.visible.everything.0")
             )
           }
@@ -545,7 +545,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?identifiers=cQYSxE7gRG,mGMGKNlQnl"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids =
                 Seq("work.visible.everything.0", "work.visible.everything.1")
             )
@@ -562,7 +562,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?identifiers=eG0HzUX6yZ"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq("work.visible.everything.1")
             )
           }
@@ -578,7 +578,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?identifiers=eG0HzUX6yZ,ji3JH82kKu"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids =
                 Seq("work.visible.everything.0", "work.visible.everything.1")
             )
@@ -595,7 +595,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?identifiers=cQYSxE7gRG,eG0HzUX6yZ"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids =
                 Seq("work.visible.everything.0", "work.visible.everything.1")
             )
@@ -618,7 +618,7 @@ class WorksFiltersTest
             path =
               s"$rootPath/works?items.locations.accessConditions.status=restricted,closed"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq(0, 1, 2).map(
                 i => s"works.examples.access-status-filters-tests.$i"
               )
@@ -641,7 +641,7 @@ class WorksFiltersTest
             path =
               s"$rootPath/works?items.locations.accessConditions.status=licensed-resources"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq(5, 6).map(
                 i => s"works.examples.access-status-filters-tests.$i"
               )
@@ -660,7 +660,7 @@ class WorksFiltersTest
             path =
               s"$rootPath/works?items.locations.accessConditions.status=!restricted,!closed"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq(3, 4, 5, 6).map(
                 i => s"works.examples.access-status-filters-tests.$i"
               )
@@ -680,7 +680,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?availabilities=open-shelves"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq("work.visible.everything.2")
             )
           }
@@ -696,7 +696,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?availabilities=open-shelves,closed-stores"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq(
                 "work.visible.everything.0",
                 "work.visible.everything.1",
@@ -715,7 +715,7 @@ class WorksFiltersTest
           indexTestDocuments(worksIndex, worksEverything: _*)
 
           assertJsonResponse(routes, path = s"$rootPath/works?partOf=dza7om88") {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq("work.visible.everything.0")
             )
           }
@@ -731,7 +731,7 @@ class WorksFiltersTest
             routes,
             path = s"$rootPath/works?partOf=title-BnN4RHJX7O"
           ) {
-            Status.OK -> newWorksListResponse(
+            Status.OK -> worksListResponse(
               ids = Seq("work.visible.everything.0")
             )
           }
@@ -801,7 +801,7 @@ class WorksFiltersTest
           indexTestDocuments(worksIndex, worksEverything: _*)
 
           assertJsonResponse(routes, path) {
-            Status.OK -> newWorksListResponse(ids = expectedIds)
+            Status.OK -> worksListResponse(ids = expectedIds)
           }
       }
   }

--- a/search/src/test/scala/weco/api/search/works/WorksTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksTest.scala
@@ -7,7 +7,7 @@ class WorksTest extends ApiWorksTestBase {
         indexTestDocuments(worksIndex, works: _*)
 
         assertJsonResponse(routes, path = s"$rootPath/works") {
-          Status.OK -> newWorksListResponse(visibleWorks)
+          Status.OK -> worksListResponse(visibleWorks)
         }
     }
   }
@@ -161,7 +161,7 @@ class WorksTest extends ApiWorksTestBase {
         }
 
         assertJsonResponse(routes, s"$rootPath/works?query=dodo") {
-          Status.OK -> newWorksListResponse(ids = Seq("work-title-dodo"))
+          Status.OK -> worksListResponse(ids = Seq("work-title-dodo"))
         }
     }
   }
@@ -218,7 +218,7 @@ class WorksTest extends ApiWorksTestBase {
           routes,
           path = s"$rootPath/works?sort=production.dates"
         ) {
-          Status.OK -> newWorksListResponse(
+          Status.OK -> worksListResponse(
             ids = Seq(
               "work-production.1098",
               "work-production.1900",
@@ -244,7 +244,7 @@ class WorksTest extends ApiWorksTestBase {
           routes,
           path = s"$rootPath/works?sort=production.dates&sortOrder=desc"
         ) {
-          Status.OK -> newWorksListResponse(
+          Status.OK -> worksListResponse(
             ids = Seq(
               "work-production.1904",
               "work-production.1900",


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5449; follows #426

Now the works API tests are fully ported, we can remove a bunch of helper code from the tests.