### PR TITLE
Prioritise exact matches at the start of titles

### DIFF
--- a/rank/data/tests/works.ts
+++ b/rank/data/tests/works.ts
@@ -13,7 +13,6 @@ const tests: Test[] = [
         // https://github.com/wellcomecollection/catalogue-api/issues/466
         query: 'information law',
         ratings: ['zkg7xqm7'],
-        knownFailure: true,
         description:
           'Multi-word exact matches at the start of a title should be prioritised',
       },

--- a/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -42,7 +42,7 @@ case object WorksMultiMatcher {
         //
         //      Human genetic information : science, law, and ethics
         //      International journal of law and information technology
-        //      Information law : compliance for librarians and information professionals 
+        //      Information law : compliance for librarians and information professionals
         //
         // and somebody searches for "Information law", all other things being equal,
         // we want to prioritise the third result.

--- a/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -12,6 +12,10 @@ import com.sksamuel.elastic4s.requests.searches.queries.matches.{
   MatchQuery,
   MultiMatchQuery
 }
+import com.sksamuel.elastic4s.requests.searches.span.{
+  SpanFirstQuery,
+  SpanTermQuery
+}
 
 case object WorksMultiMatcher {
   val titleFields = Seq(
@@ -32,6 +36,15 @@ case object WorksMultiMatcher {
   def apply(q: String): BoolQuery =
     boolQuery()
       .should(
+        SpanFirstQuery(
+          SpanTermQuery(
+            field = "data.title.shingles",
+            value = q,
+          ),
+          boost = Some(1000),
+          queryName = Some("start of title"),
+          end=1
+        ),
         MultiMatchQuery(
           q,
           queryName = Some("identifiers"),

--- a/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -36,6 +36,18 @@ case object WorksMultiMatcher {
   def apply(q: String): BoolQuery =
     boolQuery()
       .should(
+        // This prioritises exact matches at the start of titles.
+        //
+        // e.g. if we had three works
+        //
+        //      Human genetic information : science, law, and ethics
+        //      International journal of law and information technology
+        //      Information law : compliance for librarians and information professionals 
+        //
+        // and somebody searches for "Information law", all other things being equal,
+        // we want to prioritise the third result.
+        //
+        // See https://github.com/wellcomecollection/catalogue-api/issues/466
         SpanFirstQuery(
           SpanTermQuery(
             field = "data.title.shingles",

--- a/search/src/test/resources/WorksMultiMatcherQuery.json
+++ b/search/src/test/resources/WorksMultiMatcherQuery.json
@@ -2,6 +2,18 @@
   "bool": {
     "should": [
       {
+        "span_first": {
+          "match": {
+            "span_term": {
+              "data.title.shingles": "{{query}}"
+            }
+          },
+          "end": 1,
+          "boost": 1000,
+          "_name": "start of title"
+        }
+      },
+      {
         "multi_match": {
           "query": "{{query}}",
           "fields": [


### PR DESCRIPTION
This PR adds a [span_first](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-first-query.html) query to the `title.shingles` field. 

Adding this section to the query resolves https://github.com/wellcomecollection/catalogue-api/issues/466, allowing us to remove the `knownFailure` label from the "information law" rank test. The rest of the rank tests are unaffected by the change.

According to the `compareQuerySpeed` script, there's no significant performance cost to the addition either.