### PR TITLE
Use the display models for all the access-related code, not internal model

### DIFF
--- a/common/display/src/main/scala/weco/catalogue/display_model/locations/DisplayAccessCondition.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/locations/DisplayAccessCondition.scala
@@ -20,4 +20,12 @@ object DisplayAccessCondition {
       terms = accessCondition.terms,
       note = accessCondition.note
     )
+
+  def apply(method: DisplayAccessMethod, status: DisplayAccessStatus): DisplayAccessCondition =
+    DisplayAccessCondition(
+      method = method,
+      status = Some(status),
+      terms = None,
+      note = None,
+    )
 }

--- a/common/display/src/main/scala/weco/catalogue/display_model/locations/DisplayAccessCondition.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/locations/DisplayAccessCondition.scala
@@ -1,7 +1,6 @@
 package weco.catalogue.display_model.locations
 
 import io.circe.generic.extras.JsonKey
-import weco.catalogue.internal_model.locations.AccessCondition
 
 case class DisplayAccessCondition(
   method: DisplayAccessMethod,
@@ -12,15 +11,6 @@ case class DisplayAccessCondition(
 )
 
 object DisplayAccessCondition {
-
-  def apply(accessCondition: AccessCondition): DisplayAccessCondition =
-    DisplayAccessCondition(
-      method = DisplayAccessMethod(accessCondition.method),
-      status = accessCondition.status.map(DisplayAccessStatus.apply),
-      terms = accessCondition.terms,
-      note = accessCondition.note
-    )
-
   def apply(method: DisplayAccessMethod, status: DisplayAccessStatus): DisplayAccessCondition =
     DisplayAccessCondition(
       method = method,

--- a/common/display/src/main/scala/weco/catalogue/display_model/locations/DisplayAccessCondition.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/locations/DisplayAccessCondition.scala
@@ -28,4 +28,12 @@ object DisplayAccessCondition {
       terms = None,
       note = None,
     )
+
+  def apply(method: DisplayAccessMethod): DisplayAccessCondition =
+    DisplayAccessCondition(
+      method = method,
+      status = None,
+      terms = None,
+      note = None,
+    )
 }

--- a/common/display/src/main/scala/weco/catalogue/display_model/locations/DisplayAccessCondition.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/locations/DisplayAccessCondition.scala
@@ -11,12 +11,15 @@ case class DisplayAccessCondition(
 )
 
 object DisplayAccessCondition {
-  def apply(method: DisplayAccessMethod, status: DisplayAccessStatus): DisplayAccessCondition =
+  def apply(
+    method: DisplayAccessMethod,
+    status: DisplayAccessStatus
+  ): DisplayAccessCondition =
     DisplayAccessCondition(
       method = method,
       status = Some(status),
       terms = None,
-      note = None,
+      note = None
     )
 
   def apply(method: DisplayAccessMethod): DisplayAccessCondition =
@@ -24,6 +27,6 @@ object DisplayAccessCondition {
       method = method,
       status = None,
       terms = None,
-      note = None,
+      note = None
     )
 }

--- a/common/display/src/main/scala/weco/catalogue/display_model/locations/DisplayAccessMethod.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/locations/DisplayAccessMethod.scala
@@ -1,26 +1,9 @@
 package weco.catalogue.display_model.locations
 
 import io.circe.generic.extras.JsonKey
-import weco.catalogue.internal_model.locations.AccessMethod
 
 case class DisplayAccessMethod(
   id: String,
   label: String,
   @JsonKey("type") ontologyType: String = "AccessMethod"
 )
-
-object DisplayAccessMethod {
-  def apply(accessMethod: AccessMethod): DisplayAccessMethod =
-    accessMethod match {
-      case AccessMethod.OnlineRequest =>
-        DisplayAccessMethod("online-request", "Online request")
-      case AccessMethod.ManualRequest =>
-        DisplayAccessMethod("manual-request", "Manual request")
-      case AccessMethod.NotRequestable =>
-        DisplayAccessMethod("not-requestable", "Not requestable")
-      case AccessMethod.ViewOnline =>
-        DisplayAccessMethod("view-online", "View online")
-      case AccessMethod.OpenShelves =>
-        DisplayAccessMethod("open-shelves", "Open shelves")
-    }
-}

--- a/common/display/src/main/scala/weco/catalogue/display_model/locations/DisplayAccessStatus.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/locations/DisplayAccessStatus.scala
@@ -1,18 +1,9 @@
 package weco.catalogue.display_model.locations
 
 import io.circe.generic.extras.JsonKey
-import weco.catalogue.internal_model.locations.AccessStatus
 
 case class DisplayAccessStatus(
   id: String,
   label: String,
   @JsonKey("type") ontologyType: String = "AccessStatus"
 )
-
-object DisplayAccessStatus {
-  def apply(accessStatus: AccessStatus): DisplayAccessStatus =
-    DisplayAccessStatus(
-      id = accessStatus.id,
-      label = accessStatus.label
-    )
-}

--- a/common/display/src/main/scala/weco/catalogue/display_model/locations/DisplayLocationType.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/locations/DisplayLocationType.scala
@@ -1,15 +1,9 @@
 package weco.catalogue.display_model.locations
 
 import io.circe.generic.extras.JsonKey
-import weco.catalogue.internal_model.locations.LocationType
 
 case class DisplayLocationType(
   id: String,
   label: String,
   @JsonKey("type") ontologyType: String = "LocationType"
 )
-
-object DisplayLocationType {
-  def apply(locationType: LocationType): DisplayLocationType =
-    DisplayLocationType(id = locationType.id, label = locationType.label)
-}

--- a/common/stacks/src/main/scala/weco/api/stacks/models/CatalogueAccessMethod.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/CatalogueAccessMethod.scala
@@ -1,0 +1,19 @@
+package weco.api.stacks.models
+
+import weco.catalogue.display_model.locations.DisplayAccessMethod
+
+object CatalogueAccessMethod {
+  // These values mirror the access methods from the catalogue pipeline
+  // See https://github.com/wellcomecollection/catalogue-pipeline/blob/main/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessMethod.scala
+  //
+  // It only implements the subset of methods used in the API.
+  val OnlineRequest = DisplayAccessMethod(
+    id = "online-request",
+    label = "Online request"
+  )
+
+  val NotRequestable = DisplayAccessMethod(
+    id = "not-requestable",
+    label = "Not requestable"
+  )
+}

--- a/common/stacks/src/main/scala/weco/api/stacks/models/CatalogueAccessStatus.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/CatalogueAccessStatus.scala
@@ -1,0 +1,13 @@
+package weco.api.stacks.models
+
+import weco.catalogue.display_model.locations.DisplayAccessStatus
+
+object CatalogueAccessStatus {
+  // These values mirror the access statuses from the catalogue pipeline
+  // See https://github.com/wellcomecollection/catalogue-pipeline/blob/main/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/AccessStatus.scala
+  //
+  // It only implements the subset of statuses used in the API.
+  val Open = DisplayAccessStatus(id = "open", label = "Open")
+  val Restricted = DisplayAccessStatus(id = "restricted", label = "Restricted")
+  val TemporarilyUnavailable = DisplayAccessStatus(id = "temporarily-unavailable", label = "Temporarily unavailable")
+}

--- a/common/stacks/src/main/scala/weco/api/stacks/models/CatalogueAccessStatus.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/CatalogueAccessStatus.scala
@@ -9,5 +9,8 @@ object CatalogueAccessStatus {
   // It only implements the subset of statuses used in the API.
   val Open = DisplayAccessStatus(id = "open", label = "Open")
   val Restricted = DisplayAccessStatus(id = "restricted", label = "Restricted")
-  val TemporarilyUnavailable = DisplayAccessStatus(id = "temporarily-unavailable", label = "Temporarily unavailable")
+  val TemporarilyUnavailable = DisplayAccessStatus(
+    id = "temporarily-unavailable",
+    label = "Temporarily unavailable"
+  )
 }

--- a/common/stacks/src/main/scala/weco/api/stacks/models/CatalogueLocationType.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/CatalogueLocationType.scala
@@ -1,6 +1,10 @@
 package weco.api.stacks.models
 
 object CatalogueLocationType {
+  // These values mirror the location type IDs from the catalogue pipeline
+  // See https://github.com/wellcomecollection/catalogue-pipeline/blob/main/common/internal_model/src/main/scala/weco/catalogue/internal_model/locations/LocationType.scala
+  //
+  // It only implements the subset of location types used in the API.
   val ClosedStores = "closed-stores"
   val OpenShelves = "open-shelves"
   val OnExhibition = "on-exhibition"

--- a/common/stacks/src/main/scala/weco/api/stacks/models/SierraItemDataOps.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/SierraItemDataOps.scala
@@ -1,6 +1,9 @@
 package weco.api.stacks.models
 
-import weco.catalogue.display_model.locations.{DisplayAccessCondition, DisplayLocationType}
+import weco.catalogue.display_model.locations.{
+  DisplayAccessCondition,
+  DisplayLocationType
+}
 import weco.catalogue.source_model.sierra.rules.SierraItemAccess
 import weco.sierra.models.data.SierraItemData
 

--- a/common/stacks/src/main/scala/weco/api/stacks/models/SierraItemDataOps.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/SierraItemDataOps.scala
@@ -1,7 +1,6 @@
 package weco.api.stacks.models
 
-import weco.catalogue.display_model.locations.DisplayLocationType
-import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod}
+import weco.catalogue.display_model.locations.{DisplayAccessCondition, DisplayLocationType}
 import weco.catalogue.source_model.sierra.rules.SierraItemAccess
 import weco.sierra.models.data.SierraItemData
 
@@ -9,7 +8,7 @@ object SierraItemDataOps {
   implicit class ItemDataOps(itemData: SierraItemData) {
     def accessCondition(
       location: Option[DisplayLocationType]
-    ): Option[AccessCondition] = {
+    ): Option[DisplayAccessCondition] = {
       val (accessCondition, _) = SierraItemAccess(
         location = location,
         itemData = itemData
@@ -21,6 +20,6 @@ object SierraItemDataOps {
     def allowsOnlineRequesting(location: Option[DisplayLocationType]): Boolean =
       accessCondition(location)
         .map(_.method)
-        .contains(AccessMethod.OnlineRequest)
+        .contains(CatalogueAccessMethod.OnlineRequest)
   }
 }

--- a/common/stacks/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
+++ b/common/stacks/src/main/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccess.scala
@@ -1,13 +1,8 @@
 package weco.catalogue.source_model.sierra.rules
 
 import grizzled.slf4j.Logging
-import weco.api.stacks.models.CatalogueLocationType
-import weco.catalogue.display_model.locations.DisplayLocationType
-import weco.catalogue.internal_model.locations.{
-  AccessCondition,
-  AccessMethod,
-  AccessStatus,
-}
+import weco.api.stacks.models.{CatalogueAccessMethod, CatalogueAccessStatus, CatalogueLocationType}
+import weco.catalogue.display_model.locations.{DisplayAccessCondition, DisplayLocationType}
 import weco.catalogue.source_model.sierra.source.{OpacMsg, Status}
 import weco.sierra.models.SierraQueryOps
 import weco.sierra.models.data.SierraItemData
@@ -33,7 +28,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
   def apply(
     location: Option[DisplayLocationType],
     itemData: SierraItemData
-  ): (Option[AccessCondition], Option[String]) = {
+  ): (Option[DisplayAccessCondition], Option[String]) = {
     val accessCondition = createAccessCondition(
       holdCount = itemData.holdCount,
       status = itemData.status,
@@ -72,7 +67,7 @@ object SierraItemAccess extends SierraQueryOps with Logging {
     rulesForRequestingResult: Option[NotRequestable],
     locationTypeId: Option[String],
     itemData: SierraItemData
-  ): Option[AccessCondition] =
+  ): Option[DisplayAccessCondition] =
     (holdCount, status, opacmsg, rulesForRequestingResult, locationTypeId) match {
 
       // Items in the closed stores that aren't prevented from being requested get
@@ -86,9 +81,9 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         None,
         Some(CatalogueLocationType.ClosedStores)) =>
         Some(
-          AccessCondition(
-            method = AccessMethod.OnlineRequest,
-            status = AccessStatus.Open
+          DisplayAccessCondition(
+            method = CatalogueAccessMethod.OnlineRequest,
+            status = CatalogueAccessStatus.Open
           )
         )
 
@@ -103,9 +98,9 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         None,
         Some(CatalogueLocationType.ClosedStores)) =>
         Some(
-          AccessCondition(
-            method = AccessMethod.OnlineRequest,
-            status = AccessStatus.Restricted
+          DisplayAccessCondition(
+            method = CatalogueAccessMethod.OnlineRequest,
+            status = CatalogueAccessStatus.Restricted
           )
         )
 
@@ -125,11 +120,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
       case (Some(holdCount), _, _, _, Some(CatalogueLocationType.ClosedStores))
         if holdCount > 0 =>
         Some(
-          AccessCondition(
-            method = AccessMethod.NotRequestable,
-            status = Some(AccessStatus.TemporarilyUnavailable),
+          DisplayAccessCondition(
+            method = CatalogueAccessMethod.NotRequestable,
+            status = Some(CatalogueAccessStatus.TemporarilyUnavailable),
             note = Some(
-              "Item is in use by another reader. Please ask at Library Enquiry Desk.")
+              "Item is in use by another reader. Please ask at Library Enquiry Desk."),
+            terms = None
           )
         )
 
@@ -141,11 +137,12 @@ object SierraItemAccess extends SierraQueryOps with Logging {
         Some(NotRequestable.InUseByAnotherReader(_)),
         Some(CatalogueLocationType.ClosedStores)) =>
         Some(
-          AccessCondition(
-            method = AccessMethod.NotRequestable,
-            status = Some(AccessStatus.TemporarilyUnavailable),
+          DisplayAccessCondition(
+            method = CatalogueAccessMethod.NotRequestable,
+            status = Some(CatalogueAccessStatus.TemporarilyUnavailable),
             note = Some(
-              "Item is in use by another reader. Please ask at Library Enquiry Desk.")
+              "Item is in use by another reader. Please ask at Library Enquiry Desk."),
+            terms = None
           )
         )
 

--- a/common/stacks/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
+++ b/common/stacks/src/test/scala/weco/catalogue/source_model/sierra/rules/SierraItemAccessTest.scala
@@ -2,8 +2,8 @@ package weco.catalogue.source_model.sierra.rules
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.catalogue.display_model.locations.DisplayLocationType
-import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod, AccessStatus}
+import weco.api.stacks.models.{CatalogueAccessMethod, CatalogueAccessStatus}
+import weco.catalogue.display_model.locations.{DisplayAccessCondition, DisplayLocationType}
 import weco.sierra.generators.SierraDataGenerators
 import weco.sierra.models.marc.FixedField
 
@@ -48,9 +48,9 @@ class SierraItemAccessTest
             itemData = itemData
           )
 
-          ac.get shouldBe AccessCondition(
-            method = AccessMethod.OnlineRequest,
-            status = AccessStatus.Open)
+          ac.get shouldBe DisplayAccessCondition(
+            method = CatalogueAccessMethod.OnlineRequest,
+            status = CatalogueAccessStatus.Open)
         }
 
         it("if it's restricted") {
@@ -77,9 +77,9 @@ class SierraItemAccessTest
           )
 
           ac.get shouldBe
-            AccessCondition(
-              method = AccessMethod.OnlineRequest,
-              status = AccessStatus.Restricted)
+            DisplayAccessCondition(
+              method = CatalogueAccessMethod.OnlineRequest,
+              status = CatalogueAccessStatus.Restricted)
         }
       }
 
@@ -142,11 +142,12 @@ class SierraItemAccessTest
         )
 
         ac.get shouldBe
-          AccessCondition(
-            method = AccessMethod.NotRequestable,
-            status = Some(AccessStatus.TemporarilyUnavailable),
+          DisplayAccessCondition(
+            method = CatalogueAccessMethod.NotRequestable,
+            status = Some(CatalogueAccessStatus.TemporarilyUnavailable),
             note = Some(
-              "Item is in use by another reader. Please ask at Library Enquiry Desk.")
+              "Item is in use by another reader. Please ask at Library Enquiry Desk."),
+            terms = None
           )
       }
 
