### PR TITLE
Use the new query fields in the search API

### DIFF
--- a/common/search/src/test/resources/WorksIndexConfig.json
+++ b/common/search/src/test/resources/WorksIndexConfig.json
@@ -952,6 +952,14 @@
       "query": {
         "type": "object",
         "properties": {
+          "id" : {
+            "type" : "keyword",
+            "normalizer" : "lowercase_normalizer"
+          },
+          "identifiers.value" : {
+            "type" : "keyword",
+            "normalizer" : "lowercase_normalizer"
+          },
           "subjects.id": {
             "type": "keyword"
           },
@@ -959,6 +967,54 @@
             "type": "keyword"
           },
           "subjects.label": {
+            "type": "keyword"
+          },
+          "partOf.id" : {
+            "type" : "keyword",
+            "normalizer" : "lowercase_normalizer"
+          },
+          "partOf.title" : {
+            "type" : "text",
+            "fields" : {
+              "keyword" : {
+                "type" : "keyword",
+                "normalizer" : "lowercase_normalizer"
+              },
+              "english" : {
+                "type" : "text",
+                "analyzer" : "english_analyzer"
+              },
+              "shingles" : {
+                "type" : "text",
+                "analyzer" : "shingle_asciifolding_analyzer"
+              },
+              "arabic" : {
+                "type" : "text",
+                "analyzer" : "arabic_analyzer"
+              },
+              "bengali" : {
+                "type" : "text",
+                "analyzer" : "bengali_analyzer"
+              },
+              "french" : {
+                "type" : "text",
+                "analyzer" : "french_analyzer"
+              },
+              "german" : {
+                "type" : "text",
+                "analyzer" : "german_analyzer"
+              },
+              "hindi" : {
+                "type" : "text",
+                "analyzer" : "hindi_analyzer"
+              },
+              "italian" : {
+                "type" : "text",
+                "analyzer" : "italian_analyzer"
+              }
+            }
+          },
+          "availabilities.id": {
             "type": "keyword"
           }
         }

