### PR TITLE
Use source includes to limit what we get from Elasticsearch

### DIFF
--- a/search/src/main/scala/weco/api/search/services/ImagesRequestBuilder.scala
+++ b/search/src/main/scala/weco/api/search/services/ImagesRequestBuilder.scala
@@ -38,6 +38,7 @@ class ImagesRequestBuilder(queryConfig: QueryConfig)
       .sortBy { sortBy(searchOptions) }
       .limit(searchOptions.pageSize)
       .from(PaginationQuery.safeGetFrom(searchOptions))
+      .sourceInclude("display")
 
   private def filteredAggregationBuilder(searchOptions: ImageSearchOptions) =
     new ImageFiltersAndAggregationsBuilder(

--- a/search/src/main/scala/weco/api/search/services/WorksRequestBuilder.scala
+++ b/search/src/main/scala/weco/api/search/services/WorksRequestBuilder.scala
@@ -30,6 +30,7 @@ object WorksRequestBuilder
       .sortBy { sortBy }
       .limit { searchOptions.pageSize }
       .from { PaginationQuery.safeGetFrom(searchOptions) }
+      .sourceInclude("display", "type")
   }
 
   private def filteredAggregationBuilder(

--- a/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/iterators/ElasticsearchIterator.scala
+++ b/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/iterators/ElasticsearchIterator.scala
@@ -30,6 +30,7 @@ class ElasticsearchIterator(
       .scroll[HasDisplay](
         search(config.index)
           .query(termQuery("type", "Visible"))
+          .sourceInclude("display")
       )
       .map(_.display.noSpaces)
   }


### PR DESCRIPTION
The Elasticsearch documents are big and complicated and contain a lot of data the API doesn't need to create its responses. We can [retrieve the specific fields we care about](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#search-fields-param) to reduce the size of the documents we need to deal with. We discussed doing this in the past, but it was substantially more complicated because we were serialising data from a lot of different fields, and we decided it wasn't worth the additional complexity and risk.

Now we get everything from the `display` field, it’s a tiny change.

I don't think it will substantially affect the performance of the API (and I don’t think it’s worth measuring the effect of this change in particular), but it's such low-hanging fruit we might as well do it.