### PR TITLE
Switch to using the DisplayIdentifier type; not SourceIdentifier

### DIFF
--- a/common/display/src/main/scala/weco/catalogue/display_model/identifiers/DisplayIdentifier.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/identifiers/DisplayIdentifier.scala
@@ -1,19 +1,9 @@
 package weco.catalogue.display_model.identifiers
 
 import io.circe.generic.extras.JsonKey
-import weco.catalogue.internal_model.identifiers.SourceIdentifier
 
 case class DisplayIdentifier(
   identifierType: DisplayIdentifierType,
   value: String,
   @JsonKey("type") ontologyType: String = "Identifier"
 )
-
-object DisplayIdentifier {
-  def apply(sourceIdentifier: SourceIdentifier): DisplayIdentifier =
-    DisplayIdentifier(
-      identifierType =
-        DisplayIdentifierType(identifierType = sourceIdentifier.identifierType),
-      value = sourceIdentifier.value
-    )
-}

--- a/common/display/src/main/scala/weco/catalogue/display_model/identifiers/DisplayIdentifierType.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/identifiers/DisplayIdentifierType.scala
@@ -1,18 +1,9 @@
 package weco.catalogue.display_model.identifiers
 
 import io.circe.generic.extras.JsonKey
-import weco.catalogue.internal_model.identifiers.IdentifierType
 
 case class DisplayIdentifierType(
   id: String,
   label: String,
   @JsonKey("type") ontologyType: String = "IdentifierType"
 )
-
-object DisplayIdentifierType {
-  def apply(identifierType: IdentifierType): DisplayIdentifierType =
-    DisplayIdentifierType(
-      id = identifierType.id,
-      label = identifierType.label
-    )
-}

--- a/common/display/src/main/scala/weco/catalogue/display_model/identifiers/DisplayIdentifierType.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/identifiers/DisplayIdentifierType.scala
@@ -7,3 +7,14 @@ case class DisplayIdentifierType(
   label: String,
   @JsonKey("type") ontologyType: String = "IdentifierType"
 )
+
+case object DisplayIdentifierType {
+  // These values mirror the identifier types from the catalogue pipeline
+  // See https://github.com/wellcomecollection/catalogue-pipeline/blob/main/common/internal_model/src/main/scala/weco/catalogue/internal_model/identifiers/IdentifierType.scala
+  //
+  // It only implements the subset of methods used in the API.
+  val SierraSystemNumber = DisplayIdentifierType(
+    id = "sierra-system-number",
+    label = "Sierra system number"
+  )
+}

