### PR TITLE
Revert "Update date format in HoldNote.scala" #452

### DIFF
--- a/requests/src/main/scala/weco/api/requests/models/HoldNote.scala
+++ b/requests/src/main/scala/weco/api/requests/models/HoldNote.scala
@@ -6,9 +6,7 @@ import scala.util.Try
 
 object HoldNote {
   val pickupDateLabel = "Requested for"
-  // We put the date and month first because it gets truncated on the ticket slip so we want to make sure
-  // the important information is always visible.
-  val pickupDateFormat = "dd-MM-yyyy" // Format as per https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
+  val pickupDateFormat = "yyyy-MM-dd" // Format as per https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
 
   private lazy val formatter = DateTimeFormatter.ofPattern(pickupDateFormat)
   def createPickupDate(pickupDate: LocalDate): String =

--- a/requests/src/test/scala/weco/api/requests/fixtures/SierraServiceFixture.scala
+++ b/requests/src/test/scala/weco/api/requests/fixtures/SierraServiceFixture.scala
@@ -63,7 +63,7 @@ trait SierraServiceFixture
            |  "recordType": "i",
            |  "recordNumber": ${item.withoutCheckDigit},
            |  "note": "Requested for: ${DateTimeFormatter
-             .ofPattern("dd-MM-yyyy")
+             .ofPattern("yyyy-MM-dd")
              .format(pickupDate)}",
            |  "pickupLocation": "unspecified"
            |}

--- a/requests/src/test/scala/weco/api/requests/services/SierraRequestsServiceTest.scala
+++ b/requests/src/test/scala/weco/api/requests/services/SierraRequestsServiceTest.scala
@@ -53,14 +53,14 @@ class SierraRequestsServiceTest
                    |    {
                    |      "id": "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/patrons/holds/1111",
                    |      "record": "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/items/${item1.withoutCheckDigit}",
-                   |      "note": "Requested for: 18-02-2022",
+                   |      "note": "Requested for: 2022-02-18",
                    |      "pickupLocation": {"code":"sepbb", "name":"Rare Materials Room"},
                    |      "status": {"code": "0", "name": "on hold."}
                    |    },
                    |    {
                    |      "id": "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/patrons/holds/2222",
                    |      "record": "https://libsys.wellcomelibrary.org/iii/sierra-api/v6/items/${item2.withoutCheckDigit}",
-                   |      "note": "Requested for: 19-02-2022",
+                   |      "note": "Requested for: 2022-02-19",
                    |      "pickupLocation": {"code":"sotop", "name":"Rare Materials Room"},
                    |      "status": {"code": "i", "name": "item hold ready for pickup"}
                    |    }
@@ -98,7 +98,7 @@ class SierraRequestsServiceTest
                 ),
                 pickupLocation = SierraLocation("sepbb", "Rare Materials Room"),
                 notNeededAfterDate = None,
-                note = Some("Requested for: 18-02-2022"),
+                note = Some("Requested for: 2022-02-18"),
                 status = SierraHoldStatus("0", "on hold.")
               ),
               item2SrcId -> SierraHold(
@@ -110,7 +110,7 @@ class SierraRequestsServiceTest
                 ),
                 pickupLocation = SierraLocation("sotop", "Rare Materials Room"),
                 notNeededAfterDate = None,
-                note = Some("Requested for: 19-02-2022"),
+                note = Some("Requested for: 2022-02-19"),
                 status = SierraHoldStatus("i", "item hold ready for pickup")
               )
             )
@@ -279,7 +279,7 @@ class SierraRequestsServiceTest
                    |{
                    |  "recordType": "i",
                    |  "recordNumber": ${itemNumber.withoutCheckDigit},
-                   |  "note": "Requested for: 18-02-2022",
+                   |  "note": "Requested for: $pickupDateString",
                    |  "pickupLocation": "unspecified"
                    |}
                    |""".stripMargin


### PR DESCRIPTION
We don't need this change any more, and it introduces an ambiguity into the dates