### PR TITLE
Users may have multiple items on hold spanning many works

### DIFF
--- a/requests/src/main/scala/weco/api/requests/models/RequestedItemWithWork.scala
+++ b/requests/src/main/scala/weco/api/requests/models/RequestedItemWithWork.scala
@@ -2,6 +2,7 @@ package weco.api.requests.models
 
 import io.circe.Json
 import io.circe.parser._
+import weco.api.stacks.models.CatalogueWork
 import weco.catalogue.display_model.Implicits._
 import weco.catalogue.display_model.work.DisplayItem
 import weco.http.json.DisplayJsonUtil
@@ -13,6 +14,9 @@ case class RequestedItemWithWork(
 )
 
 case object RequestedItemWithWork {
+  def apply(item: DisplayItem, work: CatalogueWork): RequestedItemWithWork =
+    RequestedItemWithWork(work.id, work.title, item)
+
   def apply(
     workId: String,
     workTitle: Option[String],

--- a/requests/src/test/scala/weco/api/requests/RequestingScenarioTest.scala
+++ b/requests/src/test/scala/weco/api/requests/RequestingScenarioTest.scala
@@ -43,6 +43,7 @@ class RequestingScenarioTest
           HttpResponse(
             entity = createJsonHttpEntityWith(s"""
                  |{
+                 |  "totalResults": 1,
                  |  "results": [
                  |    {
                  |      "id": "kltbsiza",
@@ -123,6 +124,7 @@ class RequestingScenarioTest
             entity = createJsonHttpEntityWith(
               """
                 |{
+                |  "totalResults": 0,
                 |  "results": []
                 |}
                 |""".stripMargin
@@ -1434,6 +1436,7 @@ class RequestingScenarioTest
       entity = createJsonHttpEntityWith(
         s"""
            |{
+           |  "totalResults": 1,
            |  "results": [
            |    {
            |      "id": "rbhv3mnj",

--- a/requests/src/test/scala/weco/api/requests/RequestsApiFeatureTest.scala
+++ b/requests/src/test/scala/weco/api/requests/RequestsApiFeatureTest.scala
@@ -114,6 +114,7 @@ class RequestsApiFeatureTest
       val catalogueResponses = Seq(
         (
           catalogueItemsRequest(
+            page = 1,
             itemNumber1.withCheckDigit,
             itemNumber2.withCheckDigit
           ),
@@ -382,6 +383,7 @@ class RequestsApiFeatureTest
       val catalogueResponses = Seq(
         (
           catalogueItemsRequest(
+            page = 1,
             itemNumber1.withCheckDigit,
             itemNumber2.withCheckDigit
           ),

--- a/requests/src/test/scala/weco/api/requests/RequestsApiFeatureTest.scala
+++ b/requests/src/test/scala/weco/api/requests/RequestsApiFeatureTest.scala
@@ -122,6 +122,7 @@ class RequestsApiFeatureTest
               contentType = ContentTypes.`application/json`,
               s"""
                  |{
+                 |  "totalResults": 2,
                  |  "results": [
                  |    {
                  |      "id": "$workId1",

--- a/requests/src/test/scala/weco/api/requests/fixtures/ItemLookupFixture.scala
+++ b/requests/src/test/scala/weco/api/requests/fixtures/ItemLookupFixture.scala
@@ -29,13 +29,17 @@ trait ItemLookupFixture extends Akka with HttpFixtures {
       )
     )
 
-  def catalogueItemsRequest(ids: String*): HttpRequest =
+  def catalogueItemsRequest(page: Int, ids: String*): HttpRequest =
     HttpRequest(
       uri = Uri(
-        s"http://catalogue:9001/works?include=identifiers,items&items.identifiers=${ids.mkString(",")}&pageSize=100"
+        s"http://catalogue:9001/works?include=identifiers,items&items.identifiers=${ids
+          .mkString(",")}&pageSize=100&page=$page"
       )
     )
 
-  def catalogueSourceIdsRequest(ids: DisplayIdentifier*): HttpRequest =
-    catalogueItemsRequest(ids.map(_.value): _*)
+  def catalogueSourceIdsRequest(
+    page: Int,
+    ids: DisplayIdentifier*
+  ): HttpRequest =
+    catalogueItemsRequest(page, ids.map(_.value): _*)
 }

--- a/requests/src/test/scala/weco/api/requests/services/ItemLookupTest.scala
+++ b/requests/src/test/scala/weco/api/requests/services/ItemLookupTest.scala
@@ -128,6 +128,7 @@ class ItemLookupTest
       val responses = Seq(
         (
           catalogueSourceIdsRequest(
+            page = 1,
             item1.sourceIdentifier,
             item2.sourceIdentifier
           ),
@@ -175,6 +176,7 @@ class ItemLookupTest
       val responses = Seq(
         (
           catalogueSourceIdsRequest(
+            page = 1,
             item1.sourceIdentifier,
             item2.sourceIdentifier
           ),
@@ -223,6 +225,7 @@ class ItemLookupTest
       val responses = Seq(
         (
           catalogueSourceIdsRequest(
+            page = 1,
             item1.sourceIdentifier,
             item4.sourceIdentifier,
             item3.sourceIdentifier
@@ -249,12 +252,12 @@ class ItemLookupTest
           workTitle = workA.title,
           item = itemAsJson(item1)
         )
-        result(1).value shouldBe RequestedItemWithWork(
+        result(1).left.value shouldBe a[ItemNotFoundError]
+        result(2).value shouldBe RequestedItemWithWork(
           workId = workB.id,
           workTitle = workB.title,
           item = itemAsJson(item3)
         )
-        result(2).left.value shouldBe a[ItemNotFoundError]
       }
     }
 
@@ -268,15 +271,15 @@ class ItemLookupTest
 
       val responses = Seq(
         (
-          catalogueSourceIdsRequest(item1.sourceIdentifier),
+          catalogueSourceIdsRequest(page = 1, item1.sourceIdentifier),
           catalogueWorkResponse(Seq(workA))
         ),
         (
-          catalogueSourceIdsRequest(item2.sourceIdentifier),
+          catalogueSourceIdsRequest(page = 1, item2.sourceIdentifier),
           catalogueWorkResponse(Seq(workB, workA))
         ),
         (
-          catalogueSourceIdsRequest(item3.sourceIdentifier),
+          catalogueSourceIdsRequest(page = 1, item3.sourceIdentifier),
           catalogueWorkResponse(Seq(workB))
         )
       )
@@ -318,27 +321,27 @@ class ItemLookupTest
 
       val responses = Seq(
         (
-          catalogueSourceIdsRequest(item1.sourceIdentifier),
+          catalogueSourceIdsRequest(page = 1, item1.sourceIdentifier),
           catalogueWorkResponse(Seq(workA))
         ),
         (
-          catalogueSourceIdsRequest(item1.otherIdentifiers.head),
+          catalogueSourceIdsRequest(page = 1, item1.otherIdentifiers.head),
           catalogueWorkResponse(Seq(workA))
         ),
         (
-          catalogueSourceIdsRequest(item2.sourceIdentifier),
+          catalogueSourceIdsRequest(page = 1, item2.sourceIdentifier),
           catalogueWorkResponse(Seq(workA, workB))
         ),
         (
-          catalogueSourceIdsRequest(item2.otherIdentifiers.head),
+          catalogueSourceIdsRequest(page = 1, item2.otherIdentifiers.head),
           catalogueWorkResponse(Seq(workA, workB))
         ),
         (
-          catalogueSourceIdsRequest(item3.sourceIdentifier),
+          catalogueSourceIdsRequest(page = 1, item3.sourceIdentifier),
           catalogueWorkResponse(Seq(workB))
         ),
         (
-          catalogueSourceIdsRequest(item3.otherIdentifiers.head),
+          catalogueSourceIdsRequest(page = 1, item3.otherIdentifiers.head),
           catalogueWorkResponse(Seq(workB))
         )
       )
@@ -382,6 +385,7 @@ class ItemLookupTest
       val responses = Seq(
         (
           catalogueSourceIdsRequest(
+            page = 1,
             item2.sourceIdentifier,
             item3.sourceIdentifier
           ),
@@ -389,12 +393,16 @@ class ItemLookupTest
         ),
         (
           catalogueSourceIdsRequest(
-            item2.sourceIdentifier
+            page = 2,
+            item2.sourceIdentifier,
+            item3.sourceIdentifier
           ),
           catalogueWorkResponse(Seq(workA, workB))
         ),
         (
           catalogueSourceIdsRequest(
+            page = 3,
+            item2.sourceIdentifier,
             item3.sourceIdentifier
           ),
           catalogueWorkResponse(Seq(workB))

--- a/requests/src/test/scala/weco/api/requests/services/ItemLookupTest.scala
+++ b/requests/src/test/scala/weco/api/requests/services/ItemLookupTest.scala
@@ -499,7 +499,7 @@ class ItemLookupTest
       entity = createJsonHttpEntityWith(
         s"""
            |{
-           |  "totalResults": $pageSize,
+           |  "totalResults": ${works.size},
            |  "results": [ ${works
              .slice((page - 1) * pageSize, page * pageSize)
              .map(catalogueWorkJson)


### PR DESCRIPTION
Resolves https://github.com/wellcomecollection/catalogue-api/issues/459

This fix looks at all the pages of a works search - not particularly efficient, but should do the job.