--- a/common/stacks/src/main/scala/weco/api/stacks/models/SierraItemIdentifier.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/SierraItemIdentifier.scala
@@ -30,7 +30,9 @@ object SierraItemIdentifier {
   def fromSourceIdentifier(
     sourceIdentifier: DisplayIdentifier
   ): SierraItemNumber = {
-    require(sourceIdentifier.identifierType.id == DisplayIdentifierType.SierraSystemNumber.id)
+    require(
+      sourceIdentifier.identifierType.id == DisplayIdentifierType.SierraSystemNumber.id
+    )
 
     // We expect the SourceIdentifier to have a Sierra ID with a prefix
     // and a check digit, e.g. i18234495

--- a/common/stacks/src/main/scala/weco/api/stacks/models/SierraItemIdentifier.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/SierraItemIdentifier.scala
@@ -1,10 +1,6 @@
 package weco.api.stacks.models
 
-import weco.catalogue.display_model.identifiers.DisplayIdentifier
-import weco.catalogue.internal_model.identifiers.{
-  IdentifierType,
-  SourceIdentifier
-}
+import weco.catalogue.display_model.identifiers.{DisplayIdentifier, DisplayIdentifierType}
 import weco.sierra.models.identifiers.SierraItemNumber
 
 import java.net.URI
@@ -22,19 +18,19 @@ object SierraItemIdentifier {
         throw new Exception("Failed to create SierraItemNumber", e)
     }
 
-  def toSourceIdentifier(itemNumber: SierraItemNumber): SourceIdentifier =
-    SourceIdentifier(
-      identifierType = IdentifierType.SierraSystemNumber,
-      value = itemNumber.withCheckDigit,
-      ontologyType = "Item"
+  def toSourceIdentifier(itemNumber: SierraItemNumber): DisplayIdentifier =
+    DisplayIdentifier(
+      identifierType = DisplayIdentifierType(
+        id = "sierra-system-number",
+        label = "Sierra system number"
+      ),
+      value = itemNumber.withCheckDigit
     )
 
   def fromSourceIdentifier(
     sourceIdentifier: DisplayIdentifier
   ): SierraItemNumber = {
-    require(
-      sourceIdentifier.identifierType.id == IdentifierType.SierraSystemNumber.id
-    )
+    require(sourceIdentifier.identifierType.id == "sierra-system-number")
 
     // We expect the SourceIdentifier to have a Sierra ID with a prefix
     // and a check digit, e.g. i18234495

--- a/common/stacks/src/main/scala/weco/api/stacks/models/SierraItemIdentifier.scala
+++ b/common/stacks/src/main/scala/weco/api/stacks/models/SierraItemIdentifier.scala
@@ -1,6 +1,9 @@
 package weco.api.stacks.models
 
-import weco.catalogue.display_model.identifiers.{DisplayIdentifier, DisplayIdentifierType}
+import weco.catalogue.display_model.identifiers.{
+  DisplayIdentifier,
+  DisplayIdentifierType
+}
 import weco.sierra.models.identifiers.SierraItemNumber
 
 import java.net.URI
@@ -20,17 +23,14 @@ object SierraItemIdentifier {
 
   def toSourceIdentifier(itemNumber: SierraItemNumber): DisplayIdentifier =
     DisplayIdentifier(
-      identifierType = DisplayIdentifierType(
-        id = "sierra-system-number",
-        label = "Sierra system number"
-      ),
+      identifierType = DisplayIdentifierType.SierraSystemNumber,
       value = itemNumber.withCheckDigit
     )
 
   def fromSourceIdentifier(
     sourceIdentifier: DisplayIdentifier
   ): SierraItemNumber = {
-    require(sourceIdentifier.identifierType.id == "sierra-system-number")
+    require(sourceIdentifier.identifierType.id == DisplayIdentifierType.SierraSystemNumber.id)
 
     // We expect the SourceIdentifier to have a Sierra ID with a prefix
     // and a check digit, e.g. i18234495

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -6,17 +6,12 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import weco.api.items.fixtures.ItemsApiGenerators
-import weco.api.stacks.models.{
-  CatalogueAccessMethod,
-  CatalogueAccessStatus,
-  CatalogueWork
-}
-import weco.catalogue.display_model.identifiers.DisplayIdentifier
+import weco.api.stacks.models.{CatalogueAccessMethod, CatalogueAccessStatus, CatalogueWork}
+import weco.catalogue.display_model.identifiers.{DisplayIdentifier, DisplayIdentifierType}
 import weco.catalogue.display_model.locations._
 import weco.catalogue.display_model.work.DisplayItem
-import weco.catalogue.internal_model.generators.IdentifiersGenerators
 import weco.catalogue.internal_model.identifiers.IdentifierType
-import weco.fixtures.TestWith
+import weco.fixtures.{RandomGenerators, TestWith}
 import weco.json.utils.JsonAssertions
 import weco.sierra.fixtures.SierraSourceFixture
 import weco.sierra.generators.SierraIdentifierGenerators
@@ -29,10 +24,10 @@ class ItemUpdateServiceTest
     extends AnyFunSpec
     with Matchers
     with JsonAssertions
-    with IdentifiersGenerators
     with ItemsApiGenerators
-    with SierraIdentifierGenerators
+    with RandomGenerators
     with SierraSourceFixture
+    with SierraIdentifierGenerators
     with IntegrationPatience {
 
   def withSierraItemUpdater[R](
@@ -176,23 +171,12 @@ class ItemUpdateServiceTest
   it("maintains the order of items") {
     val itemUpdater = new DummyItemUpdater()
 
-    val orderedItems = List(
+    val orderedItems = (1 to 3).map(_ =>
       DisplayItem(
         id = Some(randomCanonicalId),
-        identifiers =
-          List(DisplayIdentifier(createSierraSystemSourceIdentifier))
-      ),
-      DisplayItem(
-        id = Some(randomCanonicalId),
-        identifiers =
-          List(DisplayIdentifier(createSierraSystemSourceIdentifier))
-      ),
-      DisplayItem(
-        id = Some(randomCanonicalId),
-        identifiers =
-          List(DisplayIdentifier(createSierraSystemSourceIdentifier))
+        identifiers = List(createSierraSystemSourceIdentifier)
       )
-    )
+    ).toList
 
     val reversedItems = orderedItems.reverse
 
@@ -230,23 +214,12 @@ class ItemUpdateServiceTest
       id = randomCanonicalId,
       title = None,
       identifiers = Nil,
-      items = List(
+      items = (1 to 3).map(_ =>
         DisplayItem(
           id = Some(randomCanonicalId),
-          identifiers =
-            List(DisplayIdentifier(createSierraSystemSourceIdentifier))
-        ),
-        DisplayItem(
-          id = Some(randomCanonicalId),
-          identifiers =
-            List(DisplayIdentifier(createSierraSystemSourceIdentifier))
-        ),
-        DisplayItem(
-          id = Some(randomCanonicalId),
-          identifiers =
-            List(DisplayIdentifier(createSierraSystemSourceIdentifier))
+          identifiers = List(createSierraSystemSourceIdentifier)
         )
-      )
+      ).toList
     )
 
     withItemUpdateService(itemUpdaters = List(brokenItemUpdater)) {
@@ -353,17 +326,27 @@ class ItemUpdateServiceTest
         )
       )
 
-    val itemSourceIdentifier = createSierraSystemSourceIdentifierWith(
-      value = sierraItemNumber.withCheckDigit,
-      ontologyType = "Item"
+    val itemSourceIdentifier = DisplayIdentifier(
+      identifierType = DisplayIdentifierType(
+        id = "sierra-system-number",
+        label = "Sierra system number"
+      ),
+      value = sierraItemNumber.withCheckDigit
     )
 
     DisplayItem(
       id = Some(randomAlphanumeric(length = 8)),
-      identifiers = List(
-        DisplayIdentifier(itemSourceIdentifier)
-      ),
+      identifiers = List(itemSourceIdentifier),
       locations = List(physicalItemLocation)
     )
   }
+
+  def createSierraSystemSourceIdentifier: DisplayIdentifier =
+    DisplayIdentifier(
+      identifierType = DisplayIdentifierType(
+        id = "sierra-system-number",
+        label = "Sierra system number"
+      ),
+      value = randomAlphanumeric()
+    )
 }

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -6,8 +6,15 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import weco.api.items.fixtures.ItemsApiGenerators
-import weco.api.stacks.models.{CatalogueAccessMethod, CatalogueAccessStatus, CatalogueWork}
-import weco.catalogue.display_model.identifiers.{DisplayIdentifier, DisplayIdentifierType}
+import weco.api.stacks.models.{
+  CatalogueAccessMethod,
+  CatalogueAccessStatus,
+  CatalogueWork
+}
+import weco.catalogue.display_model.identifiers.{
+  DisplayIdentifier,
+  DisplayIdentifierType
+}
 import weco.catalogue.display_model.locations._
 import weco.catalogue.display_model.work.DisplayItem
 import weco.catalogue.internal_model.identifiers.IdentifierType
@@ -327,10 +334,7 @@ class ItemUpdateServiceTest
       )
 
     val itemSourceIdentifier = DisplayIdentifier(
-      identifierType = DisplayIdentifierType(
-        id = "sierra-system-number",
-        label = "Sierra system number"
-      ),
+      identifierType = DisplayIdentifierType.SierraSystemNumber,
       value = sierraItemNumber.withCheckDigit
     )
 
@@ -343,10 +347,7 @@ class ItemUpdateServiceTest
 
   def createSierraSystemSourceIdentifier: DisplayIdentifier =
     DisplayIdentifier(
-      identifierType = DisplayIdentifierType(
-        id = "sierra-system-number",
-        label = "Sierra system number"
-      ),
+      identifierType = DisplayIdentifierType.SierraSystemNumber,
       value = randomAlphanumeric()
     )
 }

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -178,12 +178,15 @@ class ItemUpdateServiceTest
   it("maintains the order of items") {
     val itemUpdater = new DummyItemUpdater()
 
-    val orderedItems = (1 to 3).map(_ =>
-      DisplayItem(
-        id = Some(randomCanonicalId),
-        identifiers = List(createSierraSystemSourceIdentifier)
+    val orderedItems = (1 to 3)
+      .map(
+        _ =>
+          DisplayItem(
+            id = Some(randomCanonicalId),
+            identifiers = List(createSierraSystemSourceIdentifier)
+          )
       )
-    ).toList
+      .toList
 
     val reversedItems = orderedItems.reverse
 
@@ -221,12 +224,15 @@ class ItemUpdateServiceTest
       id = randomCanonicalId,
       title = None,
       identifiers = Nil,
-      items = (1 to 3).map(_ =>
-        DisplayItem(
-          id = Some(randomCanonicalId),
-          identifiers = List(createSierraSystemSourceIdentifier)
+      items = (1 to 3)
+        .map(
+          _ =>
+            DisplayItem(
+              id = Some(randomCanonicalId),
+              identifiers = List(createSierraSystemSourceIdentifier)
+            )
         )
-      ).toList
+        .toList
     )
 
     withItemUpdateService(itemUpdaters = List(brokenItemUpdater)) {

--- a/items/src/test/scala/weco/api/items/services/WorkLookupTest.scala
+++ b/items/src/test/scala/weco/api/items/services/WorkLookupTest.scala
@@ -12,7 +12,10 @@ import weco.api.stacks.models.{
   CatalogueAccessStatus,
   CatalogueWork
 }
-import weco.catalogue.display_model.identifiers.DisplayIdentifier
+import weco.catalogue.display_model.identifiers.{
+  DisplayIdentifier,
+  DisplayIdentifierType
+}
 import weco.catalogue.display_model.locations.{
   DisplayAccessCondition,
   DisplayLocationType,
@@ -20,10 +23,6 @@ import weco.catalogue.display_model.locations.{
 }
 import weco.catalogue.display_model.work.DisplayItem
 import weco.catalogue.internal_model.generators.IdentifiersGenerators
-import weco.catalogue.internal_model.identifiers.{
-  IdentifierType,
-  SourceIdentifier
-}
 import weco.fixtures.TestWith
 import weco.http.client.{HttpGet, MemoryHttpClient}
 
@@ -53,11 +52,15 @@ class WorkLookupTest
   it("returns a work with matching ID") {
     val canonicalId = createCanonicalId
     val title = "a test item"
-    val identifierType = IdentifierType.MiroImageNumber
+    val workIdentifierTypeId = "miro-image-number"
+    val workIdentifierTypeLabel = "Miro image number"
     val sourceIdentifier = randomAlphanumeric()
     val itemId = randomAlphanumeric()
     val itemNumber = "i52945510"
     val locationLabel = "where the item is"
+
+    val itemIdentifierTypeId = "sierra-system-number"
+    val itemIdentifierTypeLabel = "Sierra system number"
 
     // Note: this is deliberately a hard-coded JSON string rather than the
     // helpers we use in other tests so we can be sure we really can decode
@@ -76,8 +79,8 @@ class WorkLookupTest
               "identifiers": [
                 {
                   "identifierType": {
-                    "id": "${identifierType.id}",
-                    "label": "${identifierType.label}",
+                    "id": "$workIdentifierTypeId",
+                    "label": "$workIdentifierTypeLabel",
                     "type": "IdentifierType"
                   },
                   "value": "$sourceIdentifier",
@@ -90,8 +93,8 @@ class WorkLookupTest
                   "identifiers": [
                     {
                       "identifierType": {
-                        "id": "sierra-system-number",
-                        "label": "Sierra system number",
+                        "id": "$itemIdentifierTypeId",
+                        "label": "$itemIdentifierTypeLabel",
                         "type": "IdentifierType"
                       },
                       "value": "$itemNumber",
@@ -152,11 +155,11 @@ class WorkLookupTest
           title = Some(title),
           identifiers = List(
             DisplayIdentifier(
-              sourceIdentifier = SourceIdentifier(
-                identifierType = identifierType,
-                value = sourceIdentifier,
-                ontologyType = "Work"
-              )
+              identifierType = DisplayIdentifierType(
+                id = workIdentifierTypeId,
+                label = workIdentifierTypeLabel
+              ),
+              value = sourceIdentifier
             )
           ),
           items = List(
@@ -164,11 +167,11 @@ class WorkLookupTest
               id = Some(itemId),
               identifiers = List(
                 DisplayIdentifier(
-                  sourceIdentifier = SourceIdentifier(
-                    identifierType = IdentifierType.SierraSystemNumber,
-                    value = itemNumber,
-                    ontologyType = "Item"
-                  )
+                  identifierType = DisplayIdentifierType(
+                    id = itemIdentifierTypeId,
+                    label = itemIdentifierTypeLabel
+                  ),
+                  value = itemNumber
                 )
               ),
               locations = List(

--- a/requests/src/main/scala/weco/api/requests/services/ItemLookup.scala
+++ b/requests/src/main/scala/weco/api/requests/services/ItemLookup.scala
@@ -8,8 +8,9 @@ import grizzled.slf4j.Logging
 import weco.api.requests.models.RequestedItemWithWork
 import weco.api.stacks.models.{CatalogueWork, DisplayItemOps}
 import weco.catalogue.display_model.Implicits._
+import weco.catalogue.display_model.identifiers.DisplayIdentifier
 import weco.catalogue.display_model.work.DisplayItem
-import weco.catalogue.internal_model.identifiers.{CanonicalId, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.http.client.{HttpClient, HttpGet}
 import weco.http.json.CirceMarshalling
 import weco.json.JsonUtil._
@@ -102,7 +103,7 @@ class ItemLookup(client: HttpClient with HttpGet)(
     *
     */
   def bySourceIdentifier(
-    itemIdentifiers: Seq[SourceIdentifier]
+    itemIdentifiers: Seq[DisplayIdentifier]
   ): Future[Seq[Either[ItemLookupError, RequestedItemWithWork]]] =
     itemIdentifiers match {
       // If there are no identifiers, return the result immediately.  This is quite
@@ -113,7 +114,7 @@ class ItemLookup(client: HttpClient with HttpGet)(
     }
 
   private def searchBySourceIdentifier(
-    itemIdentifiers: Seq[SourceIdentifier]
+    itemIdentifiers: Seq[DisplayIdentifier]
   ): Future[Seq[Either[ItemLookupError, RequestedItemWithWork]]] = {
     require(itemIdentifiers.nonEmpty)
 

--- a/requests/src/main/scala/weco/api/requests/services/RequestsService.scala
+++ b/requests/src/main/scala/weco/api/requests/services/RequestsService.scala
@@ -2,7 +2,11 @@ package weco.api.requests.services
 
 import grizzled.slf4j.Logging
 import weco.api.requests.models.HoldRejected.SourceSystemNotSupported
-import weco.api.requests.models.{HoldAccepted, HoldRejected, RequestedItemWithWork}
+import weco.api.requests.models.{
+  HoldAccepted,
+  HoldRejected,
+  RequestedItemWithWork
+}
 import weco.api.stacks.models.DisplayItemOps
 import weco.catalogue.display_model.Implicits._
 import weco.catalogue.display_model.identifiers.DisplayIdentifier

--- a/requests/src/main/scala/weco/api/requests/services/RequestsService.scala
+++ b/requests/src/main/scala/weco/api/requests/services/RequestsService.scala
@@ -1,20 +1,12 @@
 package weco.api.requests.services
 
 import grizzled.slf4j.Logging
-import weco.api.requests.models.{
-  HoldAccepted,
-  HoldRejected,
-  RequestedItemWithWork
-}
 import weco.api.requests.models.HoldRejected.SourceSystemNotSupported
+import weco.api.requests.models.{HoldAccepted, HoldRejected, RequestedItemWithWork}
 import weco.api.stacks.models.DisplayItemOps
-import weco.catalogue.display_model.identifiers.DisplayIdentifier
 import weco.catalogue.display_model.Implicits._
-import weco.catalogue.internal_model.identifiers.{
-  CanonicalId,
-  IdentifierType,
-  SourceIdentifier
-}
+import weco.catalogue.display_model.identifiers.DisplayIdentifier
+import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.catalogue.internal_model.identifiers.IdentifierType.SierraSystemNumber
 import weco.sierra.models.fields.SierraHold
 import weco.sierra.models.identifiers.SierraPatronNumber
@@ -90,13 +82,7 @@ class RequestsService(
 
         val itemId = identifiers.head
 
-        val sierraId = SourceIdentifier(
-          identifierType = IdentifierType(itemId.identifierType.id),
-          value = itemId.value,
-          ontologyType = "Item"
-        )
-
-        holdsMap.get(sierraId).map { hold =>
+        holdsMap.get(itemId).map { hold =>
           (hold, itemLookup)
         }
       }

--- a/requests/src/main/scala/weco/api/requests/services/SierraRequestsService.scala
+++ b/requests/src/main/scala/weco/api/requests/services/SierraRequestsService.scala
@@ -5,11 +5,7 @@ import grizzled.slf4j.Logging
 import weco.api.requests.models.{HoldAccepted, HoldNote, HoldRejected}
 import weco.api.stacks.models.{DisplayItemOps, SierraItemIdentifier}
 import weco.catalogue.display_model.identifiers.DisplayIdentifier
-import weco.catalogue.display_model.locations.{
-  DisplayAccessCondition,
-  DisplayLocationType
-}
-import weco.catalogue.internal_model.identifiers.SourceIdentifier
+import weco.catalogue.display_model.locations.{DisplayAccessCondition, DisplayLocationType}
 import weco.http.client.{HttpClient, HttpGet, HttpPost}
 import weco.sierra.http.SierraSource
 import weco.sierra.models.data.SierraItemData
@@ -263,7 +259,7 @@ class SierraRequestsService(
 
   def getHolds(
     patronNumber: SierraPatronNumber
-  ): Future[Map[SourceIdentifier, SierraHold]] =
+  ): Future[Map[DisplayIdentifier, SierraHold]] =
     for {
       holds <- sierraSource
         .listHolds(patronNumber)

--- a/requests/src/main/scala/weco/api/requests/services/SierraRequestsService.scala
+++ b/requests/src/main/scala/weco/api/requests/services/SierraRequestsService.scala
@@ -5,7 +5,10 @@ import grizzled.slf4j.Logging
 import weco.api.requests.models.{HoldAccepted, HoldNote, HoldRejected}
 import weco.api.stacks.models.{DisplayItemOps, SierraItemIdentifier}
 import weco.catalogue.display_model.identifiers.DisplayIdentifier
-import weco.catalogue.display_model.locations.{DisplayAccessCondition, DisplayLocationType}
+import weco.catalogue.display_model.locations.{
+  DisplayAccessCondition,
+  DisplayLocationType
+}
 import weco.http.client.{HttpClient, HttpGet, HttpPost}
 import weco.sierra.http.SierraSource
 import weco.sierra.models.data.SierraItemData

--- a/requests/src/test/scala/weco/api/requests/fixtures/ItemLookupFixture.scala
+++ b/requests/src/test/scala/weco/api/requests/fixtures/ItemLookupFixture.scala
@@ -3,7 +3,8 @@ package weco.api.requests.fixtures
 import akka.http.scaladsl.model._
 import weco.akka.fixtures.Akka
 import weco.api.requests.services.ItemLookup
-import weco.catalogue.internal_model.identifiers.{CanonicalId, SourceIdentifier}
+import weco.catalogue.display_model.identifiers.DisplayIdentifier
+import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.fixtures.TestWith
 import weco.http.client.{HttpGet, HttpPost, MemoryHttpClient}
 import weco.http.fixtures.HttpFixtures
@@ -36,6 +37,6 @@ trait ItemLookupFixture extends Akka with HttpFixtures {
       )
     )
 
-  def catalogueSourceIdsRequest(ids: SourceIdentifier*): HttpRequest =
+  def catalogueSourceIdsRequest(ids: DisplayIdentifier*): HttpRequest =
     catalogueItemsRequest(ids.map(_.value): _*)
 }

--- a/requests/src/test/scala/weco/api/requests/services/ItemLookupTest.scala
+++ b/requests/src/test/scala/weco/api/requests/services/ItemLookupTest.scala
@@ -9,10 +9,10 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.api.requests.fixtures.ItemLookupFixture
 import weco.api.requests.models.RequestedItemWithWork
-import weco.catalogue.display_model.identifiers.DisplayIdentifier
+import weco.catalogue.display_model.identifiers.{DisplayIdentifier, DisplayIdentifierType}
 import weco.catalogue.display_model.work.DisplayItem
-import weco.catalogue.internal_model.generators.IdentifiersGenerators
-import weco.catalogue.internal_model.identifiers.{CanonicalId, SourceIdentifier}
+import weco.catalogue.internal_model.identifiers.CanonicalId
+import weco.fixtures.RandomGenerators
 import weco.http.client.{HttpGet, MemoryHttpClient}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -22,10 +22,10 @@ class ItemLookupTest
     extends AnyFunSpec
     with Matchers
     with EitherValues
-    with IdentifiersGenerators
     with ScalaFutures
     with IntegrationPatience
-    with ItemLookupFixture {
+    with ItemLookupFixture
+    with RandomGenerators {
 
   describe("byCanonicalId") {
     it("finds a work with the same item ID") {
@@ -61,7 +61,6 @@ class ItemLookupTest
               DisplayItem(
                 id = Some(item.id.underlying),
                 identifiers = (item.sourceIdentifier +: item.otherIdentifiers)
-                  .map(DisplayIdentifier(_))
                   .toList,
                 locations = List()
               )
@@ -401,11 +400,23 @@ class ItemLookupTest
     }
   }
 
+  private def createSourceIdentifier: DisplayIdentifier =
+    DisplayIdentifier(
+      identifierType = DisplayIdentifierType(
+        id = "miro-image-number",
+        label = "Miro image number"
+      ),
+    value = randomAlphanumeric(length = 10),
+    )
+
+  private def createCanonicalId: CanonicalId =
+    CanonicalId(randomAlphanumeric(length = 8))
+
   sealed trait ItemStub
   case class IdentifiedItemStub(
     id: CanonicalId = createCanonicalId,
-    sourceIdentifier: SourceIdentifier = createSourceIdentifier,
-    otherIdentifiers: Seq[SourceIdentifier] = List()
+    sourceIdentifier: DisplayIdentifier = createSourceIdentifier,
+    otherIdentifiers: Seq[DisplayIdentifier] = List()
   ) extends ItemStub
   case class UnidentifiedItemStub() extends ItemStub
 

--- a/requests/src/test/scala/weco/api/requests/services/ItemLookupTest.scala
+++ b/requests/src/test/scala/weco/api/requests/services/ItemLookupTest.scala
@@ -9,7 +9,10 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.api.requests.fixtures.ItemLookupFixture
 import weco.api.requests.models.RequestedItemWithWork
-import weco.catalogue.display_model.identifiers.{DisplayIdentifier, DisplayIdentifierType}
+import weco.catalogue.display_model.identifiers.{
+  DisplayIdentifier,
+  DisplayIdentifierType
+}
 import weco.catalogue.display_model.work.DisplayItem
 import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.fixtures.RandomGenerators
@@ -60,8 +63,8 @@ class ItemLookupTest
             _ shouldBe Right(
               DisplayItem(
                 id = Some(item.id.underlying),
-                identifiers = (item.sourceIdentifier +: item.otherIdentifiers)
-                  .toList,
+                identifiers =
+                  (item.sourceIdentifier +: item.otherIdentifiers).toList,
                 locations = List()
               )
             )
@@ -406,7 +409,7 @@ class ItemLookupTest
         id = "miro-image-number",
         label = "Miro image number"
       ),
-    value = randomAlphanumeric(length = 10),
+      value = randomAlphanumeric(length = 10)
     )
 
   private def createCanonicalId: CanonicalId =

--- a/requests/src/test/scala/weco/api/requests/services/SierraRequestsServiceTest.scala
+++ b/requests/src/test/scala/weco/api/requests/services/SierraRequestsServiceTest.scala
@@ -16,8 +16,6 @@ import weco.catalogue.display_model.locations.{
   DisplayAccessMethod,
   DisplayAccessStatus
 }
-import weco.catalogue.internal_model.identifiers.IdentifierType.SierraSystemNumber
-import weco.catalogue.internal_model.identifiers.SourceIdentifier
 import weco.sierra.generators.SierraIdentifierGenerators
 import weco.sierra.models.fields.{SierraHold, SierraHoldStatus, SierraLocation}
 import weco.sierra.models.identifiers.SierraPatronNumber
@@ -79,15 +77,13 @@ class SierraRequestsServiceTest
           val future = service.getHolds(patron)
 
           whenReady(future) { result =>
-            val item1SrcId = SourceIdentifier(
-              identifierType = SierraSystemNumber,
-              ontologyType = "Item",
+            val item1SrcId = DisplayIdentifier(
+              identifierType = DisplayIdentifierType.SierraSystemNumber,
               value = item1.withCheckDigit
             )
 
-            val item2SrcId = SourceIdentifier(
-              identifierType = SierraSystemNumber,
-              ontologyType = "Item",
+            val item2SrcId = DisplayIdentifier(
+              identifierType = DisplayIdentifierType.SierraSystemNumber,
               value = item2.withCheckDigit
             )
 
@@ -202,9 +198,8 @@ class SierraRequestsServiceTest
           val future = service.getHolds(patron)
 
           whenReady(future) { result =>
-            val itemSrcId = SourceIdentifier(
-              identifierType = SierraSystemNumber,
-              ontologyType = "Item",
+            val itemSrcId = DisplayIdentifier(
+              identifierType = DisplayIdentifierType.SierraSystemNumber,
               value = item.withCheckDigit
             )
 
@@ -235,10 +230,7 @@ class SierraRequestsServiceTest
         val pickupDate = LocalDate.parse(pickupDateString)
 
         val sourceIdentifier = DisplayIdentifier(
-          identifierType = DisplayIdentifierType(
-            id = "sierra-system-number",
-            label = "Sierra system number"
-          ),
+          identifierType = DisplayIdentifierType.SierraSystemNumber,
           value = item.withCheckDigit
         )
 
@@ -269,10 +261,7 @@ class SierraRequestsServiceTest
         val pickupDate = LocalDate.parse(pickupDateString)
 
         val sourceIdentifier = DisplayIdentifier(
-          identifierType = DisplayIdentifierType(
-            id = "sierra-system-number",
-            label = "Sierra system number"
-          ),
+          identifierType = DisplayIdentifierType.SierraSystemNumber,
           value = itemNumber.withCheckDigit
         )
 
@@ -377,10 +366,7 @@ class SierraRequestsServiceTest
         val pickupDate = LocalDate.parse(pickupDateString)
 
         val sourceIdentifier = DisplayIdentifier(
-          identifierType = DisplayIdentifierType(
-            id = "sierra-system-number",
-            label = "Sierra system number"
-          ),
+          identifierType = DisplayIdentifierType.SierraSystemNumber,
           value = item.withCheckDigit
         )
 

--- a/requests/src/test/scala/weco/api/requests/services/SierraRequestsServiceTest.scala
+++ b/requests/src/test/scala/weco/api/requests/services/SierraRequestsServiceTest.scala
@@ -1,6 +1,5 @@
 package weco.api.requests.services
 
-import java.net.URI
 import akka.http.scaladsl.model._
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
@@ -8,7 +7,10 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.api.requests.fixtures.SierraServiceFixture
 import weco.api.requests.models.{HoldAccepted, HoldRejected}
-import weco.catalogue.display_model.identifiers.DisplayIdentifier
+import weco.catalogue.display_model.identifiers.{
+  DisplayIdentifier,
+  DisplayIdentifierType
+}
 import weco.catalogue.display_model.locations.{
   DisplayAccessCondition,
   DisplayAccessMethod,
@@ -20,6 +22,7 @@ import weco.sierra.generators.SierraIdentifierGenerators
 import weco.sierra.models.fields.{SierraHold, SierraHoldStatus, SierraLocation}
 import weco.sierra.models.identifiers.SierraPatronNumber
 
+import java.net.URI
 import java.time.LocalDate
 
 class SierraRequestsServiceTest
@@ -231,9 +234,11 @@ class SierraRequestsServiceTest
         val pickupDateString = "2022-02-18"
         val pickupDate = LocalDate.parse(pickupDateString)
 
-        val sourceIdentifier = SourceIdentifier(
-          identifierType = SierraSystemNumber,
-          ontologyType = "Item",
+        val sourceIdentifier = DisplayIdentifier(
+          identifierType = DisplayIdentifierType(
+            id = "sierra-system-number",
+            label = "Sierra system number"
+          ),
           value = item.withCheckDigit
         )
 
@@ -247,7 +252,7 @@ class SierraRequestsServiceTest
         val future = withSierraService(responses) {
           _.placeHold(
             patron = patron,
-            sourceIdentifier = DisplayIdentifier(sourceIdentifier),
+            sourceIdentifier = sourceIdentifier,
             pickupDate = Some(pickupDate)
           )
         }
@@ -262,9 +267,12 @@ class SierraRequestsServiceTest
         val itemNumber = createSierraItemNumber
         val pickupDateString = "2022-02-18"
         val pickupDate = LocalDate.parse(pickupDateString)
-        val sourceIdentifier = SourceIdentifier(
-          identifierType = SierraSystemNumber,
-          ontologyType = "Item",
+
+        val sourceIdentifier = DisplayIdentifier(
+          identifierType = DisplayIdentifierType(
+            id = "sierra-system-number",
+            label = "Sierra system number"
+          ),
           value = itemNumber.withCheckDigit
         )
 
@@ -350,7 +358,7 @@ class SierraRequestsServiceTest
         val future = withSierraService(responses) {
           _.placeHold(
             patron = patron,
-            sourceIdentifier = DisplayIdentifier(sourceIdentifier),
+            sourceIdentifier = sourceIdentifier,
             pickupDate = Some(pickupDate)
           )
         }
@@ -368,9 +376,11 @@ class SierraRequestsServiceTest
         val pickupDateString = "2022-02-18"
         val pickupDate = LocalDate.parse(pickupDateString)
 
-        val sourceIdentifier = SourceIdentifier(
-          identifierType = SierraSystemNumber,
-          ontologyType = "Item",
+        val sourceIdentifier = DisplayIdentifier(
+          identifierType = DisplayIdentifierType(
+            id = "sierra-system-number",
+            label = "Sierra system number"
+          ),
           value = item.withCheckDigit
         )
 
@@ -409,7 +419,7 @@ class SierraRequestsServiceTest
         val future = withSierraService(responses) {
           _.placeHold(
             patron = patron,
-            sourceIdentifier = DisplayIdentifier(sourceIdentifier),
+            sourceIdentifier = sourceIdentifier,
             pickupDate = Some(pickupDate),
             accessCondition = Some(
               DisplayAccessCondition(


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5530; follows #462

These two models are extremely similar so this is a pretty simple drop-in replacement that reduces the coupling between this repo and internal model.