### PR TITLE
Remove the use of the dedicated CanonicalId type

### DIFF
--- a/common/display/src/main/scala/weco/catalogue/display_model/rest/IdentifierDirectives.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/rest/IdentifierDirectives.scala
@@ -1,0 +1,13 @@
+package weco.catalogue.display_model.rest
+
+trait IdentifierDirectives {
+
+  /** Returns true if an ID looks like a canonical ID; false otherwise.
+    *
+    * This is a weak heuristic that lets us reject requests that are for something
+    * that obviously isn't a canonical ID (e.g. empty strings, JavaScript injections).
+    *
+    */
+  def looksLikeCanonicalId(id: String): Boolean =
+    id.matches("""^[a-z0-9]+$""")
+}

--- a/common/display/src/test/scala/weco/catalogue/display_model/generators/IdentifiersGenerators.scala
+++ b/common/display/src/test/scala/weco/catalogue/display_model/generators/IdentifiersGenerators.scala
@@ -1,0 +1,8 @@
+package weco.catalogue.display_model.generators
+
+import weco.fixtures.RandomGenerators
+
+trait IdentifiersGenerators extends RandomGenerators {
+  def createCanonicalId: String =
+    randomAlphanumeric(length = 8).toLowerCase
+}

--- a/common/display/src/test/scala/weco/catalogue/display_model/generators/IdentifiersGenerators.scala
+++ b/common/display/src/test/scala/weco/catalogue/display_model/generators/IdentifiersGenerators.scala
@@ -3,6 +3,16 @@ package weco.catalogue.display_model.generators
 import weco.fixtures.RandomGenerators
 
 trait IdentifiersGenerators extends RandomGenerators {
+
+  /** Create something that looks plausibly like a canonical ID.
+    *
+    * The APIs have loose heuristics to filter out values that obviously
+    * aren't canonical IDs (e.g. JavaScript injection attacks); one of those
+    * includes checking the canonical ID is lowercase.
+    *
+    * Tests should prefer to use this helper over calling randomAlphanumeric()
+    * directly.
+    */
   def createCanonicalId: String =
     randomAlphanumeric(length = 8).toLowerCase
 }

--- a/items/src/main/scala/weco/api/items/responses/LookupItemStatus.scala
+++ b/items/src/main/scala/weco/api/items/responses/LookupItemStatus.scala
@@ -5,7 +5,6 @@ import akka.http.scaladsl.server.Route
 import weco.api.items.models.DisplayItemsList
 import weco.api.items.services._
 import weco.api.stacks.models.CatalogueWork