@@ -176,11 +177,12 @@ class SierraItemAccessTest
         )
 
         ac.get shouldBe
-          AccessCondition(
-            method = AccessMethod.NotRequestable,
-            status = Some(AccessStatus.TemporarilyUnavailable),
+          DisplayAccessCondition(
+            method = CatalogueAccessMethod.NotRequestable,
+            status = Some(CatalogueAccessStatus.TemporarilyUnavailable),
             note = Some(
-              "Item is in use by another reader. Please ask at Library Enquiry Desk.")
+              "Item is in use by another reader. Please ask at Library Enquiry Desk."),
+            terms = None
           )
       }
 
@@ -213,11 +215,12 @@ class SierraItemAccessTest
         )
 
         ac.get shouldBe
-          AccessCondition(
-            method = AccessMethod.NotRequestable,
-            status = Some(AccessStatus.TemporarilyUnavailable),
+          DisplayAccessCondition(
+            method = CatalogueAccessMethod.NotRequestable,
+            status = Some(CatalogueAccessStatus.TemporarilyUnavailable),
             note = Some(
-              "Item is in use by another reader. Please ask at Library Enquiry Desk.")
+              "Item is in use by another reader. Please ask at Library Enquiry Desk."),
+            terms = None
           )
       }
 
@@ -246,11 +249,12 @@ class SierraItemAccessTest
         )
 
         ac.get shouldBe
