### PR TITLE
Add filtering for subjects in the API

### DIFF
--- a/common/search/src/test/resources/WorksIndexConfig.json
+++ b/common/search/src/test/resources/WorksIndexConfig.json
@@ -958,6 +958,20 @@
         "type" : "object",
         "enabled": false
       },
+      "query": {
+        "type": "object",
+        "properties": {
+          "subjects.id": {
+            "type": "keyword"
+          },
+          "subjects.identifiers.value": {
+            "type": "keyword"
+          },
+          "subjects.label": {
+            "type": "keyword"
+          }
+        }
+      },
       "aggregatableValues" : {
         "type" : "object",
         "properties" : {

--- a/common/search/src/test/resources/test_documents/work.visible.everything.0.json
+++ b/common/search/src/test/resources/test_documents/work.visible.everything.0.json
@@ -1024,6 +1024,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["ArEtlVdV0j", "hG54NzomzM"]
+    },
     "aggregatableValues" : {
       "workType" : [
       ],

--- a/common/search/src/test/resources/test_documents/work.visible.everything.1.json
+++ b/common/search/src/test/resources/test_documents/work.visible.everything.1.json
@@ -1064,6 +1064,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["5LLMVvWxgX", "PSF4EIy1m2"]
+    },
     "aggregatableValues" : {
       "workType" : [
       ],

--- a/common/search/src/test/resources/test_documents/work.visible.everything.2.json
+++ b/common/search/src/test/resources/test_documents/work.visible.everything.2.json
@@ -1037,6 +1037,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["osW8hKQNGv", "h5tlAUKxcP"]
+    },
     "aggregatableValues" : {
       "workType" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.0.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["6IZ2DrUzFk"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"a\",\"label\":\"Books\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.1.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["6IZ2DrUzFk"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"q\",\"label\":\"Digital Images\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.10.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.10.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["Vo8KntFwFf"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"i\",\"label\":\"Audio\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.11.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.11.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["Vo8KntFwFf"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"g\",\"label\":\"Videos\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.12.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.12.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["v4BHmwGTZr"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"h\",\"label\":\"Archives and manuscripts\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.13.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.13.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["v4BHmwGTZr"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"n\",\"label\":\"Film\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.14.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.14.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["v4BHmwGTZr"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"b\",\"label\":\"Manuscripts\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.15.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.15.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["v4BHmwGTZr"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"c\",\"label\":\"Music\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.16.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.16.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["v4BHmwGTZr"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"u\",\"label\":\"Standing order\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.17.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.17.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["v4BHmwGTZr"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"z\",\"label\":\"Web sites\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.18.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.18.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["9hdRJC6PIO"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"v\",\"label\":\"E-books\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.19.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.19.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["9hdRJC6PIO"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"s\",\"label\":\"E-sound\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.2.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["6IZ2DrUzFk"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"l\",\"label\":\"Ephemera\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.20.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.20.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["9hdRJC6PIO"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"j\",\"label\":\"E-journals\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.21.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.21.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["9hdRJC6PIO"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"f\",\"label\":\"E-videos\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.22.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.22.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["9hdRJC6PIO"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"x\",\"label\":\"Manuscripts\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.3.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["6IZ2DrUzFk"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"e\",\"label\":\"Maps\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.4.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["6IZ2DrUzFk"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"k\",\"label\":\"Pictures\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.5.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["6IZ2DrUzFk"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"w\",\"label\":\"Student dissertations\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.6.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.6.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["Vo8KntFwFf"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"r\",\"label\":\"3-D Objects\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.7.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.7.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["Vo8KntFwFf"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"m\",\"label\":\"CD-Roms\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.8.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.8.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["Vo8KntFwFf"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"d\",\"label\":\"Journals\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.9.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.9.json
@@ -186,6 +186,11 @@
       ],
       "type" : "Work"
     },
+    "query": {
+      "subjects.id": [],
+      "subjects.identifiers": [],
+      "subjects.label": ["Vo8KntFwFf"]
+    },
     "aggregatableValues" : {
       "workType" : [
         "{\"id\":\"p\",\"label\":\"Mixed materials\",\"type\":\"Format\"}"

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.0.json
@@ -1,7 +1,7 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-05-10T09:08:11.347Z",
   "id" : "x3ofwne6",
+  "createdAt" : "2022-05-30T11:06:49.175Z",
   "document" : {
     "debug" : {
       "source" : {
@@ -63,7 +63,24 @@
       "subjects" : [
         {
           "id" : {
-            "type" : "Unidentifiable"
+            "canonicalId" : "sanitati",
+            "sourceIdentifier" : {
+              "identifierType" : {
+                "id" : "lc-subjects"
+              },
+              "ontologyType" : "Subject",
+              "value" : "lcsh-sanitation"
+            },
+            "otherIdentifiers" : [
+              {
+                "identifierType" : {
+                  "id" : "nlm-mesh"
+                },
+                "ontologyType" : "Subject",
+                "value" : "mesh-sanitation"
+              }
+            ],
+            "type" : "Identified"
           },
           "label" : "Sanitation.",
           "concepts" : [
@@ -134,6 +151,27 @@
       ],
       "subjects" : [
         {
+          "id" : "sanitati",
+          "identifiers" : [
+            {
+              "identifierType" : {
+                "id" : "lc-subjects",
+                "label" : "Library of Congress Subject Headings (LCSH)",
+                "type" : "IdentifierType"
+              },
+              "value" : "lcsh-sanitation",
+              "type" : "Identifier"
+            },
+            {
+              "identifierType" : {
+                "id" : "nlm-mesh",
+                "label" : "Medical Subject Headings (MESH) identifier",
+                "type" : "IdentifierType"
+              },
+              "value" : "mesh-sanitation",
+              "type" : "Identifier"
+            }
+          ],
           "label" : "Sanitation.",
           "concepts" : [
             {
@@ -178,6 +216,18 @@
       ],
       "type" : "Work"
     },
+    "query" : {
+      "subjects.id" : [
+        "sanitati"
+      ],
+      "subjects.identifiers.value" : [
+        "lcsh-sanitation",
+        "mesh-sanitation"
+      ],
+      "subjects.label" : [
+        "Sanitation."
+      ]
+    },
     "aggregatableValues" : {
       "workType" : [
       ],
@@ -186,7 +236,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"Sanitation.\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"id\":\"sanitati\",\"label\":\"Sanitation.\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.1.json
@@ -1,7 +1,7 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-05-10T09:08:11.347Z",
   "id" : "rdbnpfc2",
+  "createdAt" : "2022-05-30T11:06:49.176Z",
   "document" : {
     "debug" : {
       "source" : {
@@ -177,6 +177,15 @@
       "succeededBy" : [
       ],
       "type" : "Work"
+    },
+    "query" : {
+      "subjects.id" : [
+      ],
+      "subjects.identifiers.value" : [
+      ],
+      "subjects.label" : [
+        "London (England)"
+      ]
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.2.json
@@ -1,7 +1,7 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-05-10T09:08:11.347Z",
   "id" : "fjor9vqa",
+  "createdAt" : "2022-05-30T11:06:49.177Z",
   "document" : {
     "debug" : {
       "source" : {
@@ -177,6 +177,15 @@
       "succeededBy" : [
       ],
       "type" : "Work"
+    },
+    "query" : {
+      "subjects.id" : [
+      ],
+      "subjects.identifiers.value" : [
+      ],
+      "subjects.label" : [
+        "Psychology, Pathological"
+      ]
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.3.json
@@ -1,7 +1,7 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-05-10T09:08:11.348Z",
   "id" : "h18d0cbf",
+  "createdAt" : "2022-05-30T11:06:49.177Z",
   "document" : {
     "debug" : {
       "source" : {
@@ -63,7 +63,17 @@
       "subjects" : [
         {
           "id" : {
-            "type" : "Unidentifiable"
+            "canonicalId" : "darwin01",
+            "sourceIdentifier" : {
+              "identifierType" : {
+                "id" : "lc-names"
+              },
+              "ontologyType" : "Subject",
+              "value" : "lcnames-darwin"
+            },
+            "otherIdentifiers" : [
+            ],
+            "type" : "Identified"
           },
           "label" : "Darwin \"Jones\", Charles",
           "concepts" : [
@@ -134,6 +144,18 @@
       ],
       "subjects" : [
         {
+          "id" : "darwin01",
+          "identifiers" : [
+            {
+              "identifierType" : {
+                "id" : "lc-names",
+                "label" : "Library of Congress Name authority records",
+                "type" : "IdentifierType"
+              },
+              "value" : "lcnames-darwin",
+              "type" : "Identifier"
+            }
+          ],
           "label" : "Darwin \"Jones\", Charles",
           "concepts" : [
             {
@@ -178,6 +200,17 @@
       ],
       "type" : "Work"
     },
+    "query" : {
+      "subjects.id" : [
+        "darwin01"
+      ],
+      "subjects.identifiers.value" : [
+        "lcnames-darwin"
+      ],
+      "subjects.label" : [
+        "Darwin \"Jones\", Charles"
+      ]
+    },
     "aggregatableValues" : {
       "workType" : [
       ],
@@ -186,7 +219,7 @@
       "production.dates" : [
       ],
       "subjects.label" : [
-        "{\"label\":\"Darwin \\\"Jones\\\", Charles\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"id\":\"darwin01\",\"label\":\"Darwin \\\"Jones\\\", Charles\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.4.json
@@ -121,7 +121,17 @@
         },
         {
           "id" : {
-            "type" : "Unidentifiable"
+            "canonicalId" : "darwin01",
+            "sourceIdentifier" : {
+              "identifierType" : {
+                "id" : "lc-names"
+              },
+              "ontologyType" : "Subject",
+              "value" : "lcnames-darwin"
+            },
+            "otherIdentifiers" : [
+            ],
+            "type" : "Identified"
           },
           "label" : "Darwin \"Jones\", Charles",
           "concepts" : [
@@ -272,6 +282,19 @@
       ],
       "type" : "Work"
     },
+    "query" : {
+      "subjects.id" : [
+        "darwin01"
+      ],
+      "subjects.identifiers.value" : [
+        "lcnames-darwin"
+      ],
+      "subjects.label" : [
+        "London (England)",
+        "Psychology, Pathological",
+        "Darwin \"Jones\", Charles"
+      ]
+    },
     "aggregatableValues" : {
       "workType" : [
       ],
@@ -282,7 +305,7 @@
       "subjects.label" : [
         "{\"label\":\"London (England)\",\"concepts\":[],\"type\":\"Subject\"}",
         "{\"label\":\"Psychology, Pathological\",\"concepts\":[],\"type\":\"Subject\"}",
-        "{\"label\":\"Darwin \\\"Jones\\\", Charles\",\"concepts\":[],\"type\":\"Subject\"}"
+        "{\"id\":\"darwin01\",\"label\":\"Darwin \\\"Jones\\\", Charles\",\"concepts\":[],\"type\":\"Subject\"}"
       ],
       "languages" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.5.json
@@ -131,77 +131,14 @@
       ],
       "type" : "Work"
     },
-    "type" : "Visible"
-  },
-  "work" : {
-    "version" : 74,
-    "data" : {
-      "title" : "title-66qqlbcmHn",
-      "otherIdentifiers" : [
+    "query" : {
+      "subjects.id" : [
       ],
-      "alternativeTitles" : [
+      "subjects.identifiers.value" : [
       ],
-      "format" : null,
-      "description" : null,
-      "physicalDescription" : null,
-      "lettering" : null,
-      "createdDate" : null,
-      "subjects" : [
-      ],
-      "genres" : [
-      ],
-      "contributors" : [
-      ],
-      "thumbnail" : null,
-      "production" : [
-      ],
-      "languages" : [
-      ],
-      "edition" : null,
-      "notes" : [
-      ],
-      "duration" : null,
-      "items" : [
-      ],
-      "holdings" : [
-      ],
-      "collectionPath" : null,
-      "referenceNumber" : null,
-      "imageData" : [
-      ],
-      "workType" : "Standard"
+      "subjects.label" : [
+      ]
     },
-    "state" : {
-      "sourceIdentifier" : {
-        "identifierType" : {
-          "id" : "miro-image-number"
-        },
-        "ontologyType" : "Work",
-        "value" : "sAZ5Ju5hoU"
-      },
-      "canonicalId" : "h5zhfqrb",
-      "mergedTime" : "2022-05-08T03:03:37Z",
-      "sourceModifiedTime" : "2022-05-08T03:03:37Z",
-      "indexedTime" : "2022-05-10T09:08:11.348Z",
-      "availabilities" : [
-      ],
-      "derivedData" : {
-        "contributorAgents" : [
-        ]
-      },
-      "relations" : {
-        "ancestors" : [
-        ],
-        "children" : [
-        ],
-        "siblingsPreceding" : [
-        ],
-        "siblingsSucceeding" : [
-        ]
-      }
-    },
-    "redirectSources" : [
-    ],
     "type" : "Visible"
   }
 }

--- a/search/src/main/scala/weco/api/search/models/DocumentFilter.scala
+++ b/search/src/main/scala/weco/api/search/models/DocumentFilter.scala
@@ -27,7 +27,8 @@ case class GenreFilter(genreQuery: Seq[String])
     with ImageFilter
 
 case class SubjectIdFilter(ids: Seq[String]) extends WorkFilter
-case class SubjectIdentifiersFilter(sourceIdentifiers: Seq[String]) extends WorkFilter
+case class SubjectIdentifiersFilter(sourceIdentifiers: Seq[String])
+    extends WorkFilter
 case class SubjectLabelFilter(labels: Seq[String]) extends WorkFilter
 
 case class ContributorsFilter(contributorQueries: Seq[String])

--- a/search/src/main/scala/weco/api/search/models/DocumentFilter.scala
+++ b/search/src/main/scala/weco/api/search/models/DocumentFilter.scala
@@ -26,7 +26,9 @@ case class GenreFilter(genreQuery: Seq[String])
     extends WorkFilter
     with ImageFilter
 
-case class SubjectFilter(subjectQuery: Seq[String]) extends WorkFilter
+case class SubjectIdFilter(ids: Seq[String]) extends WorkFilter
+case class SubjectIdentifiersFilter(sourceIdentifiers: Seq[String]) extends WorkFilter
+case class SubjectLabelFilter(labels: Seq[String]) extends WorkFilter
 
 case class ContributorsFilter(contributorQueries: Seq[String])
     extends WorkFilter

--- a/search/src/main/scala/weco/api/search/rest/WorksParams.scala
+++ b/search/src/main/scala/weco/api/search/rest/WorksParams.scala
@@ -73,7 +73,9 @@ case class WorkFilterParams(
   `production.dates.to`: Option[LocalDate],
   languages: Option[LanguagesFilter],
   `genres.label`: Option[GenreFilter],
-  `subjects.label`: Option[SubjectFilter],
+  `subjects`: Option[SubjectIdFilter],
+  `subjects.identifiers`: Option[SubjectIdentifiersFilter],
+  `subjects.label`: Option[SubjectLabelFilter],
   `contributors.agent.label`: Option[ContributorsFilter],
   identifiers: Option[IdentifiersFilter],
   partOf: Option[PartOfFilter],
@@ -115,6 +117,8 @@ case class MultipleWorksParams(
       dateFilter,
       filterParams.languages,
       filterParams.`genres.label`,
+      filterParams.`subjects`,
+      filterParams.`subjects.identifiers`,
       filterParams.`subjects.label`,
       filterParams.`contributors.agent.label`,
       filterParams.identifiers,
@@ -195,7 +199,9 @@ object MultipleWorksParams extends QueryParamsUtils {
           "production.dates.to".as[LocalDate].?,
           "languages".as[LanguagesFilter].?,
           "genres.label".as[GenreFilter].?,
-          "subjects.label".as[SubjectFilter].?,
+          "subjects".as[SubjectIdFilter].?,
+          "subjects.identifiers".as[SubjectIdentifiersFilter].?,
+          "subjects.label".as[SubjectLabelFilter].?,
           "contributors.agent.label".as[ContributorsFilter].?,
           "identifiers".as[IdentifiersFilter].?,
           "partOf".as[PartOfFilter].?,
@@ -210,6 +216,8 @@ object MultipleWorksParams extends QueryParamsUtils {
               languages,
               genres,
               subjects,
+              subjectIdentifiers,
+              subjectLabels,
               contributors,
               identifiers,
               partOf,
@@ -224,6 +232,8 @@ object MultipleWorksParams extends QueryParamsUtils {
               languages,
               genres,
               subjects,
+              subjectIdentifiers,
+              subjectLabels,
               contributors,
               identifiers,
               partOf,
@@ -257,8 +267,14 @@ object MultipleWorksParams extends QueryParamsUtils {
   implicit val languagesFilter: Decoder[LanguagesFilter] =
     stringListFilter(LanguagesFilter)
 
-  implicit val subjectFilter: Decoder[SubjectFilter] =
-    stringListFilter(SubjectFilter)
+  implicit val subjectIdFilter: Decoder[SubjectIdFilter] =
+    stringListFilter(SubjectIdFilter)
+
+  implicit val subjectIdentifiersFilter: Decoder[SubjectIdentifiersFilter] =
+    stringListFilter(SubjectIdentifiersFilter)
+
+  implicit val subjectLabelFilter: Decoder[SubjectLabelFilter] =
+    stringListFilter(SubjectLabelFilter)
 
   implicit val identifiersFilter: Decoder[IdentifiersFilter] =
     stringListFilter(IdentifiersFilter)

--- a/search/src/main/scala/weco/api/search/services/FiltersAndAggregationsBuilder.scala
+++ b/search/src/main/scala/weco/api/search/services/FiltersAndAggregationsBuilder.scala
@@ -89,7 +89,7 @@ class WorkFiltersAndAggregationsBuilder(
       case _: FormatFilter       => List(WorkAggregationRequest.Format)
       case _: LanguagesFilter    => List(WorkAggregationRequest.Languages)
       case _: GenreFilter        => List(WorkAggregationRequest.Genre)
-      case _: SubjectLabelFilter      => List(WorkAggregationRequest.Subject)
+      case _: SubjectLabelFilter => List(WorkAggregationRequest.Subject)
       case _: ContributorsFilter => List(WorkAggregationRequest.Contributor)
       case _: LicenseFilter      => List(WorkAggregationRequest.License)
       case _: AvailabilitiesFilter =>

--- a/search/src/main/scala/weco/api/search/services/FiltersAndAggregationsBuilder.scala
+++ b/search/src/main/scala/weco/api/search/services/FiltersAndAggregationsBuilder.scala
@@ -89,7 +89,7 @@ class WorkFiltersAndAggregationsBuilder(
       case _: FormatFilter       => List(WorkAggregationRequest.Format)
       case _: LanguagesFilter    => List(WorkAggregationRequest.Languages)
       case _: GenreFilter        => List(WorkAggregationRequest.Genre)
-      case _: SubjectFilter      => List(WorkAggregationRequest.Subject)
+      case _: SubjectLabelFilter      => List(WorkAggregationRequest.Subject)
       case _: ContributorsFilter => List(WorkAggregationRequest.Contributor)
       case _: LicenseFilter      => List(WorkAggregationRequest.License)
       case _: AvailabilitiesFilter =>

--- a/search/src/main/scala/weco/api/search/services/WorksRequestBuilder.scala
+++ b/search/src/main/scala/weco/api/search/services/WorksRequestBuilder.scala
@@ -157,8 +157,14 @@ object WorksRequestBuilder
         termsQuery(field = "data.languages.id", values = languageIds)
       case GenreFilter(genreQueries) =>
         termsQuery("data.genres.label.keyword", genreQueries)
-      case SubjectFilter(subjectQueries) =>
-        termsQuery("data.subjects.label.keyword", subjectQueries)
+
+      case SubjectIdFilter(ids) =>
+        termsQuery("query.subjects.id", ids)
+      case SubjectIdentifiersFilter(sourceIdentifiers) =>
+        termsQuery("query.subjects.identifiers.value", sourceIdentifiers)
+      case SubjectLabelFilter(labels) =>
+        termsQuery("query.subjects.label", labels)
+
       case ContributorsFilter(contributorQueries) =>
         termsQuery("data.contributors.agent.label.keyword", contributorQueries)
       case LicenseFilter(licenseIds) =>

--- a/search/src/test/scala/weco/api/search/services/AggregationsTest.scala
+++ b/search/src/test/scala/weco/api/search/services/AggregationsTest.scala
@@ -148,7 +148,7 @@ class AggregationsTest
             List(WorkAggregationRequest.Format, WorkAggregationRequest.Subject),
           filters = List(
             FormatFilter(List("a")),
-            SubjectFilter(Seq("pGkJTZWwn4"))
+            SubjectLabelFilter(Seq("pGkJTZWwn4"))
           )
         )
         whenReady(aggregationQuery(index, searchOptions)) { aggs =>
@@ -192,7 +192,7 @@ class AggregationsTest
             List(WorkAggregationRequest.Format, WorkAggregationRequest.Subject),
           filters = List(
             FormatFilter(List("a")),
-            SubjectFilter(Seq("6IZ2DrUzFk"))
+            SubjectLabelFilter(Seq("6IZ2DrUzFk"))
           )
         )
         val results =

--- a/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala
@@ -345,7 +345,7 @@ class WorksFiltersTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
     }
   }
 
-  describe("filtering works by subject") {
+  describe("filtering works") {
     val sanitationWork = "works.examples.subject-filters-tests.0"
     val londonWork = "works.examples.subject-filters-tests.1"
     val psychologyWork = "works.examples.subject-filters-tests.2"
@@ -364,42 +364,70 @@ class WorksFiltersTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
       )
 
     val testCases = Table(
-      ("query", "expectedIds", "clue"),
-      ("Sanitation.", Seq(sanitationWork), "single match single subject"),
+      ("filterName", "query", "expectedIds", "clue"),
+      ("subjects.label", "Sanitation.", Seq(sanitationWork), "single match single subject"),
       (
+        "subjects.label",
         "London (England)",
         Seq(londonWork, mostThingsWork),
         "multi match single subject"
       ),
       (
+        "subjects.label",
         "Sanitation.,London (England)",
         Seq(sanitationWork, londonWork, mostThingsWork),
         "comma separated"
       ),
       (
+        "subjects.label",
         """Sanitation.,"Psychology, Pathological"""",
         Seq(sanitationWork, psychologyWork, mostThingsWork),
         "commas in quotes"
       ),
       (
+        "subjects.label",
         """"Darwin \"Jones\", Charles","Psychology, Pathological",London (England)""",
         Seq(darwinWork, psychologyWork, londonWork, mostThingsWork),
         "escaped quotes in quotes"
+      ),
+      (
+        "subjects",
+        "sanitati",
+        Seq(sanitationWork),
+        "searching for a single canonical ID"
+      ),
+      (
+        "subjects",
+        "sanitati,darwin01",
+        Seq(sanitationWork, darwinWork, mostThingsWork),
+        "searching for a multiple canonical IDs"
+      ),
+      (
+        "subjects.identifiers",
+        "mesh-sanitation",
+        Seq(sanitationWork),
+        "searching for a single source identifier"
+      ),
+      (
+        "subjects.identifiers",
+        "mesh-sanitation,lcnames-darwin",
+        Seq(sanitationWork, darwinWork, mostThingsWork),
+        "searching for multiple source identifiers"
       )
     )
 
-    it("filters by subjects as a comma separated list") {
+    it("filters by subjects") {
       withWorksApi {
         case (worksIndex, routes) =>
           indexTestDocuments(worksIndex, works: _*)
 
           forAll(testCases) {
-            (query: String, expectedIds: Seq[String], clue: String) =>
+            (filterName, query: String, expectedIds: Seq[String], clue: String) =>
               withClue(clue) {
                 assertJsonResponse(
                   routes,
                   path =
-                    s"$rootPath/works?subjects.label=${URLEncoder.encode(query, "UTF-8")}"
+                    s"$rootPath/works?$filterName=${URLEncoder.encode(query, "UTF-8")}"
                 ) {
                   Status.OK -> worksListResponse(expectedIds)
                 }

--- a/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala
@@ -365,7 +365,12 @@ class WorksFiltersTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
 
     val testCases = Table(
       ("filterName", "query", "expectedIds", "clue"),
-      ("subjects.label", "Sanitation.", Seq(sanitationWork), "single match single subject"),
+      (
+        "subjects.label",
+        "Sanitation.",
+        Seq(sanitationWork),
+        "single match single subject"
+      ),
       (
         "subjects.label",
         "London (England)",
@@ -422,7 +427,12 @@ class WorksFiltersTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
           indexTestDocuments(worksIndex, works: _*)
 
           forAll(testCases) {
-            (filterName, query: String, expectedIds: Seq[String], clue: String) =>
+            (
+              filterName,
+              query: String,
+              expectedIds: Seq[String],
+              clue: String
+            ) =>
               withClue(clue) {
                 assertJsonResponse(
                   routes,


### PR DESCRIPTION
The API now queries subjects using the new `query` object. There are now three ways to query subjects:

1. By canonical ID – for the new concepts API
2. By source identifier – for completeness from an "API as a product" perspective, even if we won't use it ourselves
3. By label – for the existing functionality on wc.org/works

For https://github.com/wellcomecollection/catalogue-api/issues/478