-import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.http.ErrorDirectives
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -19,7 +18,7 @@ trait LookupItemStatus extends ErrorDirectives {
 
   val workLookup: WorkLookup
 
-  def lookupStatus(workId: CanonicalId): Future[Route] =
+  def lookupStatus(workId: String): Future[Route] =
     workLookup.byCanonicalId(workId).flatMap {
       case Right(work: CatalogueWork) =>
         itemUpdateService

--- a/items/src/main/scala/weco/api/items/services/WorkLookup.scala
+++ b/items/src/main/scala/weco/api/items/services/WorkLookup.scala
@@ -19,8 +19,7 @@ sealed trait WorkLookupError {
 
 case class WorkNotFoundError(id: String) extends WorkLookupError
 case class WorkGoneError(id: String) extends WorkLookupError
-case class UnknownWorkError(id: String, err: Throwable)
-    extends WorkLookupError
+case class UnknownWorkError(id: String, err: Throwable) extends WorkLookupError
 
 class WorkLookup(client: HttpClient with HttpGet)(
   implicit as: ActorSystem,

--- a/items/src/main/scala/weco/api/items/services/WorkLookup.scala
+++ b/items/src/main/scala/weco/api/items/services/WorkLookup.scala
@@ -6,7 +6,6 @@ import akka.http.scaladsl.model.{HttpEntity, StatusCodes}
 import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 import grizzled.slf4j.Logging
 import weco.api.stacks.models.CatalogueWork
-import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.http.client.{HttpClient, HttpGet}
 import weco.http.json.CirceMarshalling
 import weco.catalogue.display_model.Implicits._
@@ -14,11 +13,13 @@ import weco.json.JsonUtil._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-sealed trait WorkLookupError
+sealed trait WorkLookupError {
+  val id: String
+}
 
-case class WorkNotFoundError(id: CanonicalId) extends WorkLookupError
-case class WorkGoneError(id: CanonicalId) extends WorkLookupError
-case class UnknownWorkError(id: CanonicalId, err: Throwable)
+case class WorkNotFoundError(id: String) extends WorkLookupError
+case class WorkGoneError(id: String) extends WorkLookupError
+case class UnknownWorkError(id: String, err: Throwable)
     extends WorkLookupError
 
 class WorkLookup(client: HttpClient with HttpGet)(
@@ -33,7 +34,7 @@ class WorkLookup(client: HttpClient with HttpGet)(
     *
     */
   def byCanonicalId(
-    id: CanonicalId
+    id: String
   ): Future[Either[WorkLookupError, CatalogueWork]] = {
     val path = Path(s"works/$id")
     val params = Map("include" -> "identifiers,items")

--- a/items/src/test/scala/weco/api/items/ItemsApiFeatureTest.scala
+++ b/items/src/test/scala/weco/api/items/ItemsApiFeatureTest.scala
@@ -6,12 +6,9 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.api.items.fixtures.{ItemsApiFixture, ItemsApiGenerators}
 import weco.catalogue.display_model.generators.IdentifiersGenerators
-import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.json.utils.JsonAssertions
 import weco.sierra.generators.SierraIdentifierGenerators
 import weco.sierra.models.identifiers.SierraItemNumber
-
-import scala.util.{Failure, Try}
 
 class ItemsApiFeatureTest
     extends AnyFunSpec
@@ -179,10 +176,7 @@ class ItemsApiFeatureTest
     }
 
     it("returns a 404 if the ID is not a valid canonical ID") {
-      val id = randomAlphanumeric(length = 10)
-      Try {
-        CanonicalId(id)
-      } shouldBe a[Failure[_]]
+      val id = "<script>alert('boo!');"
 
       val catalogueResponses = Seq(
         (

--- a/items/src/test/scala/weco/api/items/ItemsApiFeatureTest.scala
+++ b/items/src/test/scala/weco/api/items/ItemsApiFeatureTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.api.items.fixtures.{ItemsApiFixture, ItemsApiGenerators}
-import weco.catalogue.internal_model.generators.IdentifiersGenerators
+import weco.catalogue.display_model.generators.IdentifiersGenerators
 import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.json.utils.JsonAssertions
 import weco.sierra.generators.SierraIdentifierGenerators
@@ -26,8 +26,8 @@ class ItemsApiFeatureTest
   describe("look up the status of an item") {
     it("shows a user the items on a work") {
       val resourceName = "work-with-temporarily-unavailable-item.json"
-      val workId = CanonicalId("eccsqg7j")
-      val itemId = CanonicalId("otdlfo0u")
+      val workId = "eccsqg7j"
+      val itemId = "otdlfo0u"
       val sierraItemNumber = SierraItemNumber("1024083")
 
       val catalogueResponses = Seq(
@@ -113,7 +113,7 @@ class ItemsApiFeatureTest
 
     it("returns an empty list if a work has no items") {
       val resourceName = "work-with-no-items.json"
-      val workId = CanonicalId("eccsqg7j")
+      val workId = "eccsqg7j"
 
       val catalogueResponses = Seq(
         (

--- a/items/src/test/scala/weco/api/items/fixtures/ItemsApiGenerators.scala
+++ b/items/src/test/scala/weco/api/items/fixtures/ItemsApiGenerators.scala
@@ -1,7 +1,6 @@
 package weco.api.items.fixtures
 
 import akka.http.scaladsl.model._
-import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.fixtures.LocalResources
 import weco.http.json.DisplayJsonUtil
 import weco.http.models.DisplayError
@@ -63,7 +62,7 @@ trait ItemsApiGenerators extends LocalResources {
     )
   }
 
-  def catalogueWorkRequest(id: CanonicalId): HttpRequest =
+  def catalogueWorkRequest(id: String): HttpRequest =
     HttpRequest(
       uri = Uri(s"http://catalogue:9001/works/$id?include=identifiers,items")
     )

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -8,7 +8,10 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 import weco.api.items.fixtures.ItemsApiGenerators
 import weco.api.stacks.models.{CatalogueAccessMethod, CatalogueWork}
 import weco.catalogue.display_model.generators.IdentifiersGenerators
-import weco.catalogue.display_model.identifiers.{DisplayIdentifier, DisplayIdentifierType}
+import weco.catalogue.display_model.identifiers.{
+  DisplayIdentifier,
+  DisplayIdentifierType
+}
 import weco.catalogue.display_model.locations._
 import weco.catalogue.display_model.work.DisplayItem
 import weco.fixtures.TestWith

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -7,13 +7,11 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import weco.api.items.fixtures.ItemsApiGenerators
 import weco.api.stacks.models.{CatalogueAccessMethod, CatalogueWork}
-import weco.catalogue.display_model.identifiers.{
-  DisplayIdentifier,
-  DisplayIdentifierType
-}
+import weco.catalogue.display_model.generators.IdentifiersGenerators
+import weco.catalogue.display_model.identifiers.{DisplayIdentifier, DisplayIdentifierType}
 import weco.catalogue.display_model.locations._
 import weco.catalogue.display_model.work.DisplayItem
-import weco.fixtures.{RandomGenerators, TestWith}
+import weco.fixtures.TestWith
 import weco.json.utils.JsonAssertions
 import weco.sierra.fixtures.SierraSourceFixture
 import weco.sierra.generators.SierraIdentifierGenerators
@@ -27,8 +25,8 @@ class ItemUpdateServiceTest
     with Matchers
     with JsonAssertions
     with ItemsApiGenerators
-    with RandomGenerators
     with SierraSourceFixture
+    with IdentifiersGenerators
     with SierraIdentifierGenerators
     with IntegrationPatience {
 
@@ -167,9 +165,6 @@ class ItemUpdateServiceTest
     }
   }
 
-  def randomCanonicalId: String =
-    randomAlphanumeric()
-
   it("maintains the order of items") {
     val itemUpdater = new DummyItemUpdater()
 
@@ -177,7 +172,7 @@ class ItemUpdateServiceTest
       .map(
         _ =>
           DisplayItem(
-            id = Some(randomCanonicalId),
+            id = Some(createCanonicalId),
             identifiers = List(createSierraSystemSourceIdentifier)
           )
       )
@@ -186,14 +181,14 @@ class ItemUpdateServiceTest
     val reversedItems = orderedItems.reverse
 
     val workWithItemsForward = CatalogueWork(
-      id = randomCanonicalId,
+      id = createCanonicalId,
       title = None,
       identifiers = Nil,
       items = orderedItems
     )
 
     val workWithItemsBackward = CatalogueWork(
-      id = randomCanonicalId,
+      id = createCanonicalId,
       title = None,
       identifiers = Nil,
       items = orderedItems.reverse
@@ -216,14 +211,14 @@ class ItemUpdateServiceTest
     val brokenItemUpdater = new DummyItemUpdater(badUpdate)
 
     val workWithItems = CatalogueWork(
-      id = randomCanonicalId,
+      id = createCanonicalId,
       title = None,
       identifiers = Nil,
       items = (1 to 3)
         .map(
           _ =>
             DisplayItem(
-              id = Some(randomCanonicalId),
+              id = Some(createCanonicalId),
               identifiers = List(createSierraSystemSourceIdentifier)
             )
         )
@@ -247,7 +242,7 @@ class ItemUpdateServiceTest
     val workWithAvailableItemNumber = createSierraItemNumber
 
     val workWithUnavailableItem = CatalogueWork(
-      id = randomCanonicalId,
+      id = createCanonicalId,
       title = None,
       identifiers = Nil,
       items = List(
@@ -257,7 +252,7 @@ class ItemUpdateServiceTest
     )
 
     val workWithAvailableItem = CatalogueWork(
-      id = randomCanonicalId,
+      id = createCanonicalId,
       title = None,
       identifiers = Nil,
       items = List(
@@ -340,7 +335,7 @@ class ItemUpdateServiceTest
     )
 
     DisplayItem(
-      id = Some(randomAlphanumeric(length = 8)),
+      id = Some(createCanonicalId),
       identifiers = List(itemSourceIdentifier),
       locations = List(physicalItemLocation)
     )

--- a/items/src/test/scala/weco/api/items/services/WorkLookupTest.scala
+++ b/items/src/test/scala/weco/api/items/services/WorkLookupTest.scala
@@ -52,7 +52,7 @@ class WorkLookupTest
     val workIdentifierTypeId = "miro-image-number"
     val workIdentifierTypeLabel = "Miro image number"
     val sourceIdentifier = randomAlphanumeric()
-    val itemId = randomAlphanumeric()
+    val itemId = createCanonicalId
     val itemNumber = "i52945510"
     val locationLabel = "where the item is"
 

--- a/items/src/test/scala/weco/api/items/services/WorkLookupTest.scala
+++ b/items/src/test/scala/weco/api/items/services/WorkLookupTest.scala
@@ -19,7 +19,7 @@ import weco.catalogue.display_model.locations.{
   DisplayPhysicalLocation
 }
 import weco.catalogue.display_model.work.DisplayItem
-import weco.catalogue.internal_model.generators.IdentifiersGenerators
+import weco.catalogue.display_model.generators.IdentifiersGenerators
 import weco.fixtures.TestWith
 import weco.http.client.{HttpGet, MemoryHttpClient}
 
@@ -148,7 +148,7 @@ class WorkLookupTest
     whenReady(future) {
       _ shouldBe Right(
         CatalogueWork(
-          id = canonicalId.underlying,
+          id = canonicalId,
           title = Some(title),
           identifiers = List(
             DisplayIdentifier(

--- a/requests/src/main/scala/weco/api/requests/models/RequestedItemWithWork.scala
+++ b/requests/src/main/scala/weco/api/requests/models/RequestedItemWithWork.scala
@@ -2,20 +2,19 @@ package weco.api.requests.models
 
 import io.circe.Json
 import io.circe.parser._
-import weco.catalogue.display_model.work.DisplayItem
-import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.catalogue.display_model.Implicits._
+import weco.catalogue.display_model.work.DisplayItem
 import weco.http.json.DisplayJsonUtil
 
 case class RequestedItemWithWork(
-  workId: CanonicalId,
+  workId: String,
   workTitle: Option[String],
   item: Json
 )
 
 case object RequestedItemWithWork {
   def apply(
-    workId: CanonicalId,
+    workId: String,
     workTitle: Option[String],
     item: DisplayItem
   ): RequestedItemWithWork =

--- a/requests/src/main/scala/weco/api/requests/models/display/DisplayResultsList.scala
+++ b/requests/src/main/scala/weco/api/requests/models/display/DisplayResultsList.scala
@@ -4,7 +4,6 @@ import io.circe.Json
 
 import java.time.LocalDate
 import weco.api.requests.models.{HoldNote, RequestedItemWithWork}
-import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.sierra.models.fields.SierraHold
 
 case class DisplayResultsList(
@@ -27,7 +26,7 @@ object DisplayResultsList {
 
 case class DisplayRequest(
   workTitle: Option[String],
-  workId: CanonicalId,
+  workId: String,
   item: Json,
   pickupDate: Option[LocalDate],
   pickupLocation: DisplayLocationDescription,

--- a/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
@@ -6,7 +6,6 @@ import grizzled.slf4j.Logging
 import weco.api.requests.models.HoldRejected
 import weco.api.requests.services.RequestsService
 import HoldRejected.SourceSystemNotSupported
-import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.http.ErrorDirectives
 import weco.http.models.DisplayError
 import weco.sierra.models.identifiers.SierraPatronNumber
@@ -19,7 +18,7 @@ trait CreateRequest extends ErrorDirectives with Logging {
   val requestsService: RequestsService
 
   def createRequest(
-    itemId: CanonicalId,
+    itemId: String,
     pickupDate: Option[LocalDate],
     patronNumber: SierraPatronNumber
   ): Future[Route] =
@@ -50,7 +49,7 @@ trait CreateRequest extends ErrorDirectives with Logging {
 
   private def handleError(
     reason: HoldRejected,
-    itemId: CanonicalId
+    itemId: String
   ): (StatusCode, Option[String]) =
     reason match {
       case HoldRejected.UserIsSelfRegistered =>

--- a/requests/src/main/scala/weco/api/requests/services/ItemLookup.scala
+++ b/requests/src/main/scala/weco/api/requests/services/ItemLookup.scala
@@ -10,7 +10,6 @@ import weco.api.stacks.models.{CatalogueWork, DisplayItemOps}
 import weco.catalogue.display_model.Implicits._
 import weco.catalogue.display_model.identifiers.DisplayIdentifier
 import weco.catalogue.display_model.work.DisplayItem
-import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.http.client.{HttpClient, HttpGet}
 import weco.http.json.CirceMarshalling
 import weco.json.JsonUtil._
@@ -40,12 +39,12 @@ class ItemLookup(client: HttpClient with HttpGet)(
 
   /** Returns the item for this canonical ID. */
   def byCanonicalId(
-    itemId: CanonicalId
+    itemId: String
   ): Future[Either[ItemLookupError, DisplayItem]] = {
     val path = Path("works")
     val params = Map(
       "include" -> "identifiers,items",
-      "items" -> itemId.underlying,
+      "items" -> itemId,
       "pageSize" -> "1"
     )
 
@@ -58,7 +57,7 @@ class ItemLookup(client: HttpClient with HttpGet)(
           Unmarshal(response.entity).to[CatalogueWorkResults].map { results =>
             val items = results.results.flatMap(_.items)
 
-            val matchingItem = items.find(_.id.contains(itemId.underlying))
+            val matchingItem = items.find(_.id.contains(itemId))
 
             matchingItem match {
               case Some(item) => Right(item)
@@ -157,7 +156,7 @@ class ItemLookup(client: HttpClient with HttpGet)(
                 case Some((work, item)) =>
                   Right(
                     RequestedItemWithWork(
-                      workId = CanonicalId(work.id),
+                      workId = work.id,
                       workTitle = work.title,
                       item = item
                     )

--- a/requests/src/main/scala/weco/api/requests/services/RequestsService.scala
+++ b/requests/src/main/scala/weco/api/requests/services/RequestsService.scala
@@ -13,7 +13,6 @@ import weco.catalogue.display_model.identifiers.{
   DisplayIdentifier,
   DisplayIdentifierType
 }
-import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.sierra.models.fields.SierraHold
 import weco.sierra.models.identifiers.SierraPatronNumber
 
@@ -28,7 +27,7 @@ class RequestsService(
     with DisplayItemOps {
 
   def makeRequest(
-    itemId: CanonicalId,
+    itemId: String,
     pickupDate: Option[LocalDate],
     patronNumber: SierraPatronNumber
   ): Future[Either[HoldRejected, HoldAccepted]] =

--- a/requests/src/test/scala/weco/api/requests/RequestingScenarioTest.scala
+++ b/requests/src/test/scala/weco/api/requests/RequestingScenarioTest.scala
@@ -14,8 +14,7 @@ import weco.api.requests.services.{
   RequestsService,
   SierraRequestsService
 }
-import weco.catalogue.internal_model.generators.IdentifiersGenerators
-import weco.catalogue.internal_model.identifiers.CanonicalId
+import weco.catalogue.display_model.generators.IdentifiersGenerators
 import weco.http.client.{HttpGet, HttpPost, MemoryHttpClient}
 import weco.sierra.generators.SierraIdentifierGenerators
 import weco.sierra.models.identifiers.SierraItemNumber
@@ -1428,7 +1427,7 @@ class RequestingScenarioTest
   }
 
   private def catalogueItemResponse(
-    itemId: CanonicalId,
+    itemId: String,
     itemNumber: SierraItemNumber
   ): HttpResponse =
     HttpResponse(

--- a/requests/src/test/scala/weco/api/requests/RequestsApiFeatureTest.scala
+++ b/requests/src/test/scala/weco/api/requests/RequestsApiFeatureTest.scala
@@ -16,8 +16,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.json.utils.JsonAssertions
 import weco.api.requests.fixtures.RequestsApiFixture
-import weco.catalogue.internal_model.generators.IdentifiersGenerators
-import weco.catalogue.internal_model.identifiers.CanonicalId
+import weco.catalogue.display_model.generators.IdentifiersGenerators
 import weco.sierra.generators.SierraIdentifierGenerators
 import weco.sierra.models.identifiers.SierraPatronNumber
 
@@ -64,11 +63,11 @@ class RequestsApiFeatureTest
       val itemNumber1 = createSierraItemNumber
       val itemNumber2 = createSierraItemNumber
 
-      val workId1 = CanonicalId(randomAlphanumeric(length = 8))
-      val workId2 = CanonicalId(randomAlphanumeric(length = 8))
+      val workId1 = createCanonicalId
+      val workId2 = createCanonicalId
 
-      val itemId1 = CanonicalId(randomAlphanumeric(length = 8))
-      val itemId2 = CanonicalId(randomAlphanumeric(length = 8))
+      val itemId1 = createCanonicalId
+      val itemId2 = createCanonicalId
 
       val workTitle1 = randomAlphanumeric()
       val workTitle2 = randomAlphanumeric()

--- a/requests/src/test/scala/weco/api/requests/fixtures/ItemLookupFixture.scala
+++ b/requests/src/test/scala/weco/api/requests/fixtures/ItemLookupFixture.scala
@@ -4,7 +4,6 @@ import akka.http.scaladsl.model._
 import weco.akka.fixtures.Akka
 import weco.api.requests.services.ItemLookup
 import weco.catalogue.display_model.identifiers.DisplayIdentifier
-import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.fixtures.TestWith
 import weco.http.client.{HttpGet, HttpPost, MemoryHttpClient}
 import weco.http.fixtures.HttpFixtures
@@ -23,7 +22,7 @@ trait ItemLookupFixture extends Akka with HttpFixtures {
       testWith(new ItemLookup(client))
     }
 
-  def catalogueItemRequest(id: CanonicalId): HttpRequest =
+  def catalogueItemRequest(id: String): HttpRequest =
     HttpRequest(
       uri = Uri(
         s"http://catalogue:9001/works?include=identifiers,items&items=$id&pageSize=1"

--- a/requests/src/test/scala/weco/api/requests/services/ItemLookupTest.scala
+++ b/requests/src/test/scala/weco/api/requests/services/ItemLookupTest.scala
@@ -9,12 +9,9 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.api.requests.fixtures.ItemLookupFixture
 import weco.api.requests.models.RequestedItemWithWork
-import weco.catalogue.display_model.identifiers.{
-  DisplayIdentifier,
-  DisplayIdentifierType
-}
+import weco.catalogue.display_model.generators.IdentifiersGenerators
+import weco.catalogue.display_model.identifiers.{DisplayIdentifier, DisplayIdentifierType}
 import weco.catalogue.display_model.work.DisplayItem
-import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.fixtures.RandomGenerators
 import weco.http.client.{HttpGet, MemoryHttpClient}
 
@@ -27,6 +24,7 @@ class ItemLookupTest
     with EitherValues
     with ScalaFutures
     with IntegrationPatience
+    with IdentifiersGenerators
     with ItemLookupFixture
     with RandomGenerators {
 
@@ -62,7 +60,7 @@ class ItemLookupTest
           whenReady(future) {
             _ shouldBe Right(
               DisplayItem(
-                id = Some(item.id.underlying),
+                id = Some(item.id),
                 identifiers =
                   (item.sourceIdentifier +: item.otherIdentifiers).toList,
                 locations = List()
@@ -412,19 +410,16 @@ class ItemLookupTest
       value = randomAlphanumeric(length = 10)
     )
 
-  private def createCanonicalId: CanonicalId =
-    CanonicalId(randomAlphanumeric(length = 8))
-
   sealed trait ItemStub
   case class IdentifiedItemStub(
-    id: CanonicalId = createCanonicalId,
+    id: String = createCanonicalId,
     sourceIdentifier: DisplayIdentifier = createSourceIdentifier,
     otherIdentifiers: Seq[DisplayIdentifier] = List()
   ) extends ItemStub
   case class UnidentifiedItemStub() extends ItemStub
 
   case class WorkStub(
-    id: CanonicalId = createCanonicalId,
+    id: String = createCanonicalId,
     items: Seq[ItemStub],
     sourceIdentifier: String = randomAlphanumeric(),
     title: Option[String] = Some(s"title-${randomAlphanumeric()}")

--- a/requests/src/test/scala/weco/api/requests/services/ItemLookupTest.scala
+++ b/requests/src/test/scala/weco/api/requests/services/ItemLookupTest.scala
@@ -10,7 +10,10 @@ import org.scalatest.matchers.should.Matchers
 import weco.api.requests.fixtures.ItemLookupFixture
 import weco.api.requests.models.RequestedItemWithWork
 import weco.catalogue.display_model.generators.IdentifiersGenerators
-import weco.catalogue.display_model.identifiers.{DisplayIdentifier, DisplayIdentifierType}
+import weco.catalogue.display_model.identifiers.{
+  DisplayIdentifier,
+  DisplayIdentifierType
+}
 import weco.catalogue.display_model.work.DisplayItem
 import weco.fixtures.RandomGenerators
 import weco.http.client.{HttpGet, MemoryHttpClient}

--- a/search/src/main/scala/weco/api/search/SearchApi.scala
+++ b/search/src/main/scala/weco/api/search/SearchApi.scala
@@ -1,9 +1,18 @@
 package weco.api.search
 
-import akka.http.scaladsl.server.{MalformedQueryParamRejection, RejectionHandler, Route, ValidationRejection}
+import akka.http.scaladsl.server.{
+  MalformedQueryParamRejection,
+  RejectionHandler,
+  Route,
+  ValidationRejection
+}
 import com.sksamuel.elastic4s.ElasticClient
 import com.sksamuel.elastic4s.ElasticDsl._
-import weco.api.search.elasticsearch.{ElasticsearchService, ImagesMultiMatcher, WorksMultiMatcher}
+import weco.api.search.elasticsearch.{
+  ElasticsearchService,
+  ImagesMultiMatcher,
+  WorksMultiMatcher
+}
 import weco.api.search.models._
 import weco.api.search.rest._
 import weco.catalogue.display_model.rest.IdentifierDirectives
@@ -16,7 +25,8 @@ class SearchApi(
   queryConfig: QueryConfig,
   implicit val apiConfig: ApiConfig
 )(implicit ec: ExecutionContext)
-    extends CustomDirectives with IdentifierDirectives {
+    extends CustomDirectives
+    with IdentifierDirectives {
 
   def routes: Route = handleRejections(rejectionHandler) {
     ignoreTrailingSlash {

--- a/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala
@@ -12,7 +12,6 @@ import com.sksamuel.elastic4s.{ElasticClient, Hit, Index, Response}
 import grizzled.slf4j.Logging
 import io.circe.Decoder
 import weco.Tracing
-import weco.catalogue.internal_model.identifiers.CanonicalId
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -22,12 +21,12 @@ class ElasticsearchService(elasticClient: ElasticClient)(
 ) extends Logging
     with Tracing {
 
-  def findById[T](id: CanonicalId)(
+  def findById[T](id: String)(
     index: Index
   )(implicit decoder: Decoder[T]): Future[Either[ElasticsearchError, T]] =
     for {
       response: Response[GetResponse] <- withActiveTrace(elasticClient.execute {
-        get(index, id.underlying)
+        get(index, id)
       })
 
       result = response.toEither match {

--- a/search/src/main/scala/weco/api/search/rest/ImagesController.scala
+++ b/search/src/main/scala/weco/api/search/rest/ImagesController.scala
@@ -12,7 +12,6 @@ import weco.api.search.models.request.{
 }
 import weco.api.search.models.{ApiConfig, QueryConfig, SimilarityMetric}
 import weco.api.search.services.ImagesService
-import weco.catalogue.internal_model.identifiers.CanonicalId
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -26,7 +25,7 @@ class ImagesController(
     with CatalogueJsonUtil
     with Tracing {
 
-  def singleImage(id: CanonicalId, params: SingleImageParams): Route =
+  def singleImage(id: String, params: SingleImageParams): Route =
     get {
       withFuture {
         transactFuture("GET /images/{imageId}") {
@@ -37,7 +36,7 @@ class ImagesController(
                 getSimilarityMetrics(params.include)
                   .traverse { metric =>
                     imagesService
-                      .retrieveSimilarImages(imagesIndex, id.underlying, metric)
+                      .retrieveSimilarImages(imagesIndex, id, metric)
                       .map(metric -> _)
                   }
                   .map(_.toMap)

--- a/search/src/main/scala/weco/api/search/rest/WorksController.scala
+++ b/search/src/main/scala/weco/api/search/rest/WorksController.scala
@@ -8,7 +8,6 @@ import weco.api.search.json.CatalogueJsonUtil
 import weco.api.search.models.ApiConfig
 import weco.api.search.models.request.WorksIncludes
 import weco.api.search.services.WorksService
-import weco.catalogue.internal_model.identifiers.CanonicalId
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -48,7 +47,7 @@ class WorksController(
       }
     }
 
-  def singleWork(id: CanonicalId, params: SingleWorkParams): Route =
+  def singleWork(id: String, params: SingleWorkParams): Route =
     get {
       withFuture {
         transactFuture("GET /works/{workId}") {

--- a/search/src/main/scala/weco/api/search/services/SearchService.scala
+++ b/search/src/main/scala/weco/api/search/services/SearchService.scala
@@ -8,7 +8,6 @@ import io.circe.Decoder
 import weco.Tracing
 import weco.api.search.elasticsearch.{ElasticsearchError, ElasticsearchService}
 import weco.api.search.models.{ResultList, SearchOptions}
-import weco.catalogue.internal_model.identifiers.CanonicalId
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -24,7 +23,7 @@ trait SearchService[T, VisibleT, Aggs, S <: SearchOptions[_, _, _]] {
   protected def createAggregations(searchResponse: SearchResponse): Option[Aggs]
 
   def findById(
-    id: CanonicalId
+    id: String
   )(index: Index): Future[Either[ElasticsearchError, T]] =
     elasticsearchService.findById[T](id)(index)
 

--- a/search/src/test/scala/weco/api/search/elasticsearch/ElasticsearchServiceTest.scala
+++ b/search/src/test/scala/weco/api/search/elasticsearch/ElasticsearchServiceTest.scala
@@ -23,8 +23,7 @@ import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Seconds, Span}
-import weco.catalogue.internal_model.generators.IdentifiersGenerators
-import weco.catalogue.internal_model.identifiers.CanonicalId
+import weco.catalogue.display_model.generators.IdentifiersGenerators
 import weco.catalogue.internal_model.index.IndexFixtures
 import weco.elasticsearch.test.fixtures.ElasticsearchFixtures
 import weco.elasticsearch.{ElasticClientBuilder, IndexConfig}
@@ -42,8 +41,8 @@ class ElasticsearchServiceTest
     with IdentifiersGenerators
     with ElasticsearchFixtures {
 
-  case class ExampleThing(id: CanonicalId, name: String)
-  case class DifferentExampleThing(id: CanonicalId, age: Int)
+  case class ExampleThing(id: String, name: String)
+  case class DifferentExampleThing(id: String, age: Int)
 
   val badElasticClient: ElasticClient = ElasticClientBuilder.create(
     hostname = "noresolve",
@@ -82,7 +81,7 @@ class ElasticsearchServiceTest
           thingsToIndex.map { thing =>
             val jsonDoc = toJson(thing).get
             indexInto(index.name)
-              .id(thing.id.underlying)
+              .id(thing.id)
               .doc(jsonDoc)
           }
         ).refreshImmediately

--- a/search/src/test/scala/weco/api/search/services/ImagesServiceTest.scala
+++ b/search/src/test/scala/weco/api/search/services/ImagesServiceTest.scala
@@ -12,7 +12,6 @@ import weco.api.search.elasticsearch.{
 import weco.api.search.fixtures.TestDocumentFixtures
 import weco.api.search.models.index.IndexedImage
 import weco.api.search.models.{QueryConfig, SimilarityMetric}
-import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.catalogue.internal_model.index.IndexFixtures
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -43,7 +42,7 @@ class ImagesServiceTest
           IndexedImage(display = getDisplayImage("images.everything"))
 
         val future = imagesService.findById(
-          id = CanonicalId(getTestImageId("images.everything"))
+          id = getTestImageId("images.everything")
         )(index)
         val actualImage = whenReady(future) {
           _.right.value
@@ -55,7 +54,7 @@ class ImagesServiceTest
 
     it("returns a DocumentNotFoundError if no image can be found") {
       withLocalImagesIndex { index =>
-        val id = CanonicalId("nopenope")
+        val id = "nopenope"
         val future = imagesService.findById(id)(index)
 
         whenReady(future) {
@@ -66,7 +65,8 @@ class ImagesServiceTest
 
     it("returns an ElasticsearchError if Elasticsearch returns an error") {
       val index = createIndex
-      val future = imagesService.findById(CanonicalId("nopenope"))(index)
+      val id = "nopenope"
+      val future = imagesService.findById(id)(index)
 
       whenReady(future) { err =>
         err.left.value shouldBe a[IndexNotFoundError]

--- a/search/src/test/scala/weco/api/search/services/WorksServiceTest.scala
+++ b/search/src/test/scala/weco/api/search/services/WorksServiceTest.scala
@@ -13,7 +13,6 @@ import weco.api.search.fixtures.TestDocumentFixtures
 import weco.api.search.generators.SearchOptionsGenerators
 import weco.api.search.models._
 import weco.api.search.models.request.WorkAggregationRequest
-import weco.catalogue.internal_model.identifiers.CanonicalId
 import weco.catalogue.internal_model.index.IndexFixtures
 
 import java.time.LocalDate
@@ -370,7 +369,7 @@ class WorksServiceTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, "works.visible.0")
 
-        val future = worksService.findById(id = CanonicalId("7sjip63h"))(index)
+        val future = worksService.findById(id = "7sjip63h")(index)
 
         whenReady(future) {
           _ shouldBe Right(getVisibleWork("works.visible.0"))
@@ -381,8 +380,8 @@ class WorksServiceTest
 
     it("returns a DocumentNotFoundError if there is no work") {
       withLocalWorksIndex { index =>
-        val id = CanonicalId("nopenope")
-        val future = worksService.findById(id = id)(index)
+        val id = "nopenope"
+        val future = worksService.findById(id)(index)
 
         whenReady(future) {
           _ shouldBe Left(DocumentNotFoundError(id))
@@ -392,7 +391,8 @@ class WorksServiceTest
 
     it("returns an ElasticsearchError if there's an Elasticsearch error") {
       val index = createIndex
-      val future = worksService.findById(id = CanonicalId("nopenope"))(index)
+      val id = "nopenope"
+      val future = worksService.findById(id)(index)
 
       whenReady(future) { err =>
         err.left.value shouldBe a[IndexNotFoundError]


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5530; follows https://github.com/wellcomecollection/catalogue-api/pull/464

As discussed in Slack, this ditches the dedicated `CanonicalId` type in favour of a vanilla `String`. The two benefits of this class were:

1. **Helping the type checker.** The separate type meant you couldn't get confused about whether a particular ID value was a source identifier or a canonical ID; this is a big consideration in the pipeline, but in the APIs we're almost always dealing with canonical IDs, so the distinction is less valuable.

2. **Providing a first pass of validation on IDs.** Obviously malformed or malicious IDs (e.g. `/works/<script>alert('boo!');`) would be filtered out before we put them in an Elasticsearch query; I've replaced that with some simple heuristics that will let through anything that looks plausibly like a valid ID, but rejects the obviously bad stuff. This is similar to what we do for Prismic content IDs in the front end: https://github.com/wellcomecollection/wellcomecollection.org/search?q=looksLikePrismicId

At this point the only thing we're using internal model for is IndexFixtures, so I'll think about how we handle that and then we can snip internal model. 🎉 