### PR TITLE
Look up works with items that are unidentified

### DIFF
--- a/requests/src/test/scala/weco/api/requests/services/ItemLookupTest.scala
+++ b/requests/src/test/scala/weco/api/requests/services/ItemLookupTest.scala
@@ -10,7 +10,10 @@ import weco.api.requests.models.RequestedItemWithWork
 import weco.catalogue.display_model.identifiers.DisplayIdentifier
 import weco.catalogue.display_model.work.DisplayItem
 import weco.catalogue.internal_model.identifiers.SourceIdentifier
-import weco.catalogue.internal_model.work.generators.{ItemsGenerators, WorkGenerators}
+import weco.catalogue.internal_model.work.generators.{
+  ItemsGenerators,
+  WorkGenerators
+}
 import weco.http.client.{HttpGet, MemoryHttpClient}
 
 import scala.concurrent.ExecutionContext.Implicits.global


### PR DESCRIPTION
This should fix the issue Natalie is seeing where she can't look up her requested items.

The ItemLookup asks the Catalogue API for all the works matching a given item ID, then inspects all the items on that work to see if they're the one it's looking for. If one of those items is unidentified, it's obviously not what we want, but it calls `item.identifiers.head` which throws a `NoSuchElementException: head of empty list` exception.

This patch updates the ItemLookup to be aware of items without identifiers, and not error when it finds it.