-          AccessCondition(
-            method = AccessMethod.NotRequestable,
-            status = Some(AccessStatus.TemporarilyUnavailable),
+          DisplayAccessCondition(
+            method = CatalogueAccessMethod.NotRequestable,
+            status = Some(CatalogueAccessStatus.TemporarilyUnavailable),
             note = Some(
-              "Item is in use by another reader. Please ask at Library Enquiry Desk.")
+              "Item is in use by another reader. Please ask at Library Enquiry Desk."),
+            terms = None
           )
       }
     }

--- a/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
+++ b/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
@@ -1,8 +1,16 @@
 package weco.api.items.services
 
 import grizzled.slf4j.Logging
-import weco.api.stacks.models.{CatalogueAccessMethod, DisplayItemOps, SierraItemIdentifier}
-import weco.catalogue.display_model.locations.{DisplayAccessCondition, DisplayLocationType, DisplayPhysicalLocation}
+import weco.api.stacks.models.{
+  CatalogueAccessMethod,
+  DisplayItemOps,
+  SierraItemIdentifier
+}
+import weco.catalogue.display_model.locations.{
+  DisplayAccessCondition,
+  DisplayLocationType,
+  DisplayPhysicalLocation
+}
 import weco.catalogue.display_model.work.DisplayItem
 import weco.catalogue.internal_model.identifiers.IdentifierType
 import weco.sierra.http.SierraSource
