### PR TITLE
Build/test/push the concepts API in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -47,8 +47,21 @@ steps:
   - label: "Test concepts API"
     plugins:
       - docker-compose#v3.9.0:
-          run: concepts_api
+          run: concepts
           command: ["yarn", "test"]
+
+  - label: "Publish concepts API (ECR)"
+    #    if: build.branch == "main"
+    if: build.branch == "concepts-ci"
+    plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::756629837203:role/catalogue-ci"
+      - ecr#v2.1.1:
+          login: true
+      - docker-compose#v3.9.0:
+          push:
+            - concepts:756629837203.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/concepts:ref.${BUILDKITE_COMMIT}
+            - concepts:756629837203.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/concepts:latest
 
   - command: .buildkite/scripts/run_job.py snapshot_generator
     label: "Snapshot generator"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,8 +52,7 @@ steps:
           command: ["yarn", "test"]
 
   - label: "Publish concepts API (ECR)"
-    #    if: build.branch == "main"
-    if: build.branch == "concepts-ci"
+    if: build.branch == "main"
     depends_on:
       - "concepts-test"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,23 +35,23 @@ steps:
     priority: 1
 
   - command: .buildkite/scripts/run_job.py items
-    label: "Stacks: Items API"
+    label: "Items API"
     agents:
       queue: "scala"
 
   - command: .buildkite/scripts/run_job.py requests
-    label: "Stacks: Requests API"
+    label: "Requests API"
     agents:
       queue: "scala"
 
-  - label: "Test concepts API"
+  - label: "Concepts API (test)"
     key: "concepts-test"
     plugins:
       - docker-compose#v3.9.0:
           run: concepts
           command: ["yarn", "test"]
 
-  - label: "Publish concepts API (ECR)"
+  - label: "Concepts API (push image)"
     if: build.branch == "main"
     depends_on:
       - "concepts-test"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,6 +44,12 @@ steps:
     agents:
       queue: "scala"
 
+  - label: "Test concepts API"
+    plugins:
+      - docker-compose#v3.9.0:
+          run: concepts_api
+          command: ["yarn", "test"]
+
   - command: .buildkite/scripts/run_job.py snapshot_generator
     label: "Snapshot generator"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,6 +45,7 @@ steps:
       queue: "scala"
 
   - label: "Test concepts API"
+    key: "concepts-test"
     plugins:
       - docker-compose#v3.9.0:
           run: concepts
@@ -53,6 +54,8 @@ steps:
   - label: "Publish concepts API (ECR)"
     #    if: build.branch == "main"
     if: build.branch == "concepts-ci"
+    depends_on:
+      - "concepts-test"
     plugins:
       - wellcomecollection/aws-assume-role#v0.2.2:
           role: "arn:aws:iam::756629837203:role/catalogue-ci"

--- a/.buildkite/scripts/run_job.py
+++ b/.buildkite/scripts/run_job.py
@@ -15,6 +15,8 @@ from provider import current_branch, is_default_branch
 from sbt_dependency_tree import Repository
 
 
+non_scala_projects = ["diff_tool", "concepts"]
+
 def should_run_sbt_project(repo, project_name, changed_paths):
     project = repo.get_project(project_name)
 
@@ -46,10 +48,10 @@ def should_run_sbt_project(repo, project_name, changed_paths):
         if path.startswith("docs/"):
             continue
 
-        if path.endswith((".py", ".tf", ".md")):
+        if path.endswith((".py", ".tf", ".md", ".js", ".ts")):
             continue
 
-        if path.startswith("diff_tool"):
+        if any(path.startswith(project) for project in non_scala_projects):
             continue
 
         if os.path.basename(path) in {".terraform.lock.hcl", ".wellcome_project"}:

--- a/.buildkite/scripts/run_job.py
+++ b/.buildkite/scripts/run_job.py
@@ -17,6 +17,7 @@ from sbt_dependency_tree import Repository
 
 non_scala_projects = ["diff_tool", "concepts"]
 
+
 def should_run_sbt_project(repo, project_name, changed_paths):
     project = repo.get_project(project_name)
 

--- a/concepts/.dockerignore
+++ b/concepts/.dockerignore
@@ -1,3 +1,1 @@
 node_modules
-test
-jest.config.js

--- a/concepts/Dockerfile
+++ b/concepts/Dockerfile
@@ -7,7 +7,7 @@ COPY ./yarn.lock ./package.json ./
 COPY ./concepts ./concepts
 
 WORKDIR concepts
-RUN yarn install --frozen-lockfile --production && yarn cache clean
+RUN yarn install --frozen-lockfile && yarn cache clean
 
 CMD ["yarn", "start"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,8 @@ services:
     image: diff_tool
     build:
       context: ./diff_tool
+  concepts_api:
+    image: uk.ac.wellcome/concepts_api:${CONTAINER_TAG:-test}
+    build:
+      context: .
+      dockerfile: ./concepts/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     image: diff_tool
     build:
       context: ./diff_tool
-  concepts_api:
-    image: uk.ac.wellcome/concepts_api:${CONTAINER_TAG:-test}
+  concepts:
+    image: uk.ac.wellcome/concepts:${CONTAINER_TAG:-test}
     build:
       context: .
       dockerfile: ./concepts/Dockerfile

--- a/terraform/shared/ecr.tf
+++ b/terraform/shared/ecr.tf
@@ -33,6 +33,14 @@ resource "aws_ecr_repository" "api" {
   }
 }
 
+resource "aws_ecr_repository" "concepts" {
+  name = "uk.ac.wellcome/concepts"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "aws_ecr_repository" "nginx_api_gw" {
   name = "uk.ac.wellcome/nginx_api_gw"
 

--- a/terraform/shared/outputs.tf
+++ b/terraform/shared/outputs.tf
@@ -17,3 +17,7 @@ output "ecr_items_repository_url" {
 output "ecr_requests_repository_url" {
   value = aws_ecr_repository.requests.repository_url
 }
+
+output "ecr_concepts_repository_url" {
+  value = aws_ecr_repository.concepts.repository_url
+}


### PR DESCRIPTION
lemon squeezy

Only interesting bit is the change to `run_job.py` to avoid re-building scala projects when this mysterious javascript project changes.