--- a/common/search/src/test/resources/test_documents/work-production.1098.json
+++ b/common/search/src/test/resources/test_documents/work-production.1098.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1098",
-  "createdAt" : "2022-06-01T06:45:07.701290Z",
+  "createdAt" : "2022-06-01T09:53:15.104845Z",
   "id" : "guav7chy",
   "document" : {
     "debug" : {
@@ -163,11 +163,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "guav7chy",
+      "identifiers.value" : [
+        "W9fptfa5Xn"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/work-production.1900.json
+++ b/common/search/src/test/resources/test_documents/work-production.1900.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1900",
-  "createdAt" : "2022-05-31T18:33:50.609358Z",
+  "createdAt" : "2022-06-01T09:53:15.046864Z",
   "id" : "rbnro6wx",
   "document" : {
     "debug" : {
@@ -163,11 +163,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "rbnro6wx",
+      "identifiers.value" : [
+        "akaUmx5H3i"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/work-production.1904.json
+++ b/common/search/src/test/resources/test_documents/work-production.1904.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1904",
-  "createdAt" : "2022-05-31T18:33:50.620982Z",
+  "createdAt" : "2022-06-01T09:53:15.078216Z",
   "id" : "aiv95swj",
   "document" : {
     "debug" : {
@@ -163,11 +163,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "aiv95swj",
+      "identifiers.value" : [
+        "h0QyLvGt20"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/work-production.1976.json
+++ b/common/search/src/test/resources/test_documents/work-production.1976.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1976",
-  "createdAt" : "2022-05-31T18:33:50.615324Z",
+  "createdAt" : "2022-06-01T09:53:15.062732Z",
   "id" : "5vjghupy",
   "document" : {
     "debug" : {
@@ -163,11 +163,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "5vjghupy",
+      "identifiers.value" : [
+        "xrdlOL8J49"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/work-production.2020.json
+++ b/common/search/src/test/resources/test_documents/work-production.2020.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 2020",
-  "createdAt" : "2022-05-31T18:33:50.628064Z",
+  "createdAt" : "2022-06-01T09:53:15.091432Z",
   "id" : "0fucriyr",
   "document" : {
     "debug" : {
@@ -163,11 +163,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "0fucriyr",
+      "identifiers.value" : [
+        "KgSH5dUX0Z"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/work-thumbnail.json
+++ b/common/search/src/test/resources/test_documents/work-thumbnail.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a thumbnail",
-  "createdAt" : "2022-05-31T18:33:50.558042Z",
+  "createdAt" : "2022-06-01T09:53:14.858288Z",
   "id" : "sahqcluh",
   "document" : {
     "debug" : {
@@ -157,11 +157,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "sahqcluh",
+      "identifiers.value" : [
+        "rRRYGQYiF7"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/work-title-dodo.json
+++ b/common/search/src/test/resources/test_documents/work-title-dodo.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'dodo' in the title",
-  "createdAt" : "2022-05-31T18:33:50.566528Z",
+  "createdAt" : "2022-06-01T09:53:14.876106Z",
   "id" : "ezagik4b",
   "document" : {
     "debug" : {
@@ -129,11 +129,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "ezagik4b",
+      "identifiers.value" : [
+        "xg9OuzGali"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/work-title-mouse.json
+++ b/common/search/src/test/resources/test_documents/work-title-mouse.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'mouse' in the title",
-  "createdAt" : "2022-05-31T18:33:50.578208Z",
+  "createdAt" : "2022-06-01T09:53:14.895273Z",
   "id" : "lnn17cwk",
   "document" : {
     "debug" : {
@@ -129,11 +129,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "lnn17cwk",
+      "identifiers.value" : [
+        "EhPpSB8mq7"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/work-with-edition-and-duration.json
+++ b/common/search/src/test/resources/test_documents/work-with-edition-and-duration.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with optional top-level fields",
-  "createdAt" : "2022-05-31T18:33:50.540543Z",
+  "createdAt" : "2022-06-01T09:53:14.700120Z",
   "id" : "gsruvqwf",
   "document" : {
     "debug" : {
@@ -130,11 +130,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "gsruvqwf",
+      "identifiers.value" : [
+        "7YNi35xO0f"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/work.items-with-location-types.0.json
+++ b/common/search/src/test/resources/test_documents/work.items-with-location-types.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-05-31T18:33:51.426898Z",
+  "createdAt" : "2022-06-01T09:53:16.751359Z",
   "id" : "kdwct2lf",
   "document" : {
     "debug" : {
@@ -195,11 +195,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "kdwct2lf",
+      "identifiers.value" : [
+        "vUprsjrX3O"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/work.items-with-location-types.1.json
+++ b/common/search/src/test/resources/test_documents/work.items-with-location-types.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-05-31T18:33:51.428831Z",
+  "createdAt" : "2022-06-01T09:53:16.752706Z",
   "id" : "sgatphra",
   "document" : {
     "debug" : {
@@ -227,11 +227,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "sgatphra",
+      "identifiers.value" : [
+        "GsIdzZyGYB"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/work.items-with-location-types.2.json
+++ b/common/search/src/test/resources/test_documents/work.items-with-location-types.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-05-31T18:33:51.431509Z",
+  "createdAt" : "2022-06-01T09:53:16.754190Z",
   "id" : "wt6pclbs",
   "document" : {
     "debug" : {
@@ -203,11 +203,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "wt6pclbs",
+      "identifiers.value" : [
+        "D31AdK5EfQ"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
+        "closed-stores"
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/work.visible.everything.0.json
+++ b/common/search/src/test/resources/test_documents/work.visible.everything.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-06-01T06:45:08.447824Z",
+  "createdAt" : "2022-06-01T09:53:15.604703Z",
   "id" : "tmdfbk5k",
   "document" : {
     "debug" : {
@@ -990,6 +990,11 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "tmdfbk5k",
+      "identifiers.value" : [
+        "Aic5qOhRoS",
+        "UfcQYSxE7g"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -997,6 +1002,16 @@
       "subjects.label" : [
         "RGOo9Fg6ic",
         "k1WGWfqE6x"
+      ],
+      "partOf.id" : [
+        "0cs6cerb",
+        "nrvdy0jg"
+      ],
+      "partOf.title" : [
+        "title-b1iZslIT5y",
+        "title-MS5Hy6x38N"
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/work.visible.everything.1.json
+++ b/common/search/src/test/resources/test_documents/work.visible.everything.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-06-01T06:45:08.605231Z",
+  "createdAt" : "2022-06-01T09:53:15.708261Z",
   "id" : "nlqnlwch",
   "document" : {
     "debug" : {
@@ -1059,6 +1059,11 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "nlqnlwch",
+      "identifiers.value" : [
+        "jfcicmGMGK",
+        "aGKxAEeG0H"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -1066,6 +1071,17 @@
       "subjects.label" : [
         "zUX6yZ5LLM",
         "MbAm0vPSF4"
+      ],
+      "partOf.id" : [
+        "jlsj0le6",
+        "qfoju3if"
+      ],
+      "partOf.title" : [
+        "title-m6xTX4FOSl",
+        "title-e07i7vw7Iw"
+      ],
+      "availabilities.id" : [
+        "closed-stores"
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/work.visible.everything.2.json
+++ b/common/search/src/test/resources/test_documents/work.visible.everything.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-06-01T06:45:08.614949Z",
+  "createdAt" : "2022-06-01T09:53:15.714036Z",
   "id" : "jfzz4ou9",
   "document" : {
     "debug" : {
@@ -1068,6 +1068,11 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "jfzz4ou9",
+      "identifiers.value" : [
+        "Is1ajgcgP8",
+        "FhqVjVef8B"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -1075,6 +1080,18 @@
       "subjects.label" : [
         "dXe1K5osW8",
         "t4fspOh5tl"
+      ],
+      "partOf.id" : [
+        "k4gltrjv",
+        "0le4q0ih"
+      ],
+      "partOf.title" : [
+        "title-raPvkrZaQn",
+        "title-Z1N6BwQR6H"
+      ],
+      "availabilities.id" : [
+        "open-shelves",
+        "closed-stores"
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.collection-path.NUFFINK.json
+++ b/common/search/src/test/resources/test_documents/works.collection-path.NUFFINK.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a collection path",
-  "createdAt" : "2022-05-31T18:33:51.320371Z",
+  "createdAt" : "2022-06-01T09:53:16.405638Z",
   "id" : "dtqmc0yn",
   "document" : {
     "debug" : {
@@ -131,11 +131,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "dtqmc0yn",
+      "identifiers.value" : [
+        "Lq95TrUx7A"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.collection-path.PPCRI.json
+++ b/common/search/src/test/resources/test_documents/works.collection-path.PPCRI.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a collection path",
-  "createdAt" : "2022-05-31T18:33:51.316093Z",
+  "createdAt" : "2022-06-01T09:53:16.394191Z",
   "id" : "mlqs2qbd",
   "document" : {
     "debug" : {
@@ -131,11 +131,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "mlqs2qbd",
+      "identifiers.value" : [
+        "yQb1GgWKF4"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.contributor.0.json
+++ b/common/search/src/test/resources/test_documents/works.contributor.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-05-31T18:33:51.259875Z",
+  "createdAt" : "2022-06-01T09:53:16.268721Z",
   "id" : "gvkz3vff",
   "document" : {
     "debug" : {
@@ -151,11 +151,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "gvkz3vff",
+      "identifiers.value" : [
+        "5CJlp05MGl"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.contributor.1.json
+++ b/common/search/src/test/resources/test_documents/works.contributor.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-05-31T18:33:51.261283Z",
+  "createdAt" : "2022-06-01T09:53:16.270365Z",
   "id" : "bj9evx0c",
   "document" : {
     "debug" : {
@@ -151,11 +151,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "bj9evx0c",
+      "identifiers.value" : [
+        "TjLML0MOH1"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.contributor.2.json
+++ b/common/search/src/test/resources/test_documents/works.contributor.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-05-31T18:33:51.270306Z",
+  "createdAt" : "2022-06-01T09:53:16.280918Z",
   "id" : "z08k6cnn",
   "document" : {
     "debug" : {
@@ -174,11 +174,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "z08k6cnn",
+      "identifiers.value" : [
+        "juTufKU2Ye"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.contributor.3.json
+++ b/common/search/src/test/resources/test_documents/works.contributor.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-05-31T18:33:51.273431Z",
+  "createdAt" : "2022-06-01T09:53:16.282846Z",
   "id" : "gtfjchvo",
   "document" : {
     "debug" : {
@@ -174,11 +174,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "gtfjchvo",
+      "identifiers.value" : [
+        "xKXAvquihJ"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.0.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.336589Z",
+  "createdAt" : "2022-06-01T09:53:16.425103Z",
   "id" : "4njkixz6",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "4njkixz6",
+      "identifiers.value" : [
+        "BApNW5yJ4Q"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.1.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.337895Z",
+  "createdAt" : "2022-06-01T09:53:16.426669Z",
   "id" : "jugcpduf",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "jugcpduf",
+      "identifiers.value" : [
+        "YysYTJPbhB"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.10.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.349418Z",
+  "createdAt" : "2022-06-01T09:53:16.437054Z",
   "id" : "4wwgkp4h",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "4wwgkp4h",
+      "identifiers.value" : [
+        "miNkeZ17CI"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.11.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.351923Z",
+  "createdAt" : "2022-06-01T09:53:16.438253Z",
   "id" : "kkcl3dhq",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "kkcl3dhq",
+      "identifiers.value" : [
+        "INEpZD4veL"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.12.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.353423Z",
+  "createdAt" : "2022-06-01T09:53:16.439116Z",
   "id" : "ilrp0gol",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "ilrp0gol",
+      "identifiers.value" : [
+        "TRLxjc4Dv7"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.13.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.354046Z",
+  "createdAt" : "2022-06-01T09:53:16.439717Z",
   "id" : "rdqs25hn",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "rdqs25hn",
+      "identifiers.value" : [
+        "fZ9zaDFnzp"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.14.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.354659Z",
+  "createdAt" : "2022-06-01T09:53:16.440227Z",
   "id" : "124qx5km",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "124qx5km",
+      "identifiers.value" : [
+        "LCpWDX84If"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.15.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.355260Z",
+  "createdAt" : "2022-06-01T09:53:16.440808Z",
   "id" : "tlc5rq9a",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "tlc5rq9a",
+      "identifiers.value" : [
+        "mz25207khU"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.16.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.356254Z",
+  "createdAt" : "2022-06-01T09:53:16.441255Z",
   "id" : "sdb22mdv",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "sdb22mdv",
+      "identifiers.value" : [
+        "qjgnqBCXUR"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.17.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.357216Z",
+  "createdAt" : "2022-06-01T09:53:16.441959Z",
   "id" : "9tar4kg6",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "9tar4kg6",
+      "identifiers.value" : [
+        "WpfpIxjlf3"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.18.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.358366Z",
+  "createdAt" : "2022-06-01T09:53:16.442417Z",
   "id" : "au6tjof0",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "au6tjof0",
+      "identifiers.value" : [
+        "vISRu7MtEo"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.19.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.359178Z",
+  "createdAt" : "2022-06-01T09:53:16.443139Z",
   "id" : "ogdq417u",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "ogdq417u",
+      "identifiers.value" : [
+        "lq8kfIsxyr"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.2.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.338889Z",
+  "createdAt" : "2022-06-01T09:53:16.428089Z",
   "id" : "fuwvinln",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "fuwvinln",
+      "identifiers.value" : [
+        "40wEIb4rPR"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.20.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.360230Z",
+  "createdAt" : "2022-06-01T09:53:16.443887Z",
   "id" : "jyum0yf1",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "jyum0yf1",
+      "identifiers.value" : [
+        "KzDNfalpwO"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.21.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.361352Z",
+  "createdAt" : "2022-06-01T09:53:16.444585Z",
   "id" : "cwippax3",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "cwippax3",
+      "identifiers.value" : [
+        "2PauY4Py8G"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.22.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.362376Z",
+  "createdAt" : "2022-06-01T09:53:16.445075Z",
   "id" : "9rgmu63i",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "9rgmu63i",
+      "identifiers.value" : [
+        "3tyy1ghzsQ"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.3.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.339977Z",
+  "createdAt" : "2022-06-01T09:53:16.429128Z",
   "id" : "i77xk8vj",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "i77xk8vj",
+      "identifiers.value" : [
+        "SZKltFZVRN"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.4.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.341040Z",
+  "createdAt" : "2022-06-01T09:53:16.430337Z",
   "id" : "xgsosrhr",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "xgsosrhr",
+      "identifiers.value" : [
+        "L5s2axrzcV"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.5.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.342706Z",
+  "createdAt" : "2022-06-01T09:53:16.431721Z",
   "id" : "cvdyxyqr",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "cvdyxyqr",
+      "identifiers.value" : [
+        "LIOVK6f1ni"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.6.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.343754Z",
+  "createdAt" : "2022-06-01T09:53:16.432648Z",
   "id" : "aftvp1wz",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "aftvp1wz",
+      "identifiers.value" : [
+        "rMq0Chsgjm"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.7.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.345178Z",
+  "createdAt" : "2022-06-01T09:53:16.433459Z",
   "id" : "y8glbwdh",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "y8glbwdh",
+      "identifiers.value" : [
+        "NrhJtvfJrH"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.8.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.346936Z",
+  "createdAt" : "2022-06-01T09:53:16.434785Z",
   "id" : "4fkr6m6l",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "4fkr6m6l",
+      "identifiers.value" : [
+        "Ngls6zS4b2"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.every-format.9.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-05-31T18:33:51.348012Z",
+  "createdAt" : "2022-06-01T09:53:16.435807Z",
   "id" : "e2zva5mj",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "e2zva5mj",
+      "identifiers.value" : [
+        "2Ap82csHfk"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-05-31T18:33:51.658789Z",
+  "createdAt" : "2022-06-01T09:53:17.845889Z",
   "id" : "stsp385v",
   "document" : {
     "debug" : {
@@ -220,11 +220,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "stsp385v",
+      "identifiers.value" : [
+        "PD8H80xrR5"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-05-31T18:33:51.660850Z",
+  "createdAt" : "2022-06-01T09:53:17.846970Z",
   "id" : "jwvfegzn",
   "document" : {
     "debug" : {
@@ -218,11 +218,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "jwvfegzn",
+      "identifiers.value" : [
+        "FvAY3kDPeO"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-05-31T18:33:51.662511Z",
+  "createdAt" : "2022-06-01T09:53:17.847734Z",
   "id" : "glagakd2",
   "document" : {
     "debug" : {
@@ -218,11 +218,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "glagakd2",
+      "identifiers.value" : [
+        "aCHuXzrv8P"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-05-31T18:33:51.663694Z",
+  "createdAt" : "2022-06-01T09:53:17.848376Z",
   "id" : "wys5lz5r",
   "document" : {
     "debug" : {
@@ -227,11 +227,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "wys5lz5r",
+      "identifiers.value" : [
+        "GWT6gTiZ6K"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
+        "online"
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-05-31T18:33:51.665162Z",
+  "createdAt" : "2022-06-01T09:53:17.848968Z",
   "id" : "iqani2su",
   "document" : {
     "debug" : {
@@ -226,11 +226,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "iqani2su",
+      "identifiers.value" : [
+        "jYpuBxuni2"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
+        "online"
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-05-31T18:33:51.677105Z",
+  "createdAt" : "2022-06-01T09:53:17.914633Z",
   "id" : "yh6sk7pv",
   "document" : {
     "debug" : {
@@ -230,11 +230,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "yh6sk7pv",
+      "identifiers.value" : [
+        "5tbPGXaLqw"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
+        "online"
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.6.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-05-31T18:33:51.679110Z",
+  "createdAt" : "2022-06-01T09:53:17.915782Z",
   "id" : "uqhxoxvf",
   "document" : {
     "debug" : {
@@ -222,11 +222,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "uqhxoxvf",
+      "identifiers.value" : [
+        "Ey1hoMJJvc"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.446542Z",
+  "createdAt" : "2022-06-01T09:53:16.803362Z",
   "id" : "vqys4hio",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "vqys4hio",
+      "identifiers.value" : [
+        "ESZHkohLBq"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "6IZ2DrUzFk"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.448556Z",
+  "createdAt" : "2022-06-01T09:53:16.804901Z",
   "id" : "scernate",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "scernate",
+      "identifiers.value" : [
+        "mxTT1Dnad9"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "6IZ2DrUzFk"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.10.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.464740Z",
+  "createdAt" : "2022-06-01T09:53:16.818141Z",
   "id" : "sw2fzgit",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "sw2fzgit",
+      "identifiers.value" : [
+        "6gzFFn0MzM"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "Vo8KntFwFf"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.11.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.466183Z",
+  "createdAt" : "2022-06-01T09:53:16.819295Z",
   "id" : "4elqjncu",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "4elqjncu",
+      "identifiers.value" : [
+        "WyiVFCEDYI"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "Vo8KntFwFf"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.12.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.468426Z",
+  "createdAt" : "2022-06-01T09:53:16.822123Z",
   "id" : "8yitytyw",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "8yitytyw",
+      "identifiers.value" : [
+        "a33KTr4gSW"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "v4BHmwGTZr"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.13.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.469916Z",
+  "createdAt" : "2022-06-01T09:53:16.824162Z",
   "id" : "66bwuadw",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "66bwuadw",
+      "identifiers.value" : [
+        "t9Z95L7cLo"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "v4BHmwGTZr"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.14.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.471577Z",
+  "createdAt" : "2022-06-01T09:53:16.825955Z",
   "id" : "dborzqld",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "dborzqld",
+      "identifiers.value" : [
+        "xZlpWaXi4Y"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "v4BHmwGTZr"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.15.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.473241Z",
+  "createdAt" : "2022-06-01T09:53:16.827363Z",
   "id" : "fu0kybma",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "fu0kybma",
+      "identifiers.value" : [
+        "SlRRldG9e4"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "v4BHmwGTZr"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.16.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.474776Z",
+  "createdAt" : "2022-06-01T09:53:16.829321Z",
   "id" : "pyub9jxo",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "pyub9jxo",
+      "identifiers.value" : [
+        "qajt54m4dW"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "v4BHmwGTZr"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.17.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.476147Z",
+  "createdAt" : "2022-06-01T09:53:16.830761Z",
   "id" : "izlcv3sm",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "izlcv3sm",
+      "identifiers.value" : [
+        "x0zgHgbzqM"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "v4BHmwGTZr"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.18.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.477635Z",
+  "createdAt" : "2022-06-01T09:53:16.832462Z",
   "id" : "s4ry14qu",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "s4ry14qu",
+      "identifiers.value" : [
+        "Ue8m3HVuer"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "9hdRJC6PIO"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.19.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.478958Z",
+  "createdAt" : "2022-06-01T09:53:16.833994Z",
   "id" : "svr3x3ca",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "svr3x3ca",
+      "identifiers.value" : [
+        "FRfKD3vr5o"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "9hdRJC6PIO"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.451560Z",
+  "createdAt" : "2022-06-01T09:53:16.806341Z",
   "id" : "vpkqafpg",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "vpkqafpg",
+      "identifiers.value" : [
+        "dPAcgpfIbf"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "6IZ2DrUzFk"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.20.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.480165Z",
+  "createdAt" : "2022-06-01T09:53:16.835168Z",
   "id" : "w4lfjuza",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "w4lfjuza",
+      "identifiers.value" : [
+        "P7HD59gW9t"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "9hdRJC6PIO"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.21.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.481531Z",
+  "createdAt" : "2022-06-01T09:53:16.836684Z",
   "id" : "5hlmpzzh",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "5hlmpzzh",
+      "identifiers.value" : [
+        "PyW5z3uVBA"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "9hdRJC6PIO"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.22.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.483164Z",
+  "createdAt" : "2022-06-01T09:53:16.837738Z",
   "id" : "b5lylqvq",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "b5lylqvq",
+      "identifiers.value" : [
+        "DIlUXQf0x4"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "9hdRJC6PIO"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.453226Z",
+  "createdAt" : "2022-06-01T09:53:16.808227Z",
   "id" : "ivw1mq40",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "ivw1mq40",
+      "identifiers.value" : [
+        "zoIhNdLDgG"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "6IZ2DrUzFk"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.454655Z",
+  "createdAt" : "2022-06-01T09:53:16.809758Z",
   "id" : "mxssba8u",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "mxssba8u",
+      "identifiers.value" : [
+        "QnFei9OwDH"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "6IZ2DrUzFk"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.456172Z",
+  "createdAt" : "2022-06-01T09:53:16.811Z",
   "id" : "pi8hxmce",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "pi8hxmce",
+      "identifiers.value" : [
+        "tXxMtg7dko"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "6IZ2DrUzFk"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.6.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.457770Z",
+  "createdAt" : "2022-06-01T09:53:16.812552Z",
   "id" : "lwt2ohte",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "lwt2ohte",
+      "identifiers.value" : [
+        "zOTvHYjPJX"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "Vo8KntFwFf"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.7.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.459128Z",
+  "createdAt" : "2022-06-01T09:53:16.814145Z",
   "id" : "a62ffqxh",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "a62ffqxh",
+      "identifiers.value" : [
+        "dUrbgrWtto"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "Vo8KntFwFf"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.8.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.460797Z",
+  "createdAt" : "2022-06-01T09:53:16.815492Z",
   "id" : "atgvzcvy",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "atgvzcvy",
+      "identifiers.value" : [
+        "za69e7zAIP"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "Vo8KntFwFf"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.9.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-05-31T18:33:51.462973Z",
+  "createdAt" : "2022-06-01T09:53:16.816947Z",
   "id" : "mopzrqzu",
   "document" : {
     "debug" : {
@@ -183,12 +183,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "mopzrqzu",
+      "identifiers.value" : [
+        "DIXUuyd8hW"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "Vo8KntFwFf"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-05-31T18:33:51.578205Z",
+  "createdAt" : "2022-06-01T09:53:17.303232Z",
   "id" : "h5zn9bqm",
   "document" : {
     "debug" : {
@@ -153,11 +153,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "h5zn9bqm",
+      "identifiers.value" : [
+        "OQ6G6Rkv6Q"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-05-31T18:33:51.579035Z",
+  "createdAt" : "2022-06-01T09:53:17.303991Z",
   "id" : "gnuj1it3",
   "document" : {
     "debug" : {
@@ -153,11 +153,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "gnuj1it3",
+      "identifiers.value" : [
+        "Og3KGy7Mz5"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-05-31T18:33:51.581354Z",
+  "createdAt" : "2022-06-01T09:53:17.304776Z",
   "id" : "e1k1l8xu",
   "document" : {
     "debug" : {
@@ -153,11 +153,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "e1k1l8xu",
+      "identifiers.value" : [
+        "Kvqw9fGol7"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-05-31T18:33:51.583612Z",
+  "createdAt" : "2022-06-01T09:53:17.305495Z",
   "id" : "6q7wkowr",
   "document" : {
     "debug" : {
@@ -153,11 +153,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "6q7wkowr",
+      "identifiers.value" : [
+        "AgxJAjEybh"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-05-31T18:33:51.585960Z",
+  "createdAt" : "2022-06-01T09:53:17.306265Z",
   "id" : "cpwnrkdo",
   "document" : {
     "debug" : {
@@ -178,11 +178,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "cpwnrkdo",
+      "identifiers.value" : [
+        "FqozNGJ9Pf"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-05-31T18:33:51.586646Z",
+  "createdAt" : "2022-06-01T09:53:17.306939Z",
   "id" : "bexh6kx6",
   "document" : {
     "debug" : {
@@ -128,11 +128,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "bexh6kx6",
+      "identifiers.value" : [
+        "5q2ktKEnxz"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.different-work-types.Collection.json
+++ b/common/search/src/test/resources/test_documents/works.examples.different-work-types.Collection.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-05-31T18:33:51.520283Z",
+  "createdAt" : "2022-06-01T09:53:17.099709Z",
   "id" : "2tqcclh1",
   "document" : {
     "debug" : {
@@ -128,11 +128,21 @@
       "type" : "Collection"
     },
     "query" : {
+      "id" : "2tqcclh1",
+      "identifiers.value" : [
+        "ZiS5MlN0hQ"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.different-work-types.Section.json
+++ b/common/search/src/test/resources/test_documents/works.examples.different-work-types.Section.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-05-31T18:33:51.516843Z",
+  "createdAt" : "2022-06-01T09:53:17.090505Z",
   "id" : "iw5fnuyy",
   "document" : {
     "debug" : {
@@ -128,11 +128,21 @@
       "type" : "Section"
     },
     "query" : {
+      "id" : "iw5fnuyy",
+      "identifiers.value" : [
+        "Xo35aec2Io"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.different-work-types.Series.json
+++ b/common/search/src/test/resources/test_documents/works.examples.different-work-types.Series.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-05-31T18:33:51.523975Z",
+  "createdAt" : "2022-06-01T09:53:17.107562Z",
   "id" : "fndkxmxs",
   "document" : {
     "debug" : {
@@ -128,11 +128,21 @@
       "type" : "Series"
     },
     "query" : {
+      "id" : "fndkxmxs",
+      "identifiers.value" : [
+        "yW6CgVzwIJ"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-05-31T18:33:51.694287Z",
+  "createdAt" : "2022-06-01T09:53:17.990618Z",
   "id" : "phodmv5g",
   "document" : {
     "debug" : {
@@ -145,11 +145,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "phodmv5g",
+      "identifiers.value" : [
+        "kSl7z2IaIy"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-05-31T18:33:51.696663Z",
+  "createdAt" : "2022-06-01T09:53:17.991248Z",
   "id" : "580nnpfa",
   "document" : {
     "debug" : {
@@ -145,11 +145,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "580nnpfa",
+      "identifiers.value" : [
+        "wz2OkOJHcs"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-05-31T18:33:51.699135Z",
+  "createdAt" : "2022-06-01T09:53:17.992019Z",
   "id" : "jfnymrg2",
   "document" : {
     "debug" : {
@@ -145,11 +145,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "jfnymrg2",
+      "identifiers.value" : [
+        "zrSaF1p8IU"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-05-31T18:33:51.700153Z",
+  "createdAt" : "2022-06-01T09:53:17.992846Z",
   "id" : "lpoz1fy9",
   "document" : {
     "debug" : {
@@ -145,11 +145,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "lpoz1fy9",
+      "identifiers.value" : [
+        "FGpPdnmb6i"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-05-31T18:33:51.701507Z",
+  "createdAt" : "2022-06-01T09:53:17.993510Z",
   "id" : "in2u7aru",
   "document" : {
     "debug" : {
@@ -145,11 +145,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "in2u7aru",
+      "identifiers.value" : [
+        "OHrklHuS07"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-05-31T18:33:51.702475Z",
+  "createdAt" : "2022-06-01T09:53:17.994156Z",
   "id" : "wkzjlx5a",
   "document" : {
     "debug" : {
@@ -145,11 +145,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "wkzjlx5a",
+      "identifiers.value" : [
+        "SKphDnojLC"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.6.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-05-31T18:33:51.703423Z",
+  "createdAt" : "2022-06-01T09:53:17.994607Z",
   "id" : "iykrudzs",
   "document" : {
     "debug" : {
@@ -145,11 +145,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "iykrudzs",
+      "identifiers.value" : [
+        "QnjXRANbEF"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.7.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-05-31T18:33:51.704665Z",
+  "createdAt" : "2022-06-01T09:53:17.996105Z",
   "id" : "pskvh87t",
   "document" : {
     "debug" : {
@@ -145,11 +145,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "pskvh87t",
+      "identifiers.value" : [
+        "lBGTOMLJUB"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.8.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-05-31T18:33:51.705488Z",
+  "createdAt" : "2022-06-01T09:53:17.996667Z",
   "id" : "k57syong",
   "document" : {
     "debug" : {
@@ -145,11 +145,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "k57syong",
+      "identifiers.value" : [
+        "czKSHpT0IR"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.9.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-05-31T18:33:51.706433Z",
+  "createdAt" : "2022-06-01T09:53:17.997451Z",
   "id" : "lkq8nygj",
   "document" : {
     "debug" : {
@@ -145,11 +145,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "lkq8nygj",
+      "identifiers.value" : [
+        "UBhh45MMdu"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-05-31T18:33:51.538411Z",
+  "createdAt" : "2022-06-01T09:53:17.117528Z",
   "id" : "jywtq4xg",
   "document" : {
     "debug" : {
@@ -172,11 +172,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "jywtq4xg",
+      "identifiers.value" : [
+        "LgGFRAV0Zs"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-05-31T18:33:51.541401Z",
+  "createdAt" : "2022-06-01T09:53:17.118645Z",
   "id" : "ahr8n4ei",
   "document" : {
     "debug" : {
@@ -172,11 +172,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "ahr8n4ei",
+      "identifiers.value" : [
+        "g4JnCRDZnk"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-05-31T18:33:51.543672Z",
+  "createdAt" : "2022-06-01T09:53:17.119746Z",
   "id" : "yhjhxcof",
   "document" : {
     "debug" : {
@@ -172,11 +172,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "yhjhxcof",
+      "identifiers.value" : [
+        "lydjDVoexx"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-05-31T18:33:51.545125Z",
+  "createdAt" : "2022-06-01T09:53:17.121372Z",
   "id" : "1mqutqzm",
   "document" : {
     "debug" : {
@@ -172,11 +172,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "1mqutqzm",
+      "identifiers.value" : [
+        "EmqhmRoJyr"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-05-31T18:33:51.546865Z",
+  "createdAt" : "2022-06-01T09:53:17.124380Z",
   "id" : "4btprmwn",
   "document" : {
     "debug" : {
@@ -260,11 +260,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "4btprmwn",
+      "identifiers.value" : [
+        "C7XCeymDdf"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-05-31T18:33:51.547506Z",
+  "createdAt" : "2022-06-01T09:53:17.126068Z",
   "id" : "oo0o5odf",
   "document" : {
     "debug" : {
@@ -128,11 +128,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "oo0o5odf",
+      "identifiers.value" : [
+        "T9fhswtSuP"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-05-31T18:33:51.558865Z",
+  "createdAt" : "2022-06-01T09:53:17.226536Z",
   "id" : "tayys6jp",
   "document" : {
     "debug" : {
@@ -213,6 +213,10 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "tayys6jp",
+      "identifiers.value" : [
+        "3OfWNE6m5y"
+      ],
       "subjects.id" : [
         "sanitati"
       ],
@@ -222,6 +226,12 @@
       ],
       "subjects.label" : [
         "Sanitation."
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-05-31T18:33:51.559772Z",
+  "createdAt" : "2022-06-01T09:53:17.228010Z",
   "id" : "zwggainv",
   "document" : {
     "debug" : {
@@ -175,12 +175,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "zwggainv",
+      "identifiers.value" : [
+        "RdbNpFC2P5"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "London (England)"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-05-31T18:33:51.561049Z",
+  "createdAt" : "2022-06-01T09:53:17.230006Z",
   "id" : "mazaizfa",
   "document" : {
     "debug" : {
@@ -175,12 +175,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "mazaizfa",
+      "identifiers.value" : [
+        "QFJOR9VqAE"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "Psychology, Pathological"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-05-31T18:33:51.563812Z",
+  "createdAt" : "2022-06-01T09:53:17.231249Z",
   "id" : "b1r485o0",
   "document" : {
     "debug" : {
@@ -197,6 +197,10 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "b1r485o0",
+      "identifiers.value" : [
+        "4zh18D0cbF"
+      ],
       "subjects.id" : [
         "darwin01"
       ],
@@ -205,6 +209,12 @@
       ],
       "subjects.label" : [
         "Darwin \"Jones\", Charles"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-05-31T18:33:51.566356Z",
+  "createdAt" : "2022-06-01T09:53:17.233055Z",
   "id" : "gmzc1icz",
   "document" : {
     "debug" : {
@@ -291,6 +291,10 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "gmzc1icz",
+      "identifiers.value" : [
+        "Q8QOPJdAXF"
+      ],
       "subjects.id" : [
         "darwin01"
       ],
@@ -301,6 +305,12 @@
         "London (England)",
         "Psychology, Pathological",
         "Darwin \"Jones\", Charles"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-05-31T18:33:51.567651Z",
+  "createdAt" : "2022-06-01T09:53:17.235797Z",
   "id" : "rbao66qq",
   "document" : {
     "debug" : {
@@ -128,11 +128,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "rbao66qq",
+      "identifiers.value" : [
+        "5hoUH5ZhFq"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.formats.0.Books.json
+++ b/common/search/src/test/resources/test_documents/works.formats.0.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-05-31T18:33:51.074940Z",
+  "createdAt" : "2022-06-01T09:53:15.774695Z",
   "id" : "gfw8fs9l",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "gfw8fs9l",
+      "identifiers.value" : [
+        "wayOhJ3Mha"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.formats.1.Books.json
+++ b/common/search/src/test/resources/test_documents/works.formats.1.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-05-31T18:33:51.078887Z",
+  "createdAt" : "2022-06-01T09:53:15.788203Z",
   "id" : "ciweswu5",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "ciweswu5",
+      "identifiers.value" : [
+        "ESu6j0cajz"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.formats.2.Books.json
+++ b/common/search/src/test/resources/test_documents/works.formats.2.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-05-31T18:33:51.083472Z",
+  "createdAt" : "2022-06-01T09:53:15.799383Z",
   "id" : "j27g6hhl",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "j27g6hhl",
+      "identifiers.value" : [
+        "vyeItSna2X"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.formats.3.Books.json
+++ b/common/search/src/test/resources/test_documents/works.formats.3.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-05-31T18:33:51.086243Z",
+  "createdAt" : "2022-06-01T09:53:15.809061Z",
   "id" : "bujceq4p",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "bujceq4p",
+      "identifiers.value" : [
+        "HuLHN83UU0"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.formats.4.Journals.json
+++ b/common/search/src/test/resources/test_documents/works.formats.4.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-05-31T18:33:51.090350Z",
+  "createdAt" : "2022-06-01T09:53:15.819716Z",
   "id" : "wqcumcet",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "wqcumcet",
+      "identifiers.value" : [
+        "vc628Sgu9f"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.formats.5.Journals.json
+++ b/common/search/src/test/resources/test_documents/works.formats.5.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-05-31T18:33:51.093288Z",
+  "createdAt" : "2022-06-01T09:53:15.833878Z",
   "id" : "plmmmkup",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "plmmmkup",
+      "identifiers.value" : [
+        "X7kBc19InD"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.formats.6.Journals.json
+++ b/common/search/src/test/resources/test_documents/works.formats.6.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-05-31T18:33:51.096585Z",
+  "createdAt" : "2022-06-01T09:53:15.845332Z",
   "id" : "xc5d7pc4",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "xc5d7pc4",
+      "identifiers.value" : [
+        "HXsUYY6dN4"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.formats.7.Audio.json
+++ b/common/search/src/test/resources/test_documents/works.formats.7.Audio.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-05-31T18:33:51.101696Z",
+  "createdAt" : "2022-06-01T09:53:15.856389Z",
   "id" : "t3q2ufnz",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "t3q2ufnz",
+      "identifiers.value" : [
+        "nNHPpdWbrm"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.formats.8.Audio.json
+++ b/common/search/src/test/resources/test_documents/works.formats.8.Audio.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-05-31T18:33:51.103995Z",
+  "createdAt" : "2022-06-01T09:53:15.868130Z",
   "id" : "elrgwjtd",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "elrgwjtd",
+      "identifiers.value" : [
+        "RMKkkMWH2B"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.formats.9.Pictures.json
+++ b/common/search/src/test/resources/test_documents/works.formats.9.Pictures.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-05-31T18:33:51.106640Z",
+  "createdAt" : "2022-06-01T09:53:15.884881Z",
   "id" : "sym6ne7x",
   "document" : {
     "debug" : {
@@ -136,11 +136,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "sym6ne7x",
+      "identifiers.value" : [
+        "FRzpe3bQyh"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.genres.json
+++ b/common/search/src/test/resources/test_documents/works.genres.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with different concepts in the genre",
-  "createdAt" : "2022-05-31T18:33:51.201994Z",
+  "createdAt" : "2022-06-01T09:53:16.122326Z",
   "id" : "2zo588up",
   "document" : {
     "debug" : {
@@ -195,11 +195,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "2zo588up",
+      "identifiers.value" : [
+        "rVoekomuzt"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.0.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-05-31T18:33:51.158646Z",
+  "createdAt" : "2022-06-01T09:53:16.007356Z",
   "id" : "yodfctxx",
   "document" : {
     "debug" : {
@@ -175,11 +175,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "yodfctxx",
+      "identifiers.value" : [
+        "HfU454vgiI"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.1.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-05-31T18:33:51.161591Z",
+  "createdAt" : "2022-06-01T09:53:16.009045Z",
   "id" : "runiusy8",
   "document" : {
     "debug" : {
@@ -177,11 +177,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "runiusy8",
+      "identifiers.value" : [
+        "ZGWEGMyTaq"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.2.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-05-31T18:33:51.164297Z",
+  "createdAt" : "2022-06-01T09:53:16.010297Z",
   "id" : "ougtipki",
   "document" : {
     "debug" : {
@@ -175,11 +175,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "ougtipki",
+      "identifiers.value" : [
+        "fbITZO5oAg"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.3.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-05-31T18:33:51.165775Z",
+  "createdAt" : "2022-06-01T09:53:16.011834Z",
   "id" : "rstrzip9",
   "document" : {
     "debug" : {
@@ -226,11 +226,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "rstrzip9",
+      "identifiers.value" : [
+        "AbkJTEEoLH"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.4.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-05-31T18:33:51.166608Z",
+  "createdAt" : "2022-06-01T09:53:16.012766Z",
   "id" : "vwg1cj2y",
   "document" : {
     "debug" : {
@@ -128,11 +128,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "vwg1cj2y",
+      "identifiers.value" : [
+        "FIC2DNd6NA"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.0.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-05-31T18:33:51.294681Z",
+  "createdAt" : "2022-06-01T09:53:16.325356Z",
   "id" : "qjnwiqbs",
   "document" : {
     "debug" : {
@@ -211,11 +211,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "qjnwiqbs",
+      "identifiers.value" : [
+        "Jj1GugWgka"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.1.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-05-31T18:33:51.296607Z",
+  "createdAt" : "2022-06-01T09:53:16.328587Z",
   "id" : "upm4bal7",
   "document" : {
     "debug" : {
@@ -212,11 +212,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "upm4bal7",
+      "identifiers.value" : [
+        "wkKE1s2opA"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.2.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-05-31T18:33:51.298515Z",
+  "createdAt" : "2022-06-01T09:53:16.330278Z",
   "id" : "zbejhda8",
   "document" : {
     "debug" : {
@@ -212,11 +212,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "zbejhda8",
+      "identifiers.value" : [
+        "l7ykrmHfSg"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.3.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-05-31T18:33:51.300345Z",
+  "createdAt" : "2022-06-01T09:53:16.332207Z",
   "id" : "pex9vogp",
   "document" : {
     "debug" : {
@@ -213,11 +213,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "pex9vogp",
+      "identifiers.value" : [
+        "MEUfT3H8Xn"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.4.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-05-31T18:33:51.301900Z",
+  "createdAt" : "2022-06-01T09:53:16.333249Z",
   "id" : "c5xw2xfj",
   "document" : {
     "debug" : {
@@ -213,11 +213,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "c5xw2xfj",
+      "identifiers.value" : [
+        "fREqoThymw"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.languages.0.eng.json
+++ b/common/search/src/test/resources/test_documents/works.languages.0.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-05-31T18:33:51.116087Z",
+  "createdAt" : "2022-06-01T09:53:15.918370Z",
   "id" : "i8zcsj78",
   "document" : {
     "debug" : {
@@ -137,11 +137,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "i8zcsj78",
+      "identifiers.value" : [
+        "ZquhBnzQPW"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.languages.1.eng.json
+++ b/common/search/src/test/resources/test_documents/works.languages.1.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-05-31T18:33:51.118687Z",
+  "createdAt" : "2022-06-01T09:53:15.931349Z",
   "id" : "qn97gvxq",
   "document" : {
     "debug" : {
@@ -137,11 +137,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "qn97gvxq",
+      "identifiers.value" : [
+        "BbZQhYTTwR"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.languages.2.eng.json
+++ b/common/search/src/test/resources/test_documents/works.languages.2.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-05-31T18:33:51.121511Z",
+  "createdAt" : "2022-06-01T09:53:15.942316Z",
   "id" : "yhrq0rmr",
   "document" : {
     "debug" : {
@@ -137,11 +137,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "yhrq0rmr",
+      "identifiers.value" : [
+        "tXlgR2VtcJ"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.languages.3.eng+swe.json
+++ b/common/search/src/test/resources/test_documents/works.languages.3.eng+swe.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-05-31T18:33:51.124833Z",
+  "createdAt" : "2022-06-01T09:53:15.953559Z",
   "id" : "ioqwetut",
   "document" : {
     "debug" : {
@@ -146,11 +146,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "ioqwetut",
+      "identifiers.value" : [
+        "5WuJppwWsm"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.languages.4.eng+swe+tur.json
+++ b/common/search/src/test/resources/test_documents/works.languages.4.eng+swe+tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-05-31T18:33:51.129453Z",
+  "createdAt" : "2022-06-01T09:53:15.964294Z",
   "id" : "edfiesed",
   "document" : {
     "debug" : {
@@ -155,11 +155,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "edfiesed",
+      "identifiers.value" : [
+        "tQZYPmQieO"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.languages.5.swe.json
+++ b/common/search/src/test/resources/test_documents/works.languages.5.swe.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-05-31T18:33:51.138068Z",
+  "createdAt" : "2022-06-01T09:53:15.977711Z",
   "id" : "qfscz1rj",
   "document" : {
     "debug" : {
@@ -137,11 +137,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "qfscz1rj",
+      "identifiers.value" : [
+        "Gk6juMbOeK"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.languages.6.tur.json
+++ b/common/search/src/test/resources/test_documents/works.languages.6.tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-05-31T18:33:51.144746Z",
+  "createdAt" : "2022-06-01T09:53:15.991557Z",
   "id" : "yblbdpjf",
   "document" : {
     "debug" : {
@@ -137,11 +137,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "yblbdpjf",
+      "identifiers.value" : [
+        "vcw0LP9LzQ"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.0.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-05-31T18:33:51.404542Z",
+  "createdAt" : "2022-06-01T09:53:16.660780Z",
   "id" : "31spt9st",
   "document" : {
     "debug" : {
@@ -186,11 +186,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "31spt9st",
+      "identifiers.value" : [
+        "WzsZA7OUAa"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.1.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-05-31T18:33:51.406945Z",
+  "createdAt" : "2022-06-01T09:53:16.661951Z",
   "id" : "v9is9e3t",
   "document" : {
     "debug" : {
@@ -186,11 +186,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "v9is9e3t",
+      "identifiers.value" : [
+        "fZVe3xG7r6"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.2.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-05-31T18:33:51.408812Z",
+  "createdAt" : "2022-06-01T09:53:16.663114Z",
   "id" : "wg3kq4ux",
   "document" : {
     "debug" : {
@@ -186,11 +186,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "wg3kq4ux",
+      "identifiers.value" : [
+        "lfq9upMxJZ"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.3.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-05-31T18:33:51.410269Z",
+  "createdAt" : "2022-06-01T09:53:16.664549Z",
   "id" : "q4abgj9v",
   "document" : {
     "debug" : {
@@ -186,11 +186,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "q4abgj9v",
+      "identifiers.value" : [
+        "09dkccFCHG"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.4.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-05-31T18:33:51.411576Z",
+  "createdAt" : "2022-06-01T09:53:16.666226Z",
   "id" : "cuh8ak2g",
   "document" : {
     "debug" : {
@@ -186,11 +186,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "cuh8ak2g",
+      "identifiers.value" : [
+        "KabHlF2fhJ"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.5.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-05-31T18:33:51.413014Z",
+  "createdAt" : "2022-06-01T09:53:16.667344Z",
   "id" : "wmzcsqaf",
   "document" : {
     "debug" : {
@@ -186,11 +186,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "wmzcsqaf",
+      "identifiers.value" : [
+        "Kwytcvu6mF"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.subjects.0.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-05-31T18:33:51.217793Z",
+  "createdAt" : "2022-06-01T09:53:16.140071Z",
   "id" : "6uwysojy",
   "document" : {
     "debug" : {
@@ -175,12 +175,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "6uwysojy",
+      "identifiers.value" : [
+        "pzLgxSR5EK"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "paleoNeuroBiology"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.subjects.1.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-05-31T18:33:51.220146Z",
+  "createdAt" : "2022-06-01T09:53:16.141854Z",
   "id" : "mihwfxry",
   "document" : {
     "debug" : {
@@ -175,12 +175,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "mihwfxry",
+      "identifiers.value" : [
+        "HypKD9r1zH"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "realAnalysis"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.subjects.2.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-05-31T18:33:51.225417Z",
+  "createdAt" : "2022-06-01T09:53:16.144639Z",
   "id" : "evraub2i",
   "document" : {
     "debug" : {
@@ -175,12 +175,22 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "evraub2i",
+      "identifiers.value" : [
+        "E3Fqby26w1"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
         "realAnalysis"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.subjects.3.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-05-31T18:33:51.230960Z",
+  "createdAt" : "2022-06-01T09:53:16.146379Z",
   "id" : "xcssabt1",
   "document" : {
     "debug" : {
@@ -222,6 +222,10 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "xcssabt1",
+      "identifiers.value" : [
+        "7XE0Jxv45o"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
@@ -229,6 +233,12 @@
       "subjects.label" : [
         "paleoNeuroBiology",
         "realAnalysis"
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.subjects.4.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-05-31T18:33:51.233199Z",
+  "createdAt" : "2022-06-01T09:53:16.147462Z",
   "id" : "t9nj8zse",
   "document" : {
     "debug" : {
@@ -128,11 +128,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "t9nj8zse",
+      "identifiers.value" : [
+        "8imBUVPHmu"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.title-query-parens.json
+++ b/common/search/src/test/resources/test_documents/works.title-query-parens.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has parens meant to trip up ES",
-  "createdAt" : "2022-05-31T18:33:51.111575Z",
+  "createdAt" : "2022-06-01T09:53:15.906185Z",
   "id" : "omok5a37",
   "document" : {
     "debug" : {
@@ -128,11 +128,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "omok5a37",
+      "identifiers.value" : [
+        "y59nY1Nuok"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.title-query-syntax.json
+++ b/common/search/src/test/resources/test_documents/works.title-query-syntax.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has lots of ES query syntax operators",
-  "createdAt" : "2022-05-31T18:33:51.108995Z",
+  "createdAt" : "2022-06-01T09:53:15.896223Z",
   "id" : "hjjs3mu3",
   "document" : {
     "debug" : {
@@ -128,11 +128,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "hjjs3mu3",
+      "identifiers.value" : [
+        "Z3LIdvnOPk"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.visible.0.json
+++ b/common/search/src/test/resources/test_documents/works.visible.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-05-31T18:33:50.410053Z",
+  "createdAt" : "2022-06-01T09:53:13.344185Z",
   "id" : "2twopft1",
   "document" : {
     "debug" : {
@@ -128,11 +128,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "2twopft1",
+      "identifiers.value" : [
+        "Uaequ81tpB"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.visible.1.json
+++ b/common/search/src/test/resources/test_documents/works.visible.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-05-31T18:33:50.413039Z",
+  "createdAt" : "2022-06-01T09:53:13.357867Z",
   "id" : "dph7sjip",
   "document" : {
     "debug" : {
@@ -128,11 +128,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "dph7sjip",
+      "identifiers.value" : [
+        "WpBejTwv1N"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.visible.2.json
+++ b/common/search/src/test/resources/test_documents/works.visible.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-05-31T18:33:50.415671Z",
+  "createdAt" : "2022-06-01T09:53:13.361879Z",
   "id" : "fyqts0co",
   "document" : {
     "debug" : {
@@ -128,11 +128,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "fyqts0co",
+      "identifiers.value" : [
+        "ZvWebpA5WH"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.visible.3.json
+++ b/common/search/src/test/resources/test_documents/works.visible.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-05-31T18:33:50.417982Z",
+  "createdAt" : "2022-06-01T09:53:13.365259Z",
   "id" : "raob2ruv",
   "document" : {
     "debug" : {
@@ -128,11 +128,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "raob2ruv",
+      "identifiers.value" : [
+        "wyJzS2SuiH"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/common/search/src/test/resources/test_documents/works.visible.4.json
+++ b/common/search/src/test/resources/test_documents/works.visible.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-05-31T18:33:50.420316Z",
+  "createdAt" : "2022-06-01T09:53:13.367640Z",
   "id" : "vbi1ii19",
   "document" : {
     "debug" : {
@@ -128,11 +128,21 @@
       "type" : "Work"
     },
     "query" : {
+      "id" : "vbi1ii19",
+      "identifiers.value" : [
+        "CzLNHBFHuR"
+      ],
       "subjects.id" : [
       ],
       "subjects.identifiers.value" : [
       ],
       "subjects.label" : [
+      ],
+      "partOf.id" : [
+      ],
+      "partOf.title" : [
+      ],
+      "availabilities.id" : [
       ]
     },
     "aggregatableValues" : {

--- a/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -66,9 +66,8 @@ case object WorksMultiMatcher {
           fields = fieldsWithBoost(
             boost = 1000,
             Seq(
-              "state.canonicalId",
-              "state.sourceIdentifier.value",
-              "data.otherIdentifiers.value",
+              "query.id",
+              "query.identifiers.value",
               "data.items.id.canonicalId",
               "data.items.id.sourceIdentifier.value",
               "data.items.id.otherIdentifiers.value",

--- a/search/src/main/scala/weco/api/search/services/WorksRequestBuilder.scala
+++ b/search/src/main/scala/weco/api/search/services/WorksRequestBuilder.scala
@@ -20,7 +20,7 @@ object WorksRequestBuilder
 
   import ElasticsearchRequestBuilder._
 
-  val idSort: FieldSort = fieldSort("state.canonicalId").order(SortOrder.ASC)
+  val idSort: FieldSort = fieldSort("query.id").order(SortOrder.ASC)
 
   def request(searchOptions: WorkSearchOptions, index: Index): SearchRequest = {
     implicit val s = searchOptions
@@ -176,11 +176,7 @@ object WorksRequestBuilder
       case IdentifiersFilter(identifiers) =>
         should(
           termsQuery(
-            field = "state.sourceIdentifier.value",
-            values = identifiers
-          ),
-          termsQuery(
-            field = "data.otherIdentifiers.value",
+            field = "query.identifiers.value",
             values = identifiers
           )
         )
@@ -236,11 +232,11 @@ object WorksRequestBuilder
              separate non-analysed version of title for term matching.
              */
             matchPhraseQuery(
-              field = "state.relations.ancestors.title",
+              field = "query.partOf.title",
               value = search_term
             ),
             termQuery(
-              field = "state.relations.ancestors.id",
+              field = "query.partOf.id",
               value = search_term
             )
           ),
@@ -248,12 +244,12 @@ object WorksRequestBuilder
         )
       case PartOfTitleFilter(search_term) =>
         termQuery(
-          field = "state.relations.ancestors.title.keyword",
+          field = "query.partOf.title.keyword",
           value = search_term
         )
       case AvailabilitiesFilter(availabilityIds) =>
         termsQuery(
-          field = "state.availabilities.id",
+          field = "query.availabilities.id",
           values = availabilityIds
         )
     }

--- a/search/src/test/resources/WorksMultiMatcherQuery.json
+++ b/search/src/test/resources/WorksMultiMatcherQuery.json
@@ -17,9 +17,8 @@
         "multi_match": {
           "query": "{{query}}",
           "fields": [
-            "state.canonicalId^1000.0",
-            "state.sourceIdentifier.value^1000.0",
-            "data.otherIdentifiers.value^1000.0",
+            "query.id^1000.0",
+            "query.identifiers.value^1000.0",
             "data.items.id.canonicalId^1000.0",
             "data.items.id.sourceIdentifier.value^1000.0",
             "data.items.id.otherIdentifiers.value^1000.0",


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5550; accompanies https://github.com/wellcomecollection/catalogue-pipeline/pull/2107

This is a much smaller change than the diff implies; most of it is copying across autogenerated test documents. All the interesting stuff is in the final commit.

This repo is now totally divorced from `WorkState.Indexed`; it no longer uses it. We can't get rid of it quite yet because it's used for some copyTo in the Elasticsearch mapping, but we're getting closer to removing it.