@@ -56,7 +64,9 @@ class SierraItemUpdater(sierraSource: SierraSource)(
     for {
       itemEither <- sierraSource.lookupItemEntries(existingItems.keys.toSeq)
 
-      maybeAccessConditions: Map[SierraItemNumber, Option[DisplayAccessCondition]] = itemEither match {
+      maybeAccessConditions: Map[SierraItemNumber, Option[
+        DisplayAccessCondition
+      ]] = itemEither match {
         case Right(SierraItemDataEntries(_, _, entries)) =>
           entries
             .map(item => {
@@ -133,7 +143,11 @@ class SierraItemUpdater(sierraSource: SierraSource)(
           missingItemIds = itemIds.keySet.diff(accessConditionsMap.keySet)
 
           missingItemsMap = missingItemIds
-            .map(_ -> DisplayAccessCondition(method = CatalogueAccessMethod.NotRequestable))
+            .map(
+              _ -> DisplayAccessCondition(
+                method = CatalogueAccessMethod.NotRequestable
+              )
+            )
             .toMap
         } yield accessConditionsMap ++ missingItemsMap
     }

--- a/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
+++ b/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
@@ -1,16 +1,11 @@
 package weco.api.items.services
 
 import grizzled.slf4j.Logging
-import weco.sierra.http.SierraSource
-import weco.api.stacks.models.{DisplayItemOps, SierraItemIdentifier}
-import weco.catalogue.display_model.locations.{
-  DisplayAccessCondition,
-  DisplayLocationType,
-  DisplayPhysicalLocation
-}
+import weco.api.stacks.models.{CatalogueAccessMethod, DisplayItemOps, SierraItemIdentifier}
+import weco.catalogue.display_model.locations.{DisplayAccessCondition, DisplayLocationType, DisplayPhysicalLocation}
 import weco.catalogue.display_model.work.DisplayItem
 import weco.catalogue.internal_model.identifiers.IdentifierType
-import weco.catalogue.internal_model.locations.{AccessCondition, AccessMethod}
+import weco.sierra.http.SierraSource
 import weco.sierra.models.errors.SierraItemLookupError
 import weco.sierra.models.fields.SierraItemDataEntries
 import weco.sierra.models.identifiers.SierraItemNumber
@@ -44,13 +39,11 @@ class SierraItemUpdater(sierraSource: SierraSource)(
     */
   private def updateAccessCondition(
     item: DisplayItem,
-    accessCondition: AccessCondition
+    accessCondition: DisplayAccessCondition
   ): DisplayItem = {
     val updatedItemLocations = item.locations.map {
       case physicalLocation: DisplayPhysicalLocation =>
-        physicalLocation.copy(
-          accessConditions = List(DisplayAccessCondition(accessCondition))
-        )
+        physicalLocation.copy(accessConditions = List(accessCondition))
       case location => location
     }
 
@@ -59,11 +52,11 @@ class SierraItemUpdater(sierraSource: SierraSource)(
 
   private def getAccessConditions(
     existingItems: Map[SierraItemNumber, Option[DisplayLocationType]]
-  ): Future[Map[SierraItemNumber, AccessCondition]] =
+  ): Future[Map[SierraItemNumber, DisplayAccessCondition]] =
     for {
       itemEither <- sierraSource.lookupItemEntries(existingItems.keys.toSeq)
 
-      maybeAccessConditions: Map[SierraItemNumber, Option[AccessCondition]] = itemEither match {
+      maybeAccessConditions: Map[SierraItemNumber, Option[DisplayAccessCondition]] = itemEither match {
         case Right(SierraItemDataEntries(_, _, entries)) =>
           entries
             .map(item => {
@@ -83,7 +76,7 @@ class SierraItemUpdater(sierraSource: SierraSource)(
             .toMap
         case Left(itemLookupError) =>
           error(s"Item lookup failed: $itemLookupError")
-          Map.empty[SierraItemNumber, Option[AccessCondition]]
+          Map.empty[SierraItemNumber, Option[DisplayAccessCondition]]
       }
 
       accessConditions = maybeAccessConditions
@@ -125,7 +118,7 @@ class SierraItemUpdater(sierraSource: SierraSource)(
     */
   private def getUpdatedAccessConditions(
     itemIds: Map[SierraItemNumber, Option[DisplayLocationType]]
-  ): Future[Map[SierraItemNumber, AccessCondition]] =
+  ): Future[Map[SierraItemNumber, DisplayAccessCondition]] =
     itemIds.size match {
       case 0 => Future.successful(Map())
 
@@ -140,7 +133,7 @@ class SierraItemUpdater(sierraSource: SierraSource)(
           missingItemIds = itemIds.keySet.diff(accessConditionsMap.keySet)
 
           missingItemsMap = missingItemIds
-            .map(_ -> AccessCondition(method = AccessMethod.NotRequestable))
+            .map(_ -> DisplayAccessCondition(method = CatalogueAccessMethod.NotRequestable))
             .toMap
         } yield accessConditionsMap ++ missingItemsMap
     }

--- a/items/src/test/scala/weco/api/items/services/WorkLookupTest.scala
+++ b/items/src/test/scala/weco/api/items/services/WorkLookupTest.scala
@@ -24,7 +24,6 @@ import weco.catalogue.internal_model.identifiers.{
   IdentifierType,
   SourceIdentifier
 }
-import weco.catalogue.internal_model.locations.LocationType
 import weco.fixtures.TestWith
 import weco.http.client.{HttpGet, MemoryHttpClient}
 
@@ -176,7 +175,8 @@ class WorkLookupTest
                 DisplayPhysicalLocation(
                   label = locationLabel,
                   locationType = DisplayLocationType(
-                    locationType = LocationType.ClosedStores
+                    id = "closed-stores",
+                    label = "Closed stores"
                   ),
                   accessConditions = List(
                     DisplayAccessCondition(

--- a/items/src/test/scala/weco/api/items/services/WorkLookupTest.scala
+++ b/items/src/test/scala/weco/api/items/services/WorkLookupTest.scala
@@ -7,7 +7,11 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.akka.fixtures.Akka
 import weco.api.items.fixtures.ItemsApiGenerators
-import weco.api.stacks.models.CatalogueWork
+import weco.api.stacks.models.{
+  CatalogueAccessMethod,
+  CatalogueAccessStatus,
+  CatalogueWork
+}
 import weco.catalogue.display_model.identifiers.DisplayIdentifier
 import weco.catalogue.display_model.locations.{
   DisplayAccessCondition,
@@ -20,12 +24,7 @@ import weco.catalogue.internal_model.identifiers.{
   IdentifierType,
   SourceIdentifier
 }
-import weco.catalogue.internal_model.locations.{
-  AccessCondition,
-  AccessMethod,
-  AccessStatus,
-  LocationType
-}
+import weco.catalogue.internal_model.locations.LocationType
 import weco.fixtures.TestWith
 import weco.http.client.{HttpGet, MemoryHttpClient}
 
@@ -181,10 +180,8 @@ class WorkLookupTest
                   ),
                   accessConditions = List(
                     DisplayAccessCondition(
-                      AccessCondition(
-                        status = AccessStatus.TemporarilyUnavailable,
-                        method = AccessMethod.NotRequestable
-                      )
+                      status = CatalogueAccessStatus.TemporarilyUnavailable,
+                      method = CatalogueAccessMethod.NotRequestable
                     )
                   )
                 )


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5530

We might want to think about the catalogue/display naming at some point, but in the meantime it gets us a bit closer to being able to remove internal model.