### PR TITLE
Don't return a 500 error if we get a non-hex color parameter

### DIFF
--- a/search/src/main/scala/weco/api/search/elasticsearch/ColorQuery.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/ColorQuery.scala
@@ -1,10 +1,8 @@
 package weco.api.search.elasticsearch
 
-import java.awt.{Color => AwtColor}
-
 import com.sksamuel.elastic4s.ElasticApi._
 import com.sksamuel.elastic4s.requests.searches.queries.MoreLikeThisQuery
-import weco.api.search.models.Color
+import weco.api.search.models.HsvColor
 
 class ColorQuery(binSizes: Seq[Seq[Int]], binMinima: Seq[Float]) {
   require(
@@ -29,7 +27,7 @@ class ColorQuery(binSizes: Seq[Seq[Int]], binMinima: Seq[Float]) {
   ): MoreLikeThisQuery =
     moreLikeThisQuery(field)
       .likeTexts(
-        getColorsSignature(hexColors.map(ColorQuery.hexToHsv), binIndices)
+        getColorsSignature(hexColors.map(HsvColor.fromHex(_).get), binIndices)
       )
       .copy(
         minTermFreq = Some(1),
@@ -41,7 +39,7 @@ class ColorQuery(binSizes: Seq[Seq[Int]], binMinima: Seq[Float]) {
 
   // This replicates the logic in palette_encoder.py:get_bin_index
   private def getColorsSignature(
-    colors: Seq[Color.Hsv],
+    colors: Seq[HsvColor],
     binIndices: Seq[Int]
   ): Seq[String] =
     binIndices
@@ -74,18 +72,4 @@ class ColorQuery(binSizes: Seq[Seq[Int]], binMinima: Seq[Float]) {
         case (binIndex, i) => s"$binIndex/$i"
       }
 
-}
-
-object ColorQuery {
-  def hexToHsv(hex: String): Color.Hsv = {
-    val n = Integer.parseInt(hex, 16)
-    val (r, g, b) = (
-      (n >> 16) & 0xFF,
-      (n >> 8) & 0xFF,
-      n & 0xFF
-    )
-    val hsv = AwtColor.RGBtoHSB(r, g, b, null)
-
-    Color.Hsv(hue = hsv(0), saturation = hsv(1), value = hsv(2))
-  }
 }

--- a/search/src/main/scala/weco/api/search/elasticsearch/ColorQuery.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/ColorQuery.scala
@@ -48,21 +48,21 @@ class ColorQuery(binSizes: Seq[Seq[Int]], binMinima: Seq[Float]) {
           val nValBins = nBins(1)
           colors
             .map {
-              case c if c.value < valMin => 0
-              case c if c.saturation < satMin =>
+              case HsvColor(_, _, v) if v < valMin => 0
+              case HsvColor(_, s, v) if s < satMin =>
                 1 + math
-                  .floor(nValBins * (c.value - valMin) / (1 - valMin + minBinWidth))
+                  .floor(nValBins * (v - valMin) / (1 - valMin + minBinWidth))
                   .toInt
-              case c =>
+              case HsvColor(h, s, v) =>
                 def idx(x: Float, i: Int): Int = {
                   val num = nBins(i) * (x - binMinima(i))
                   val denom = 1 - binMinima(i) + minBinWidth
                   math.floor(num / denom).toInt
                 }
                 1 + nValBins +
-                  idx(c.hue, 0) +
-                  nBins(0) * idx(c.saturation, 1) +
-                  nBins(0) * nBins(1) * idx(c.value, 2)
+                  idx(h, 0) +
+                  nBins(0) * idx(s, 1) +
+                  nBins(0) * nBins(1) * idx(v, 2)
             }
             .map((_, i))
       }

--- a/search/src/main/scala/weco/api/search/elasticsearch/ColorQuery.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/ColorQuery.scala
@@ -22,13 +22,11 @@ class ColorQuery(binSizes: Seq[Seq[Int]], binMinima: Seq[Float]) {
 
   def apply(
     field: String,
-    hexColors: Seq[String],
+    colors: Seq[HsvColor],
     binIndices: Seq[Int] = binSizes.indices
   ): MoreLikeThisQuery =
     moreLikeThisQuery(field)
-      .likeTexts(
-        getColorsSignature(hexColors.map(HsvColor.fromHex(_).get), binIndices)
-      )
+      .likeTexts(getColorsSignature(colors, binIndices))
       .copy(
         minTermFreq = Some(1),
         minDocFreq = Some(1),

--- a/search/src/main/scala/weco/api/search/models/Color.scala
+++ b/search/src/main/scala/weco/api/search/models/Color.scala
@@ -1,5 +1,0 @@
-package weco.api.search.models
-
-object Color {
-  case class Hsv(hue: Float, saturation: Float, value: Float)
-}

--- a/search/src/main/scala/weco/api/search/models/Color.scala
+++ b/search/src/main/scala/weco/api/search/models/Color.scala
@@ -1,0 +1,5 @@
+package weco.api.search.models
+
+object Color {
+  case class Hsv(hue: Float, saturation: Float, value: Float)
+}

--- a/search/src/main/scala/weco/api/search/models/HsvColor.scala
+++ b/search/src/main/scala/weco/api/search/models/HsvColor.scala
@@ -1,0 +1,20 @@
+package weco.api.search.models
+
+import java.awt.{Color => AwtColor}
+import scala.util.Try
+
+case class HsvColor(hue: Float, saturation: Float, value: Float)
+
+case object HsvColor {
+  def fromHex(hexString: String): Try[HsvColor] = Try {
+    val n = Integer.parseInt(hexString, 16)
+    val (r, g, b) = (
+      (n >> 16) & 0xFF,
+      (n >> 8) & 0xFF,
+      n & 0xFF
+    )
+    val hsv = AwtColor.RGBtoHSB(r, g, b, null)
+
+    HsvColor(hue = hsv(0), saturation = hsv(1), value = hsv(2))
+  }
+}

--- a/search/src/main/scala/weco/api/search/models/MustQuery.scala
+++ b/search/src/main/scala/weco/api/search/models/MustQuery.scala
@@ -4,4 +4,4 @@ sealed trait WorkMustQuery
 
 sealed trait ImageMustQuery
 
-case class ColorMustQuery(hexColors: Seq[String]) extends ImageMustQuery
+case class ColorMustQuery(colors: Seq[HsvColor]) extends ImageMustQuery

--- a/search/src/main/scala/weco/api/search/rest/ImagesParams.scala
+++ b/search/src/main/scala/weco/api/search/rest/ImagesParams.scala
@@ -9,6 +9,8 @@ import weco.api.search.models.request.{
   SingleImageIncludes
 }
 
+import scala.util.{Failure, Success}
+
 case class SingleImageParams(
   include: Option[SingleImageIncludes]
 ) extends QueryParams
@@ -86,7 +88,24 @@ object MultipleImagesParams extends QueryParamsUtils {
     }
 
   implicit val colorMustQuery: Decoder[ColorMustQuery] =
-    decodeCommaSeparated.emap(strs => Right(ColorMustQuery(strs)))
+    decodeCommaSeparated.emap { strs =>
+      val tryColors = strs.map { s => (s, HsvColor.fromHex(s)) }
+
+      val colors = tryColors.collect { case (_, Success(c)) => c }
+      val unparsed = tryColors.collect { case (s, Failure(_)) => s }
+
+      val errorMessage = unparsed match {
+        case Nil => ""
+        case Seq(singleColor) => s"'$singleColor' is not a valid value. Please supply a hex string."
+        case multipleColors => s"${multipleColors.map(mc => s"'$mc'").mkString(", ")} are not valid values. Please supply hex strings."
+      }
+
+      Either.cond(
+        unparsed.isEmpty,
+        right = ColorMustQuery(colors),
+        left = errorMessage
+      )
+    }
 
   implicit val includesDecoder: Decoder[MultipleImagesIncludes] =
     decodeOneOfCommaSeparated(

--- a/search/src/main/scala/weco/api/search/rest/ImagesParams.scala
+++ b/search/src/main/scala/weco/api/search/rest/ImagesParams.scala
@@ -89,15 +89,19 @@ object MultipleImagesParams extends QueryParamsUtils {
 
   implicit val colorMustQuery: Decoder[ColorMustQuery] =
     decodeCommaSeparated.emap { strs =>
-      val tryColors = strs.map { s => (s, HsvColor.fromHex(s)) }
+      val tryColors = strs.map { s =>
+        (s, HsvColor.fromHex(s))
+      }
 
-      val colors = tryColors.collect { case (_, Success(c)) => c }
+      val colors = tryColors.collect { case (_, Success(c))   => c }
       val unparsed = tryColors.collect { case (s, Failure(_)) => s }
 
       val errorMessage = unparsed match {
         case Nil => ""
-        case Seq(singleColor) => s"'$singleColor' is not a valid value. Please supply a hex string."
-        case multipleColors => s"${multipleColors.map(mc => s"'$mc'").mkString(", ")} are not valid values. Please supply hex strings."
+        case Seq(singleColor) =>
+          s"'$singleColor' is not a valid value. Please supply a hex string."
+        case multipleColors =>
+          s"${multipleColors.map(mc => s"'$mc'").mkString(", ")} are not valid values. Please supply hex strings."
       }
 
       Either.cond(

--- a/search/src/test/scala/weco/api/search/elasticsearch/ColorQueryTest.scala
+++ b/search/src/test/scala/weco/api/search/elasticsearch/ColorQueryTest.scala
@@ -2,6 +2,7 @@ package weco.api.search.elasticsearch
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import weco.api.search.models.HsvColor
 
 class ColorQueryTest extends AnyFunSpec with Matchers {
   val colorQuery = new ColorQuery(
@@ -9,9 +10,13 @@ class ColorQueryTest extends AnyFunSpec with Matchers {
     binMinima = Seq(0f, 10f / 256, 10f / 256)
   )
 
+  val red: HsvColor = HsvColor.fromHex("ff0000").get
+  val green: HsvColor = HsvColor.fromHex("00ff00").get
+  val blue: HsvColor = HsvColor.fromHex("0000ff").get
+  val yellow: HsvColor = HsvColor.fromHex("ffff00").get
+
   it("creates queries for signatures with given bin sizes") {
-    val hexCode = "ffff00"
-    val q = colorQuery("colorField", Seq(hexCode))
+    val q = colorQuery("colorField", colors = Seq(yellow))
 
     q.fields should contain only "colorField"
     q.likeTexts shouldBe Seq(
@@ -22,16 +27,14 @@ class ColorQueryTest extends AnyFunSpec with Matchers {
   }
 
   it("creates queries for signatures with only some bins used") {
-    val hexCode = "ffff00"
-    val q = colorQuery("colorField", Seq(hexCode), binIndices = Seq(2))
+    val q = colorQuery("colorField", colors = Seq(yellow), binIndices = Seq(2))
 
     q.fields should contain only "colorField"
     q.likeTexts shouldBe Seq("269/2")
   }
 
   it("creates queries for multiple colors") {
-    val hexCodes = Seq("ff0000", "00ff00", "0000ff")
-    val q = colorQuery("colorField", hexCodes)
+    val q = colorQuery("colorField", colors = Seq(red, green, blue))
 
     q.fields should contain only "colorField"
     q.likeTexts shouldBe Seq(

--- a/search/src/test/scala/weco/api/search/elasticsearch/ColorQueryTest.scala
+++ b/search/src/test/scala/weco/api/search/elasticsearch/ColorQueryTest.scala
@@ -9,18 +9,6 @@ class ColorQueryTest extends AnyFunSpec with Matchers {
     binMinima = Seq(0f, 10f / 256, 10f / 256)
   )
 
-  it("converts hex colors to hsv tuples") {
-    val hexes = Seq("ff0000", "00ff00", "0000ff", "00fa9a")
-    val tuples = hexes.map(ColorQuery.hexToHsv)
-
-    tuples shouldBe Seq(
-      (0f, 1f, 1f),
-      (120f / 360f, 1f, 1f),
-      (240f / 360f, 1f, 1f),
-      (0.43600f, 1f, 0.98039216f)
-    )
-  }
-
   it("creates queries for signatures with given bin sizes") {
     val hexCode = "ffff00"
     val q = colorQuery("colorField", Seq(hexCode))

--- a/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
@@ -31,6 +31,18 @@ class ImagesErrorsTest
     }
   }
 
+  describe("returns a 400 Bad Request for invalid parameters") {
+    it("rejects an invalid color parameter") {
+      withApi { route =>
+        assertBadRequest(route)(
+          path = s"$rootPath/images?color=%3C",
+          description =
+            s"color: '%3C' is not a valid value. Please supply a hex string."
+        )
+      }
+    }
+  }
+
   it("returns a 500 error if the default index doesn't exist") {
     val elasticConfig = ElasticConfig(
       worksIndex = createIndex,

--- a/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
@@ -37,7 +37,17 @@ class ImagesErrorsTest
         assertBadRequest(route)(
           path = s"$rootPath/images?color=%3C",
           description =
-            s"color: '%3C' is not a valid value. Please supply a hex string."
+            s"color: '<' is not a valid value. Please supply a hex string."
+        )
+      }
+    }
+
+    it("rejects multiple invalid color parameters") {
+      withApi { route =>
+        assertBadRequest(route)(
+          path = s"$rootPath/images?color=%3C,ff0000,<script>",
+          description =
+            s"color: '<', '<script>' are not valid values. Please supply hex strings."
         )
       }
     }

--- a/search/src/test/scala/weco/api/search/models/HsvColorTest.scala
+++ b/search/src/test/scala/weco/api/search/models/HsvColorTest.scala
@@ -5,18 +5,23 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 
-class HsvColorTest extends AnyFunSpec with Matchers with TryValues with TableDrivenPropertyChecks {
+class HsvColorTest
+    extends AnyFunSpec
+    with Matchers
+    with TryValues
+    with TableDrivenPropertyChecks {
   it("creates an HSV from a valid string") {
     val testCases = Table(
       ("hexString", "expectedColor"),
       ("ff0000", HsvColor(0, 1, 1)),
       ("00ff00", HsvColor(120f / 360f, 1, 1)),
       ("0000ff", HsvColor(240f / 360f, 1, 1)),
-      ("00fa9a", HsvColor(0.43600f, 1f, 0.98039216f)),
+      ("00fa9a", HsvColor(0.43600f, 1f, 0.98039216f))
     )
 
-    forAll(testCases) { case (hexString, expectedColor) =>
-      HsvColor.fromHex(hexString).success.value shouldBe expectedColor
+    forAll(testCases) {
+      case (hexString, expectedColor) =>
+        HsvColor.fromHex(hexString).success.value shouldBe expectedColor
     }
   }
 

--- a/search/src/test/scala/weco/api/search/models/HsvColorTest.scala
+++ b/search/src/test/scala/weco/api/search/models/HsvColorTest.scala
@@ -1,0 +1,26 @@
+package weco.api.search.models
+
+import org.scalatest.TryValues
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class HsvColorTest extends AnyFunSpec with Matchers with TryValues with TableDrivenPropertyChecks {
+  it("creates an HSV from a valid string") {
+    val testCases = Table(
+      ("hexString", "expectedColor"),
+      ("ff0000", HsvColor(0, 1, 1)),
+      ("00ff00", HsvColor(120f / 360f, 1, 1)),
+      ("0000ff", HsvColor(240f / 360f, 1, 1)),
+      ("00fa9a", HsvColor(0.43600f, 1f, 0.98039216f)),
+    )
+
+    forAll(testCases) { case (hexString, expectedColor) =>
+      HsvColor.fromHex(hexString).success.value shouldBe expectedColor
+    }
+  }
+
+  it("fails if passed something that isn't a hex string") {
+    HsvColor.fromHex("XYZ").failure.exception shouldBe a[NumberFormatException]
+  }
+}


### PR DESCRIPTION
Closes https://github.com/wellcomecollection/platform/issues/5529

Previously the images API would crash if you passed it a non-hex string as a parameter, e.g. `/images?color=x`, because we defer parsing it into an HSV colour until quite a long way down – when we build the Elasticsearch query. There was no expectation that code could throw an error, so we didn't handle it.

I've extracted this code, wrapped it in a `Try` block to emphasise it can fail, and added error handling when we parse the user-supplied query parameters. If it's not a hex string, we now fail more gracefully with a 400 Bad Request.
