### PR TITLE
Remove internal model from the items API

### DIFF
--- a/common/display/src/main/scala/weco/catalogue/display_model/identifiers/GetIdentifiers.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/identifiers/GetIdentifiers.scala
@@ -5,13 +5,4 @@ import weco.catalogue.internal_model.identifiers.IdState
 trait GetIdentifiers {
   protected def getIdentifiers(id: IdState): List[DisplayIdentifier] =
     id.allSourceIdentifiers.map(DisplayIdentifier(_))
-
-  protected def getIdentifiers(
-    id: IdState,
-    includesIdentifiers: Boolean
-  ): Option[List[DisplayIdentifier]] =
-    if (includesIdentifiers)
-      Option(getIdentifiers(id)).filter(_.nonEmpty)
-    else
-      None
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/models/CatalogueWork.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/CatalogueWork.scala
@@ -2,23 +2,11 @@ package weco.api.stacks.models
 
 import weco.catalogue.display_model.identifiers.DisplayIdentifier
 import weco.catalogue.display_model.work.DisplayItem
-import weco.catalogue.internal_model.work.{Work, WorkState}
 
-// This is a fork of the DisplayWork model in the display library, which represents
-// a work as we receive it from the catalogue API.
+// This represents a work as we receive it from the catalogue API.
 case class CatalogueWork(
   id: String,
   title: Option[String],
   identifiers: List[DisplayIdentifier],
   items: List[DisplayItem]
 )
-
-object CatalogueWork {
-  def apply(work: Work.Visible[WorkState.Indexed]): CatalogueWork =
-    CatalogueWork(
-      id = work.state.canonicalId.underlying,
-      title = work.data.title,
-      identifiers = work.identifiers.map { DisplayIdentifier(_) },
-      items = work.data.items.map { DisplayItem(_) }
-    )
-}

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -1,7 +1,6 @@
 package weco.api.items.services
 
 import akka.http.scaladsl.model._
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
@@ -34,9 +33,7 @@ class ItemUpdateServiceTest
     extends AnyFunSpec
     with Matchers
     with JsonAssertions
-    with ScalaFutures
     with ItemsApiGenerators
-    with IntegrationPatience
     with SierraIdentifierGenerators
     with SierraSourceFixture {
 

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -161,32 +161,43 @@ class ItemUpdateServiceTest
     val itemUpdater = new DummyItemUpdater()
 
     val orderedItems = List(
-      temporarilyUnavailableItem(createSierraItemNumber),
-      createDigitalItem,
-      availableItem(createSierraItemNumber),
-      createDigitalItem,
-      availableItem(createSierraItemNumber),
-      temporarilyUnavailableItem(createSierraItemNumber),
-      createDigitalItem,
-      createDigitalItem
+      DisplayItem(
+        id = Some(randomCanonicalId),
+        identifiers = List(DisplayIdentifier(createSierraSystemSourceIdentifier))
+      ),
+      DisplayItem(
+        id = Some(randomCanonicalId),
+        identifiers = List(DisplayIdentifier(createSierraSystemSourceIdentifier))
+      ),
+      DisplayItem(
+        id = Some(randomCanonicalId),
+        identifiers = List(DisplayIdentifier(createSierraSystemSourceIdentifier))
+      ),
     )
 
     val reversedItems = orderedItems.reverse
 
     val workWithItemsForward = CatalogueWork(
-      indexedWork().items(orderedItems)
+      id = randomCanonicalId,
+      title = None,
+      identifiers = Nil,
+      items = orderedItems
     )
+
     val workWithItemsBackward = CatalogueWork(
-      indexedWork().items(reversedItems)
+      id = randomCanonicalId,
+      title = None,
+      identifiers = Nil,
+      items = orderedItems.reverse
     )
 
     withItemUpdateService(List(itemUpdater)) { itemUpdateService =>
       whenReady(itemUpdateService.updateItems(workWithItemsForward)) {
-        _ shouldBe orderedItems.map(it => DisplayItem(it))
+        _ shouldBe orderedItems
       }
 
       whenReady(itemUpdateService.updateItems(workWithItemsBackward)) {
-        _ shouldBe reversedItems.map(it => DisplayItem(it))
+        _ shouldBe reversedItems
       }
     }
   }

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -21,7 +21,6 @@ import weco.catalogue.internal_model.locations.{
   AccessStatus
 }
 import weco.catalogue.internal_model.work.Item
-import weco.catalogue.internal_model.work.generators.WorkGenerators
 import weco.fixtures.TestWith
 import weco.json.utils.JsonAssertions
 import weco.sierra.fixtures.SierraSourceFixture
@@ -39,7 +38,6 @@ class ItemUpdateServiceTest
     with ItemsApiGenerators
     with IntegrationPatience
     with SierraIdentifierGenerators
-    with WorkGenerators
     with SierraSourceFixture {
 
   def withSierraItemUpdater[R](

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -242,17 +242,23 @@ class ItemUpdateServiceTest
     val workWithUnavailableItemNumber = createSierraItemNumber
     val workWithAvailableItemNumber = createSierraItemNumber
 
-    val workWithUnavailableItem = indexedWork().items(
-      List(
-        temporarilyUnavailableItem(workWithUnavailableItemNumber),
-        dummyDigitalItem
+    val workWithUnavailableItem = CatalogueWork(
+      id = randomCanonicalId,
+      title = None,
+      identifiers = Nil,
+      items = List(
+        DisplayItem(temporarilyUnavailableItem(workWithUnavailableItemNumber)),
+        DisplayItem(dummyDigitalItem)
       )
     )
 
-    val workWithAvailableItem = indexedWork().items(
-      List(
-        availableItem(workWithAvailableItemNumber),
-        dummyDigitalItem
+    val workWithAvailableItem = CatalogueWork(
+      id = randomCanonicalId,
+      title = None,
+      identifiers = Nil,
+      items = List(
+        DisplayItem(availableItem(workWithAvailableItemNumber)),
+        DisplayItem(dummyDigitalItem)
       )
     )
 
@@ -287,11 +293,9 @@ class ItemUpdateServiceTest
 
     it("updates AccessCondition correctly based on Sierra responses") {
       forAll(itemStates) {
-        (sierraResponses, catalogueWork, expectedAccessCondition) =>
+        (sierraResponses, work, expectedAccessCondition) =>
           withSierraItemUpdater(sierraResponses) { itemUpdater =>
             withItemUpdateService(List(itemUpdater)) { itemUpdateService =>
-              val work = CatalogueWork(catalogueWork)
-
               whenReady(itemUpdateService.updateItems(work)) { updatedItems =>
                 updatedItems.length shouldBe 2
 

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -158,16 +158,19 @@ class ItemUpdateServiceTest
     val orderedItems = List(
       DisplayItem(
         id = Some(randomCanonicalId),
-        identifiers = List(DisplayIdentifier(createSierraSystemSourceIdentifier))
+        identifiers =
+          List(DisplayIdentifier(createSierraSystemSourceIdentifier))
       ),
       DisplayItem(
         id = Some(randomCanonicalId),
-        identifiers = List(DisplayIdentifier(createSierraSystemSourceIdentifier))
+        identifiers =
+          List(DisplayIdentifier(createSierraSystemSourceIdentifier))
       ),
       DisplayItem(
         id = Some(randomCanonicalId),
-        identifiers = List(DisplayIdentifier(createSierraSystemSourceIdentifier))
-      ),
+        identifiers =
+          List(DisplayIdentifier(createSierraSystemSourceIdentifier))
+      )
     )
 
     val reversedItems = orderedItems.reverse
@@ -209,27 +212,31 @@ class ItemUpdateServiceTest
       items = List(
         DisplayItem(
           id = Some(randomCanonicalId),
-          identifiers = List(DisplayIdentifier(createSierraSystemSourceIdentifier))
+          identifiers =
+            List(DisplayIdentifier(createSierraSystemSourceIdentifier))
         ),
         DisplayItem(
           id = Some(randomCanonicalId),
-          identifiers = List(DisplayIdentifier(createSierraSystemSourceIdentifier))
+          identifiers =
+            List(DisplayIdentifier(createSierraSystemSourceIdentifier))
         ),
         DisplayItem(
           id = Some(randomCanonicalId),
-          identifiers = List(DisplayIdentifier(createSierraSystemSourceIdentifier))
-        ),
+          identifiers =
+            List(DisplayIdentifier(createSierraSystemSourceIdentifier))
+        )
       )
     )
 
-    withItemUpdateService(itemUpdaters = List(brokenItemUpdater)) { itemUpdateService =>
-      whenReady(itemUpdateService.updateItems(workWithItems).failed) {
-        failure =>
-          failure shouldBe a[IllegalArgumentException]
-          failure.getMessage should include(
-            "Inconsistent results updating items"
-          )
-      }
+    withItemUpdateService(itemUpdaters = List(brokenItemUpdater)) {
+      itemUpdateService =>
+        whenReady(itemUpdateService.updateItems(workWithItems).failed) {
+          failure =>
+            failure shouldBe a[IllegalArgumentException]
+            failure.getMessage should include(
+              "Inconsistent results updating items"
+            )
+        }
     }
   }
 
@@ -287,28 +294,27 @@ class ItemUpdateServiceTest
     )
 
     it("updates AccessCondition correctly based on Sierra responses") {
-      forAll(itemStates) {
-        (sierraResponses, work, expectedAccessCondition) =>
-          withSierraItemUpdater(sierraResponses) { itemUpdater =>
-            withItemUpdateService(List(itemUpdater)) { itemUpdateService =>
-              whenReady(itemUpdateService.updateItems(work)) { updatedItems =>
-                updatedItems.length shouldBe 2
+      forAll(itemStates) { (sierraResponses, work, expectedAccessCondition) =>
+        withSierraItemUpdater(sierraResponses) { itemUpdater =>
+          withItemUpdateService(List(itemUpdater)) { itemUpdateService =>
+            whenReady(itemUpdateService.updateItems(work)) { updatedItems =>
+              updatedItems.length shouldBe 2
 
-                val physicalItem = updatedItems(0)
-                val digitalItem = updatedItems(1)
+              val physicalItem = updatedItems(0)
+              val digitalItem = updatedItems(1)
 
-                val updatedAccessCondition = physicalItem.locations.head
-                  .asInstanceOf[DisplayPhysicalLocation]
-                  .accessConditions
-                  .head
-                updatedAccessCondition shouldBe DisplayAccessCondition(
-                  expectedAccessCondition
-                )
+              val updatedAccessCondition = physicalItem.locations.head
+                .asInstanceOf[DisplayPhysicalLocation]
+                .accessConditions
+                .head
+              updatedAccessCondition shouldBe DisplayAccessCondition(
+                expectedAccessCondition
+              )
 
-                digitalItem shouldBe DisplayItem(dummyDigitalItem)
-              }
+              digitalItem shouldBe DisplayItem(dummyDigitalItem)
             }
           }
+        }
       }
     }
   }

--- a/items/src/test/scala/weco/api/items/services/WorkLookupTest.scala
+++ b/items/src/test/scala/weco/api/items/services/WorkLookupTest.scala
@@ -9,10 +9,23 @@ import weco.akka.fixtures.Akka
 import weco.api.items.fixtures.ItemsApiGenerators
 import weco.api.stacks.models.CatalogueWork
 import weco.catalogue.display_model.identifiers.DisplayIdentifier
-import weco.catalogue.display_model.locations.{DisplayAccessCondition, DisplayLocationType, DisplayPhysicalLocation}
+import weco.catalogue.display_model.locations.{
+  DisplayAccessCondition,
+  DisplayLocationType,
+  DisplayPhysicalLocation
+}
 import weco.catalogue.display_model.work.DisplayItem
-import weco.catalogue.internal_model.identifiers.{CanonicalId, IdentifierType, SourceIdentifier}
-import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod, AccessStatus, LocationType}
+import weco.catalogue.internal_model.identifiers.{
+  CanonicalId,
+  IdentifierType,
+  SourceIdentifier
+}
+import weco.catalogue.internal_model.locations.{
+  AccessCondition,
+  AccessMethod,
+  AccessStatus,
+  LocationType
+}
 import weco.fixtures.TestWith
 import weco.http.client.{HttpGet, MemoryHttpClient}
 

--- a/items/src/test/scala/weco/api/items/services/WorkLookupTest.scala
+++ b/items/src/test/scala/weco/api/items/services/WorkLookupTest.scala
@@ -2,7 +2,7 @@ package weco.api.items.services
 
 import akka.http.scaladsl.model._
 import org.scalatest.EitherValues
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.akka.fixtures.Akka
@@ -13,10 +13,8 @@ import weco.catalogue.display_model.locations.{DisplayAccessCondition, DisplayLo
 import weco.catalogue.display_model.work.DisplayItem
 import weco.catalogue.internal_model.identifiers.{CanonicalId, IdentifierType, SourceIdentifier}
 import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod, AccessStatus, LocationType}
-import weco.catalogue.internal_model.work.generators.WorkGenerators
 import weco.fixtures.TestWith
 import weco.http.client.{HttpGet, MemoryHttpClient}
-import weco.sierra.generators.SierraIdentifierGenerators
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -25,12 +23,9 @@ class WorkLookupTest
     extends AnyFunSpec
     with Matchers
     with EitherValues
-    with WorkGenerators
     with Akka
     with ScalaFutures
-    with IntegrationPatience
-    with ItemsApiGenerators
-    with SierraIdentifierGenerators {
+    with ItemsApiGenerators {
 
   def withLookup[R](
     responses: Seq[(HttpRequest, HttpResponse)]

--- a/snapshots/snapshot_generator/src/test/scala/weco/elasticsearch/ElasticsearchScannerTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/weco/elasticsearch/ElasticsearchScannerTest.scala
@@ -5,7 +5,6 @@ import com.sksamuel.elastic4s.{Index, Response}
 import com.sksamuel.elastic4s.requests.searches.SearchResponse
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.catalogue.internal_model.work.generators.WorkGenerators
 import weco.elasticsearch.test.fixtures.ElasticsearchFixtures
 import weco.fixtures.TestWith
 import weco.json.JsonUtil._
@@ -13,8 +12,7 @@ import weco.json.JsonUtil._
 class ElasticsearchScannerTest
     extends AnyFunSpec
     with Matchers
-    with ElasticsearchFixtures
-    with WorkGenerators {
+    with ElasticsearchFixtures {
   val scanner = new ElasticsearchScanner()(elasticClient)
 
   case class Shape(sides: Int, colour: String)


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5530, follows #448

The items API also shouldn't know about the internal model – it just deals in the public API responses. This unpicks it from some of the tests in favour of public catalogue models and/or hard-coded JSON responses.