### PR TITLE
Only fetch information for "stale" Sierra items

### DIFF
--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -33,9 +33,9 @@ class ItemUpdateServiceTest
     with JsonAssertions
     with IdentifiersGenerators
     with ItemsApiGenerators
-    with IntegrationPatience
     with SierraIdentifierGenerators
-    with SierraSourceFixture {
+    with SierraSourceFixture
+    with IntegrationPatience {
 
   def withSierraItemUpdater[R](
     responses: Seq[(HttpRequest, HttpResponse)] = Seq()

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -1,6 +1,7 @@
 package weco.api.items.services
 
 import akka.http.scaladsl.model._
+import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
@@ -12,11 +13,7 @@ import weco.catalogue.display_model.work.DisplayItem
 import weco.catalogue.internal_model.generators.IdentifiersGenerators
 import weco.catalogue.internal_model.identifiers.IdentifierType
 import weco.catalogue.internal_model.locations.AccessStatus.TemporarilyUnavailable
-import weco.catalogue.internal_model.locations.{
-  AccessCondition,
-  AccessMethod,
-  AccessStatus
-}
+import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod, AccessStatus}
 import weco.fixtures.TestWith
 import weco.json.utils.JsonAssertions
 import weco.sierra.fixtures.SierraSourceFixture
@@ -32,6 +29,7 @@ class ItemUpdateServiceTest
     with JsonAssertions
     with IdentifiersGenerators
     with ItemsApiGenerators
+    with IntegrationPatience
     with SierraIdentifierGenerators
     with SierraSourceFixture {
 

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -13,7 +13,11 @@ import weco.catalogue.display_model.work.DisplayItem
 import weco.catalogue.internal_model.generators.IdentifiersGenerators
 import weco.catalogue.internal_model.identifiers.IdentifierType
 import weco.catalogue.internal_model.locations.AccessStatus.TemporarilyUnavailable
-import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod, AccessStatus}
+import weco.catalogue.internal_model.locations.{
+  AccessCondition,
+  AccessMethod,
+  AccessStatus
+}
 import weco.fixtures.TestWith
 import weco.json.utils.JsonAssertions
 import weco.sierra.fixtures.SierraSourceFixture


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5530

One of the remaining couplings between the pipeline/API repo is all the logic for deciding if a Sierra item is requestable (the rules for requesting, item access rules). This is duplicated across the repos and we have Buildkite checks that the two move in sync. This ties us both to the internal model and Scala specifically, which we want to eventually ditch in the items API. This dependency prevents us doing that.

I think we can drastically simplify this logic in the items API.

In particular: we know a lot of items are not going to change in a way that requires real-time updates on the site; we can accept the latency in the catalogue API. Only items that are requestable need real-time information. (We already have [logic in the front-end](https://github.com/wellcomecollection/wellcomecollection.org/blob/fbec553332d061a6cdec5580c591ca810833e629/catalogue/webapp/components/PhysicalItems/PhysicalItems.tsx#L33-L52) that will decide if an item is "stale". If an item isn't stale, we skip going to the items API.)

This patch starts by tweaking the logic in the Sierra item updater:

* If an item is stale, we get new data from Sierra and re-run the access condition rules
* If an item is up-to-date, we use the access condition from the catalogue API

In a subsequent PR, this will let us cut down the amount of access condition related logic.