### PR TITLE
Use the 2022-06-18 index

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
@@ -10,7 +10,7 @@ case class ElasticConfig(
 trait ElasticConfigBase {
   // We use this to share config across API applications
   // i.e. The API and the snapshot generator.
-  val pipelineDate = "2022-06-17"
+  val pipelineDate = "2022-06-18"
 }
 
 object PipelineClusterElasticConfig extends ElasticConfigBase {

--- a/common/search/src/test/resources/ImagesIndexConfig.json
+++ b/common/search/src/test/resources/ImagesIndexConfig.json
@@ -173,921 +173,457 @@
       },
       "source" : {
         "type" : "object",
+        "dynamic" : "false",
         "properties" : {
-          "canonicalWork" : {
-            "type" : "object",
-            "properties" : {
-              "id" : {
-                "type" : "object",
-                "properties" : {
-                  "canonicalId" : {
-                    "type" : "keyword",
-                    "normalizer" : "lowercase_normalizer"
-                  },
-                  "sourceIdentifier" : {
-                    "type" : "object",
-                    "properties" : {
-                      "value" : {
-                        "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
-                      }
-                    },
-                    "dynamic" : "false"
-                  }
-                }
+          "id": {
+            "type": "object",
+            "properties": {
+              "canonicalId": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer"
               },
-              "data" : {
-                "type" : "object",
-                "properties" : {
-                  "otherIdentifiers" : {
-                    "type" : "object",
-                    "properties" : {
-                      "value" : {
-                        "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
-                      }
-                    }
-                  },
-                  "title" : {
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
-                      },
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english_analyzer"
-                      },
-                      "shingles" : {
-                        "type" : "text",
-                        "analyzer" : "shingle_asciifolding_analyzer"
-                      },
-                      "arabic" : {
-                        "type" : "text",
-                        "analyzer" : "arabic_analyzer"
-                      },
-                      "bengali" : {
-                        "type" : "text",
-                        "analyzer" : "bengali_analyzer"
-                      },
-                      "french" : {
-                        "type" : "text",
-                        "analyzer" : "french_analyzer"
-                      },
-                      "german" : {
-                        "type" : "text",
-                        "analyzer" : "german_analyzer"
-                      },
-                      "hindi" : {
-                        "type" : "text",
-                        "analyzer" : "hindi_analyzer"
-                      },
-                      "italian" : {
-                        "type" : "text",
-                        "analyzer" : "italian_analyzer"
-                      }
-                    }
-                  },
-                  "alternativeTitles" : {
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
-                      },
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english_analyzer"
-                      },
-                      "shingles" : {
-                        "type" : "text",
-                        "analyzer" : "shingle_asciifolding_analyzer"
-                      },
-                      "arabic" : {
-                        "type" : "text",
-                        "analyzer" : "arabic_analyzer"
-                      },
-                      "bengali" : {
-                        "type" : "text",
-                        "analyzer" : "bengali_analyzer"
-                      },
-                      "french" : {
-                        "type" : "text",
-                        "analyzer" : "french_analyzer"
-                      },
-                      "german" : {
-                        "type" : "text",
-                        "analyzer" : "german_analyzer"
-                      },
-                      "hindi" : {
-                        "type" : "text",
-                        "analyzer" : "hindi_analyzer"
-                      },
-                      "italian" : {
-                        "type" : "text",
-                        "analyzer" : "italian_analyzer"
-                      }
-                    }
-                  },
-                  "description" : {
-                    "type" : "text",
-                    "fields" : {
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english_analyzer"
-                      },
-                      "shingles" : {
-                        "type" : "text",
-                        "analyzer" : "shingle_asciifolding_analyzer"
-                      },
-                      "arabic" : {
-                        "type" : "text",
-                        "analyzer" : "arabic_analyzer"
-                      },
-                      "bengali" : {
-                        "type" : "text",
-                        "analyzer" : "bengali_analyzer"
-                      },
-                      "french" : {
-                        "type" : "text",
-                        "analyzer" : "french_analyzer"
-                      },
-                      "german" : {
-                        "type" : "text",
-                        "analyzer" : "german_analyzer"
-                      },
-                      "hindi" : {
-                        "type" : "text",
-                        "analyzer" : "hindi_analyzer"
-                      },
-                      "italian" : {
-                        "type" : "text",
-                        "analyzer" : "italian_analyzer"
-                      }
-                    }
-                  },
-                  "physicalDescription" : {
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "type" : "keyword"
-                      },
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english"
-                      }
-                    }
-                  },
-                  "lettering" : {
-                    "type" : "text",
-                    "fields" : {
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english_analyzer"
-                      },
-                      "shingles" : {
-                        "type" : "text",
-                        "analyzer" : "shingle_asciifolding_analyzer"
-                      },
-                      "arabic" : {
-                        "type" : "text",
-                        "analyzer" : "arabic_analyzer"
-                      },
-                      "bengali" : {
-                        "type" : "text",
-                        "analyzer" : "bengali_analyzer"
-                      },
-                      "french" : {
-                        "type" : "text",
-                        "analyzer" : "french_analyzer"
-                      },
-                      "german" : {
-                        "type" : "text",
-                        "analyzer" : "german_analyzer"
-                      },
-                      "hindi" : {
-                        "type" : "text",
-                        "analyzer" : "hindi_analyzer"
-                      },
-                      "italian" : {
-                        "type" : "text",
-                        "analyzer" : "italian_analyzer"
-                      }
-                    }
-                  },
-                  "contributors" : {
-                    "type" : "object",
-                    "properties" : {
-                      "agent" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "subjects" : {
-                    "type" : "object",
-                    "properties" : {
-                      "concepts" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "genres" : {
-                    "type" : "object",
-                    "properties" : {
-                      "label" : {
-                        "type" : "text",
-                        "analyzer" : "asciifolding_analyzer",
-                        "fields" : {
-                          "keyword" : {
-                            "type" : "keyword"
-                          },
-                          "lowercaseKeyword" : {
-                            "type" : "keyword",
-                            "normalizer" : "lowercase_normalizer"
-                          }
-                        }
-                      },
-                      "concepts" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "production" : {
-                    "type" : "object",
-                    "properties" : {
-                      "places" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "agents" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "dates" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "function" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "languages" : {
-                    "type" : "object",
-                    "properties" : {
-                      "label" : {
-                        "type" : "text",
-                        "analyzer" : "asciifolding_analyzer",
-                        "fields" : {
-                          "keyword" : {
-                            "type" : "keyword"
-                          },
-                          "lowercaseKeyword" : {
-                            "type" : "keyword",
-                            "normalizer" : "lowercase_normalizer"
-                          }
-                        }
-                      },
-                      "id" : {
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "edition" : {
-                    "type" : "text"
-                  },
-                  "notes" : {
-                    "type" : "object",
-                    "properties" : {
-                      "content" : {
-                        "type" : "text",
-                        "fields" : {
-                          "english" : {
-                            "type" : "text",
-                            "analyzer" : "english_analyzer"
-                          },
-                          "shingles" : {
-                            "type" : "text",
-                            "analyzer" : "shingle_asciifolding_analyzer"
-                          },
-                          "arabic" : {
-                            "type" : "text",
-                            "analyzer" : "arabic_analyzer"
-                          },
-                          "bengali" : {
-                            "type" : "text",
-                            "analyzer" : "bengali_analyzer"
-                          },
-                          "french" : {
-                            "type" : "text",
-                            "analyzer" : "french_analyzer"
-                          },
-                          "german" : {
-                            "type" : "text",
-                            "analyzer" : "german_analyzer"
-                          },
-                          "hindi" : {
-                            "type" : "text",
-                            "analyzer" : "hindi_analyzer"
-                          },
-                          "italian" : {
-                            "type" : "text",
-                            "analyzer" : "italian_analyzer"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "collectionPath" : {
-                    "type" : "object",
-                    "properties" : {
-                      "label" : {
-                        "type" : "text",
-                        "analyzer" : "asciifolding_analyzer",
-                        "fields" : {
-                          "keyword" : {
-                            "type" : "keyword"
-                          },
-                          "lowercaseKeyword" : {
-                            "type" : "keyword",
-                            "normalizer" : "lowercase_normalizer"
-                          }
-                        }
-                      },
-                      "path" : {
-                        "type" : "text"
-                      }
-                    }
+              "sourceIdentifier": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "keyword",
+                    "normalizer": "lowercase_normalizer"
                   }
-                }
-              },
-              "type" : {
-                "type" : "keyword"
+                },
+                "dynamic": "false"
               }
-            },
-            "dynamic" : "false"
+            }
           },
-          "redirectedWork" : {
-            "type" : "object",
-            "properties" : {
-              "id" : {
-                "type" : "object",
-                "properties" : {
-                  "canonicalId" : {
-                    "type" : "keyword",
-                    "normalizer" : "lowercase_normalizer"
-                  },
-                  "sourceIdentifier" : {
-                    "type" : "object",
-                    "properties" : {
-                      "value" : {
-                        "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
-                      }
-                    },
-                    "dynamic" : "false"
+          "data": {
+            "type": "object",
+            "properties": {
+              "otherIdentifiers": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "keyword",
+                    "normalizer": "lowercase_normalizer"
                   }
                 }
               },
-              "data" : {
-                "type" : "object",
-                "properties" : {
-                  "otherIdentifiers" : {
-                    "type" : "object",
-                    "properties" : {
-                      "value" : {
-                        "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
-                      }
-                    }
+              "title": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "normalizer": "lowercase_normalizer"
                   },
-                  "title" : {
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
-                      },
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english_analyzer"
-                      },
-                      "shingles" : {
-                        "type" : "text",
-                        "analyzer" : "shingle_asciifolding_analyzer"
-                      },
-                      "arabic" : {
-                        "type" : "text",
-                        "analyzer" : "arabic_analyzer"
-                      },
-                      "bengali" : {
-                        "type" : "text",
-                        "analyzer" : "bengali_analyzer"
-                      },
-                      "french" : {
-                        "type" : "text",
-                        "analyzer" : "french_analyzer"
-                      },
-                      "german" : {
-                        "type" : "text",
-                        "analyzer" : "german_analyzer"
-                      },
-                      "hindi" : {
-                        "type" : "text",
-                        "analyzer" : "hindi_analyzer"
-                      },
-                      "italian" : {
-                        "type" : "text",
-                        "analyzer" : "italian_analyzer"
-                      }
-                    }
+                  "english": {
+                    "type": "text",
+                    "analyzer": "english_analyzer"
                   },
-                  "alternativeTitles" : {
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "type" : "keyword",
-                        "normalizer" : "lowercase_normalizer"
-                      },
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english_analyzer"
-                      },
-                      "shingles" : {
-                        "type" : "text",
-                        "analyzer" : "shingle_asciifolding_analyzer"
-                      },
-                      "arabic" : {
-                        "type" : "text",
-                        "analyzer" : "arabic_analyzer"
-                      },
-                      "bengali" : {
-                        "type" : "text",
-                        "analyzer" : "bengali_analyzer"
-                      },
-                      "french" : {
-                        "type" : "text",
-                        "analyzer" : "french_analyzer"
-                      },
-                      "german" : {
-                        "type" : "text",
-                        "analyzer" : "german_analyzer"
-                      },
-                      "hindi" : {
-                        "type" : "text",
-                        "analyzer" : "hindi_analyzer"
-                      },
-                      "italian" : {
-                        "type" : "text",
-                        "analyzer" : "italian_analyzer"
-                      }
-                    }
+                  "shingles": {
+                    "type": "text",
+                    "analyzer": "shingle_asciifolding_analyzer"
                   },
-                  "description" : {
-                    "type" : "text",
-                    "fields" : {
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english_analyzer"
-                      },
-                      "shingles" : {
-                        "type" : "text",
-                        "analyzer" : "shingle_asciifolding_analyzer"
-                      },
-                      "arabic" : {
-                        "type" : "text",
-                        "analyzer" : "arabic_analyzer"
-                      },
-                      "bengali" : {
-                        "type" : "text",
-                        "analyzer" : "bengali_analyzer"
-                      },
-                      "french" : {
-                        "type" : "text",
-                        "analyzer" : "french_analyzer"
-                      },
-                      "german" : {
-                        "type" : "text",
-                        "analyzer" : "german_analyzer"
-                      },
-                      "hindi" : {
-                        "type" : "text",
-                        "analyzer" : "hindi_analyzer"
-                      },
-                      "italian" : {
-                        "type" : "text",
-                        "analyzer" : "italian_analyzer"
-                      }
-                    }
+                  "arabic": {
+                    "type": "text",
+                    "analyzer": "arabic_analyzer"
                   },
-                  "physicalDescription" : {
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "type" : "keyword"
-                      },
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english"
-                      }
-                    }
+                  "bengali": {
+                    "type": "text",
+                    "analyzer": "bengali_analyzer"
                   },
-                  "lettering" : {
-                    "type" : "text",
-                    "fields" : {
-                      "english" : {
-                        "type" : "text",
-                        "analyzer" : "english_analyzer"
-                      },
-                      "shingles" : {
-                        "type" : "text",
-                        "analyzer" : "shingle_asciifolding_analyzer"
-                      },
-                      "arabic" : {
-                        "type" : "text",
-                        "analyzer" : "arabic_analyzer"
-                      },
-                      "bengali" : {
-                        "type" : "text",
-                        "analyzer" : "bengali_analyzer"
-                      },
-                      "french" : {
-                        "type" : "text",
-                        "analyzer" : "french_analyzer"
-                      },
-                      "german" : {
-                        "type" : "text",
-                        "analyzer" : "german_analyzer"
-                      },
-                      "hindi" : {
-                        "type" : "text",
-                        "analyzer" : "hindi_analyzer"
-                      },
-                      "italian" : {
-                        "type" : "text",
-                        "analyzer" : "italian_analyzer"
-                      }
-                    }
+                  "french": {
+                    "type": "text",
+                    "analyzer": "french_analyzer"
                   },
-                  "contributors" : {
-                    "type" : "object",
-                    "properties" : {
-                      "agent" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
+                  "german": {
+                    "type": "text",
+                    "analyzer": "german_analyzer"
                   },
-                  "subjects" : {
-                    "type" : "object",
-                    "properties" : {
-                      "concepts" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
+                  "hindi": {
+                    "type": "text",
+                    "analyzer": "hindi_analyzer"
                   },
-                  "genres" : {
-                    "type" : "object",
-                    "properties" : {
-                      "label" : {
-                        "type" : "text",
-                        "analyzer" : "asciifolding_analyzer",
-                        "fields" : {
-                          "keyword" : {
-                            "type" : "keyword"
+                  "italian": {
+                    "type": "text",
+                    "analyzer": "italian_analyzer"
+                  }
+                }
+              },
+              "alternativeTitles": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "normalizer": "lowercase_normalizer"
+                  },
+                  "english": {
+                    "type": "text",
+                    "analyzer": "english_analyzer"
+                  },
+                  "shingles": {
+                    "type": "text",
+                    "analyzer": "shingle_asciifolding_analyzer"
+                  },
+                  "arabic": {
+                    "type": "text",
+                    "analyzer": "arabic_analyzer"
+                  },
+                  "bengali": {
+                    "type": "text",
+                    "analyzer": "bengali_analyzer"
+                  },
+                  "french": {
+                    "type": "text",
+                    "analyzer": "french_analyzer"
+                  },
+                  "german": {
+                    "type": "text",
+                    "analyzer": "german_analyzer"
+                  },
+                  "hindi": {
+                    "type": "text",
+                    "analyzer": "hindi_analyzer"
+                  },
+                  "italian": {
+                    "type": "text",
+                    "analyzer": "italian_analyzer"
+                  }
+                }
+              },
+              "description": {
+                "type": "text",
+                "fields": {
+                  "english": {
+                    "type": "text",
+                    "analyzer": "english_analyzer"
+                  },
+                  "shingles": {
+                    "type": "text",
+                    "analyzer": "shingle_asciifolding_analyzer"
+                  },
+                  "arabic": {
+                    "type": "text",
+                    "analyzer": "arabic_analyzer"
+                  },
+                  "bengali": {
+                    "type": "text",
+                    "analyzer": "bengali_analyzer"
+                  },
+                  "french": {
+                    "type": "text",
+                    "analyzer": "french_analyzer"
+                  },
+                  "german": {
+                    "type": "text",
+                    "analyzer": "german_analyzer"
+                  },
+                  "hindi": {
+                    "type": "text",
+                    "analyzer": "hindi_analyzer"
+                  },
+                  "italian": {
+                    "type": "text",
+                    "analyzer": "italian_analyzer"
+                  }
+                }
+              },
+              "physicalDescription": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword"
+                  },
+                  "english": {
+                    "type": "text",
+                    "analyzer": "english"
+                  }
+                }
+              },
+              "lettering": {
+                "type": "text",
+                "fields": {
+                  "english": {
+                    "type": "text",
+                    "analyzer": "english_analyzer"
+                  },
+                  "shingles": {
+                    "type": "text",
+                    "analyzer": "shingle_asciifolding_analyzer"
+                  },
+                  "arabic": {
+                    "type": "text",
+                    "analyzer": "arabic_analyzer"
+                  },
+                  "bengali": {
+                    "type": "text",
+                    "analyzer": "bengali_analyzer"
+                  },
+                  "french": {
+                    "type": "text",
+                    "analyzer": "french_analyzer"
+                  },
+                  "german": {
+                    "type": "text",
+                    "analyzer": "german_analyzer"
+                  },
+                  "hindi": {
+                    "type": "text",
+                    "analyzer": "hindi_analyzer"
+                  },
+                  "italian": {
+                    "type": "text",
+                    "analyzer": "italian_analyzer"
+                  }
+                }
+              },
+              "contributors": {
+                "type": "object",
+                "properties": {
+                  "agent": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "text",
+                        "analyzer": "asciifolding_analyzer",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword"
                           },
-                          "lowercaseKeyword" : {
-                            "type" : "keyword",
-                            "normalizer" : "lowercase_normalizer"
+                          "lowercaseKeyword": {
+                            "type": "keyword",
+                            "normalizer": "lowercase_normalizer"
                           }
                         }
-                      },
-                      "concepts" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "production" : {
-                    "type" : "object",
-                    "properties" : {
-                      "places" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "agents" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "dates" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "function" : {
-                        "type" : "object",
-                        "properties" : {
-                          "label" : {
-                            "type" : "text",
-                            "analyzer" : "asciifolding_analyzer",
-                            "fields" : {
-                              "keyword" : {
-                                "type" : "keyword"
-                              },
-                              "lowercaseKeyword" : {
-                                "type" : "keyword",
-                                "normalizer" : "lowercase_normalizer"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "languages" : {
-                    "type" : "object",
-                    "properties" : {
-                      "label" : {
-                        "type" : "text",
-                        "analyzer" : "asciifolding_analyzer",
-                        "fields" : {
-                          "keyword" : {
-                            "type" : "keyword"
-                          },
-                          "lowercaseKeyword" : {
-                            "type" : "keyword",
-                            "normalizer" : "lowercase_normalizer"
-                          }
-                        }
-                      },
-                      "id" : {
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "edition" : {
-                    "type" : "text"
-                  },
-                  "notes" : {
-                    "type" : "object",
-                    "properties" : {
-                      "content" : {
-                        "type" : "text",
-                        "fields" : {
-                          "english" : {
-                            "type" : "text",
-                            "analyzer" : "english_analyzer"
-                          },
-                          "shingles" : {
-                            "type" : "text",
-                            "analyzer" : "shingle_asciifolding_analyzer"
-                          },
-                          "arabic" : {
-                            "type" : "text",
-                            "analyzer" : "arabic_analyzer"
-                          },
-                          "bengali" : {
-                            "type" : "text",
-                            "analyzer" : "bengali_analyzer"
-                          },
-                          "french" : {
-                            "type" : "text",
-                            "analyzer" : "french_analyzer"
-                          },
-                          "german" : {
-                            "type" : "text",
-                            "analyzer" : "german_analyzer"
-                          },
-                          "hindi" : {
-                            "type" : "text",
-                            "analyzer" : "hindi_analyzer"
-                          },
-                          "italian" : {
-                            "type" : "text",
-                            "analyzer" : "italian_analyzer"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "collectionPath" : {
-                    "type" : "object",
-                    "properties" : {
-                      "label" : {
-                        "type" : "text",
-                        "analyzer" : "asciifolding_analyzer",
-                        "fields" : {
-                          "keyword" : {
-                            "type" : "keyword"
-                          },
-                          "lowercaseKeyword" : {
-                            "type" : "keyword",
-                            "normalizer" : "lowercase_normalizer"
-                          }
-                        }
-                      },
-                      "path" : {
-                        "type" : "text"
                       }
                     }
                   }
                 }
               },
-              "type" : {
-                "type" : "keyword"
+              "subjects": {
+                "type": "object",
+                "properties": {
+                  "concepts": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "text",
+                        "analyzer": "asciifolding_analyzer",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword"
+                          },
+                          "lowercaseKeyword": {
+                            "type": "keyword",
+                            "normalizer": "lowercase_normalizer"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "genres": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "text",
+                    "analyzer": "asciifolding_analyzer",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword"
+                      },
+                      "lowercaseKeyword": {
+                        "type": "keyword",
+                        "normalizer": "lowercase_normalizer"
+                      }
+                    }
+                  },
+                  "concepts": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "text",
+                        "analyzer": "asciifolding_analyzer",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword"
+                          },
+                          "lowercaseKeyword": {
+                            "type": "keyword",
+                            "normalizer": "lowercase_normalizer"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "production": {
+                "type": "object",
+                "properties": {
+                  "places": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "text",
+                        "analyzer": "asciifolding_analyzer",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword"
+                          },
+                          "lowercaseKeyword": {
+                            "type": "keyword",
+                            "normalizer": "lowercase_normalizer"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "agents": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "text",
+                        "analyzer": "asciifolding_analyzer",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword"
+                          },
+                          "lowercaseKeyword": {
+                            "type": "keyword",
+                            "normalizer": "lowercase_normalizer"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "dates": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "text",
+                        "analyzer": "asciifolding_analyzer",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword"
+                          },
+                          "lowercaseKeyword": {
+                            "type": "keyword",
+                            "normalizer": "lowercase_normalizer"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "function": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "text",
+                        "analyzer": "asciifolding_analyzer",
+                        "fields": {
+                          "keyword": {
+                            "type": "keyword"
+                          },
+                          "lowercaseKeyword": {
+                            "type": "keyword",
+                            "normalizer": "lowercase_normalizer"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "languages": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "text",
+                    "analyzer": "asciifolding_analyzer",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword"
+                      },
+                      "lowercaseKeyword": {
+                        "type": "keyword",
+                        "normalizer": "lowercase_normalizer"
+                      }
+                    }
+                  },
+                  "id": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "edition": {
+                "type": "text"
+              },
+              "notes": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "text",
+                    "fields": {
+                      "english": {
+                        "type": "text",
+                        "analyzer": "english_analyzer"
+                      },
+                      "shingles": {
+                        "type": "text",
+                        "analyzer": "shingle_asciifolding_analyzer"
+                      },
+                      "arabic": {
+                        "type": "text",
+                        "analyzer": "arabic_analyzer"
+                      },
+                      "bengali": {
+                        "type": "text",
+                        "analyzer": "bengali_analyzer"
+                      },
+                      "french": {
+                        "type": "text",
+                        "analyzer": "french_analyzer"
+                      },
+                      "german": {
+                        "type": "text",
+                        "analyzer": "german_analyzer"
+                      },
+                      "hindi": {
+                        "type": "text",
+                        "analyzer": "hindi_analyzer"
+                      },
+                      "italian": {
+                        "type": "text",
+                        "analyzer": "italian_analyzer"
+                      }
+                    }
+                  }
+                }
+              },
+              "collectionPath": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "text",
+                    "analyzer": "asciifolding_analyzer",
+                    "fields": {
+                      "keyword": {
+                        "type": "keyword"
+                      },
+                      "lowercaseKeyword": {
+                        "type": "keyword",
+                        "normalizer": "lowercase_normalizer"
+                      }
+                    }
+                  },
+                  "path": {
+                    "type": "text"
+                  }
+                }
               }
-            },
-            "dynamic" : "false"
+            }
           },
-          "type" : {
-            "type" : "keyword"
+          "type": {
+            "type": "keyword"
           }
         }
       },
@@ -1137,15 +673,6 @@
                 "type" : "float"
               }
             }
-          },
-          "derivedData" : {
-            "type" : "object",
-            "properties" : {
-              "sourceContributorAgents" : {
-                "type" : "keyword"
-              }
-            },
-            "dynamic" : "false"
           }
         }
       },

--- a/common/search/src/test/resources/test_documents/images.contributors.0.json
+++ b/common/search/src/test/resources/test_documents/images.contributors.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different contributors",
-  "createdAt" : "2022-06-16T10:05:58.995Z",
+  "createdAt" : "2022-06-17T14:17:36.622693Z",
   "id" : "vfhrlsz5",
   "document" : {
     "version" : 1,
@@ -4272,24 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/xua.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: AsBzkmS",
-          "linkText" : "Link text: 3vV5CO0lv",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-          "Agent:carrots"
-        ]
       }
     },
     "locations" : [
@@ -4308,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "hr55ornz",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "RQcuhTTiaE"
+      "id" : {
+        "canonicalId" : "hr55ornz",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "RQcuhTTiaE"
         },
-        "data" : {
-          "title" : "title-bA22VxYxvw",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-            {
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-bA22VxYxvw",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+          {
+            "id" : {
+              "type" : "Unidentifiable"
+            },
+            "agent" : {
               "id" : {
                 "type" : "Unidentifiable"
               },
-              "agent" : {
-                "id" : {
-                  "type" : "Unidentifiable"
-                },
-                "label" : "carrots",
-                "type" : "Agent"
-              },
-              "roles" : [
-              ]
-            }
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 36
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "qm8swrzi",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
+              "label" : "carrots",
+              "type" : "Agent"
             },
-            "ontologyType" : "Work",
-            "value" : "pLpOdhurZO"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-KazBvOQfgk",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "UH3REaaf1q"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "GGRhJQ3L00"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 95
+            "roles" : [
+            ]
+          }
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 36,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1965-07-07T22:50:25Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.contributors.1.json
+++ b/common/search/src/test/resources/test_documents/images.contributors.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different contributors",
-  "createdAt" : "2022-06-16T13:22:33.820085Z",
+  "createdAt" : "2022-06-17T14:17:36.663311Z",
   "id" : "0taf9mko",
   "document" : {
     "version" : 1,
@@ -4272,25 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/WJb.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: gq8acPVa2M",
-          "linkText" : "Link text: LIo1BtSQj",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-          "Agent:carrots",
-          "Organisation:parrots"
-        ]
       }
     },
     "locations" : [
@@ -4309,165 +4290,84 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "nbflmlls",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "miro-image-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "cuV30UpZ7e"
+      "id" : {
+        "canonicalId" : "nbflmlls",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "miro-image-number"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "cuV30UpZ7e"
         },
-        "data" : {
-          "title" : "title-MKFqleolFi",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "agent" : {
-                "id" : {
-                  "type" : "Unidentifiable"
-                },
-                "label" : "carrots",
-                "type" : "Agent"
-              },
-              "roles" : [
-              ]
-            },
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "agent" : {
-                "id" : {
-                  "type" : "Unidentifiable"
-                },
-                "label" : "parrots",
-                "type" : "Organisation"
-              },
-              "roles" : [
-              ]
-            }
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 76
+        "otherIdentifiers" : [
+        ]
       },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "hxr2dqvq",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "miro-image-number"
+      "data" : {
+        "title" : "title-MKFqleolFi",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+          {
+            "id" : {
+              "type" : "Unidentifiable"
             },
-            "ontologyType" : "Work",
-            "value" : "FDI5PSSBY0"
+            "agent" : {
+              "id" : {
+                "type" : "Unidentifiable"
+              },
+              "label" : "carrots",
+              "type" : "Agent"
+            },
+            "roles" : [
+            ]
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-YVG9tsY4JK",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "agent" : {
-                "id" : {
-                  "type" : "Unidentifiable"
-                },
-                "label" : "parrots",
-                "type" : "Organisation"
-              },
-              "roles" : [
-              ]
+          {
+            "id" : {
+              "type" : "Unidentifiable"
             },
-            {
+            "agent" : {
               "id" : {
                 "type" : "Unidentifiable"
               },
-              "agent" : {
-                "id" : {
-                  "type" : "Unidentifiable"
-                },
-                "label" : "parrots",
-                "type" : "Meeting"
-              },
-              "roles" : [
-              ]
-            }
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 33
+              "label" : "parrots",
+              "type" : "Organisation"
+            },
+            "roles" : [
+            ]
+          }
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 76,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1993-01-08T03:06:42Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.contributors.2.json
+++ b/common/search/src/test/resources/test_documents/images.contributors.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different contributors",
-  "createdAt" : "2022-06-16T13:22:33.846319Z",
+  "createdAt" : "2022-06-17T14:17:36.698284Z",
   "id" : "krb6vjce",
   "document" : {
     "version" : 1,
@@ -4272,25 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/eTy.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-          "Agent:carrots",
-          "Meeting:parrots"
-        ]
       }
     },
     "locations" : [
@@ -4309,153 +4290,84 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "apls471y",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "miro-image-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "Uhj907eeAc"
+      "id" : {
+        "canonicalId" : "apls471y",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "miro-image-number"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "Uhj907eeAc"
         },
-        "data" : {
-          "title" : "title-ngkzrTYfkQ",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "agent" : {
-                "id" : {
-                  "type" : "Unidentifiable"
-                },
-                "label" : "carrots",
-                "type" : "Agent"
-              },
-              "roles" : [
-              ]
-            },
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "agent" : {
-                "id" : {
-                  "type" : "Unidentifiable"
-                },
-                "label" : "parrots",
-                "type" : "Meeting"
-              },
-              "roles" : [
-              ]
-            }
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 71
+        "otherIdentifiers" : [
+        ]
       },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "iffrfkfi",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "miro-image-number"
+      "data" : {
+        "title" : "title-ngkzrTYfkQ",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+          {
+            "id" : {
+              "type" : "Unidentifiable"
             },
-            "ontologyType" : "Work",
-            "value" : "Xdhrg3bcU7"
+            "agent" : {
+              "id" : {
+                "type" : "Unidentifiable"
+              },
+              "label" : "carrots",
+              "type" : "Agent"
+            },
+            "roles" : [
+            ]
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-rHZI3YvD3n",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-            {
+          {
+            "id" : {
+              "type" : "Unidentifiable"
+            },
+            "agent" : {
               "id" : {
                 "type" : "Unidentifiable"
               },
-              "agent" : {
-                "id" : {
-                  "type" : "Unidentifiable"
-                },
-                "label" : "rats",
-                "prefix" : null,
-                "numeration" : null,
-                "type" : "Person"
-              },
-              "roles" : [
-              ]
-            }
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 35
+              "label" : "parrots",
+              "type" : "Meeting"
+            },
+            "roles" : [
+            ]
+          }
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 71,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1938-05-06T18:45:07Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.different-licenses.0.json
+++ b/common/search/src/test/resources/test_documents/images.different-licenses.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-06-16T10:05:58.826Z",
+  "createdAt" : "2022-06-17T14:17:35.869620Z",
   "id" : "f0nj3tuz",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/CCz.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,160 +4290,93 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "yqts0coj",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "yqts0coj",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "vWebpA5WHf"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-QqPyuxbr58",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "vWebpA5WHf"
+            "value" : "wyJzS2SuiH"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-QqPyuxbr58",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "wyJzS2SuiH"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "rAOB2RuvBb"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "title" : null,
-              "note" : null,
-              "locations" : [
-                {
-                  "url" : "https://iiif.wellcomecollection.org/image/CCz.jpg/info.json",
-                  "locationType" : {
-                    "id" : "iiif-image"
-                  },
-                  "license" : {
-                    "id" : "cc-by"
-                  },
-                  "credit" : null,
-                  "linkText" : null,
-                  "accessConditions" : [
-                  ],
-                  "type" : "DigitalLocation"
-                }
-              ]
-            }
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 6
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "vu8irsvn",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "WXSBlJFu0Q"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-bWsensP3JJ",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "1MHKXQ3glZ"
+            "value" : "rAOB2RuvBb"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+          {
+            "id" : {
+              "type" : "Unidentifiable"
             },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "ntXsvtioPG"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 61
+            "title" : null,
+            "note" : null,
+            "locations" : [
+              {
+                "url" : "https://iiif.wellcomecollection.org/image/CCz.jpg/info.json",
+                "locationType" : {
+                  "id" : "iiif-image"
+                },
+                "license" : {
+                  "id" : "cc-by"
+                },
+                "credit" : null,
+                "linkText" : null,
+                "accessConditions" : [
+                ],
+                "type" : "DigitalLocation"
+              }
+            ]
+          }
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 6,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1941-09-23T10:55:10Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.different-licenses.1.json
+++ b/common/search/src/test/resources/test_documents/images.different-licenses.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-06-16T10:05:58.829Z",
+  "createdAt" : "2022-06-17T14:17:35.877739Z",
   "id" : "fhe0mza5",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/9UI.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,160 +4290,93 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "6gwbs7oc",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "6gwbs7oc",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "Y4M5JWvJyZ"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-MNnr9kNroY",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "Y4M5JWvJyZ"
+            "value" : "uxRqEOmVr7"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-MNnr9kNroY",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "uxRqEOmVr7"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "oYM65gjgNk"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "title" : null,
-              "note" : null,
-              "locations" : [
-                {
-                  "url" : "https://iiif.wellcomecollection.org/image/9UI.jpg/info.json",
-                  "locationType" : {
-                    "id" : "iiif-image"
-                  },
-                  "license" : {
-                    "id" : "cc-by"
-                  },
-                  "credit" : null,
-                  "linkText" : null,
-                  "accessConditions" : [
-                  ],
-                  "type" : "DigitalLocation"
-                }
-              ]
-            }
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 38
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "pxdxadij",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "2KuBAFtcQe"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-ySiiyfK19T",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "ULsTtNlyi9"
+            "value" : "oYM65gjgNk"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+          {
+            "id" : {
+              "type" : "Unidentifiable"
             },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "iJ18AHifj4"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 76
+            "title" : null,
+            "note" : null,
+            "locations" : [
+              {
+                "url" : "https://iiif.wellcomecollection.org/image/9UI.jpg/info.json",
+                "locationType" : {
+                  "id" : "iiif-image"
+                },
+                "license" : {
+                  "id" : "cc-by"
+                },
+                "credit" : null,
+                "linkText" : null,
+                "accessConditions" : [
+                ],
+                "type" : "DigitalLocation"
+              }
+            ]
+          }
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 38,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1951-12-14T08:26:28Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.different-licenses.2.json
+++ b/common/search/src/test/resources/test_documents/images.different-licenses.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-06-16T10:05:58.831Z",
+  "createdAt" : "2022-06-17T14:17:35.880074Z",
   "id" : "ufwuwch3",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/ASu.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: Mu1w5nUkFX",
-          "linkText" : "Link text: fdT3kzyNAn",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,160 +4290,93 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "id3h1gbz",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "id3h1gbz",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "pgLaFdFV62"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-V0vsNu6VGS",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "pgLaFdFV62"
+            "value" : "Tt46XEFFyH"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-V0vsNu6VGS",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "Tt46XEFFyH"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "8iDKRhGT0W"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "title" : null,
-              "note" : null,
-              "locations" : [
-                {
-                  "url" : "https://iiif.wellcomecollection.org/image/ASu.jpg/info.json",
-                  "locationType" : {
-                    "id" : "iiif-image"
-                  },
-                  "license" : {
-                    "id" : "cc-by"
-                  },
-                  "credit" : "Credit line: Mu1w5nUkFX",
-                  "linkText" : "Link text: fdT3kzyNAn",
-                  "accessConditions" : [
-                  ],
-                  "type" : "DigitalLocation"
-                }
-              ]
-            }
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 40
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "uggctu4t",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "a0C44EkWOX"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-HWuxhtyDWp",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "dIXiPVJzvU"
+            "value" : "8iDKRhGT0W"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+          {
+            "id" : {
+              "type" : "Unidentifiable"
             },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "T3414OlMN8"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 94
+            "title" : null,
+            "note" : null,
+            "locations" : [
+              {
+                "url" : "https://iiif.wellcomecollection.org/image/ASu.jpg/info.json",
+                "locationType" : {
+                  "id" : "iiif-image"
+                },
+                "license" : {
+                  "id" : "cc-by"
+                },
+                "credit" : "Credit line: Mu1w5nUkFX",
+                "linkText" : "Link text: fdT3kzyNAn",
+                "accessConditions" : [
+                ],
+                "type" : "DigitalLocation"
+              }
+            ]
+          }
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 40,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1953-05-25T18:51:16Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.different-licenses.3.json
+++ b/common/search/src/test/resources/test_documents/images.different-licenses.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-06-16T10:05:58.833Z",
+  "createdAt" : "2022-06-17T14:17:35.882644Z",
   "id" : "e3pbbjqd",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/V3C.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : "Link text: jiS6NyP",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,160 +4290,93 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "tuhtjrse",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "tuhtjrse",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "ayhcMfoo0p"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-NaWZXyY9dy",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "ayhcMfoo0p"
+            "value" : "19gJNMnTLm"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-NaWZXyY9dy",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "19gJNMnTLm"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "F3057sOKqV"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "title" : null,
-              "note" : null,
-              "locations" : [
-                {
-                  "url" : "https://iiif.wellcomecollection.org/image/V3C.jpg/info.json",
-                  "locationType" : {
-                    "id" : "iiif-image"
-                  },
-                  "license" : {
-                    "id" : "cc-by"
-                  },
-                  "credit" : null,
-                  "linkText" : "Link text: jiS6NyP",
-                  "accessConditions" : [
-                  ],
-                  "type" : "DigitalLocation"
-                }
-              ]
-            }
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 16
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "iljzgh0h",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "MlP4Mpw0R6"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-Kya0MYextQ",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "5jify40WAX"
+            "value" : "F3057sOKqV"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+          {
+            "id" : {
+              "type" : "Unidentifiable"
             },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "TDjcbm3Ev9"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 23
+            "title" : null,
+            "note" : null,
+            "locations" : [
+              {
+                "url" : "https://iiif.wellcomecollection.org/image/V3C.jpg/info.json",
+                "locationType" : {
+                  "id" : "iiif-image"
+                },
+                "license" : {
+                  "id" : "cc-by"
+                },
+                "credit" : null,
+                "linkText" : "Link text: jiS6NyP",
+                "accessConditions" : [
+                ],
+                "type" : "DigitalLocation"
+              }
+            ]
+          }
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 16,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2009-08-08T17:20:12Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.different-licenses.4.json
+++ b/common/search/src/test/resources/test_documents/images.different-licenses.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-06-16T10:05:58.834Z",
+  "createdAt" : "2022-06-17T14:17:35.884431Z",
   "id" : "qotyzauo",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/E1M.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: 9pa7OAH1De",
-          "linkText" : "Link text: ZIdoU4x",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,160 +4290,93 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "lggdv9n5",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "lggdv9n5",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "jMoo93ssBF"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-TicpHDwc6D",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "jMoo93ssBF"
+            "value" : "fM6sHtIhDe"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-TicpHDwc6D",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "fM6sHtIhDe"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "kSPTf70D0p"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "title" : null,
-              "note" : null,
-              "locations" : [
-                {
-                  "url" : "https://iiif.wellcomecollection.org/image/E1M.jpg/info.json",
-                  "locationType" : {
-                    "id" : "iiif-image"
-                  },
-                  "license" : {
-                    "id" : "cc-by"
-                  },
-                  "credit" : "Credit line: 9pa7OAH1De",
-                  "linkText" : "Link text: ZIdoU4x",
-                  "accessConditions" : [
-                  ],
-                  "type" : "DigitalLocation"
-                }
-              ]
-            }
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 7
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "o3aajaqz",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "GPT1Fvwfec"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-sFyHRBJKGE",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "07LLrOm5D5"
+            "value" : "kSPTf70D0p"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+          {
+            "id" : {
+              "type" : "Unidentifiable"
             },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "5U8fISYf1X"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 16
+            "title" : null,
+            "note" : null,
+            "locations" : [
+              {
+                "url" : "https://iiif.wellcomecollection.org/image/E1M.jpg/info.json",
+                "locationType" : {
+                  "id" : "iiif-image"
+                },
+                "license" : {
+                  "id" : "cc-by"
+                },
+                "credit" : "Credit line: 9pa7OAH1De",
+                "linkText" : "Link text: ZIdoU4x",
+                "accessConditions" : [
+                ],
+                "type" : "DigitalLocation"
+              }
+            ]
+          }
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 7,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2005-09-05T19:23:25Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.different-licenses.5.json
+++ b/common/search/src/test/resources/test_documents/images.different-licenses.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-06-16T10:05:58.835Z",
+  "createdAt" : "2022-06-17T14:17:35.886121Z",
   "id" : "wm3hzclj",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/cHo.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "pdm"
-          },
-          "credit" : null,
-          "linkText" : "Link text: O9o98Ps",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,160 +4290,93 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "tvsmmrz4",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "tvsmmrz4",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "VgDOfrRHgh"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-iCT8Z6qYJP",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "VgDOfrRHgh"
+            "value" : "t8EcDG3LIH"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-iCT8Z6qYJP",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "t8EcDG3LIH"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "Ytqggz0zLO"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "title" : null,
-              "note" : null,
-              "locations" : [
-                {
-                  "url" : "https://iiif.wellcomecollection.org/image/cHo.jpg/info.json",
-                  "locationType" : {
-                    "id" : "iiif-image"
-                  },
-                  "license" : {
-                    "id" : "pdm"
-                  },
-                  "credit" : null,
-                  "linkText" : "Link text: O9o98Ps",
-                  "accessConditions" : [
-                  ],
-                  "type" : "DigitalLocation"
-                }
-              ]
-            }
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 16
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "wyj4v7my",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "d7EJ2WUMiI"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-YaMFO6rDFb",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "8dwWmsLer3"
+            "value" : "Ytqggz0zLO"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+          {
+            "id" : {
+              "type" : "Unidentifiable"
             },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "Ng28WelhFI"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 77
+            "title" : null,
+            "note" : null,
+            "locations" : [
+              {
+                "url" : "https://iiif.wellcomecollection.org/image/cHo.jpg/info.json",
+                "locationType" : {
+                  "id" : "iiif-image"
+                },
+                "license" : {
+                  "id" : "pdm"
+                },
+                "credit" : null,
+                "linkText" : "Link text: O9o98Ps",
+                "accessConditions" : [
+                ],
+                "type" : "DigitalLocation"
+              }
+            ]
+          }
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 16,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2028-03-10T22:32:58Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.different-licenses.6.json
+++ b/common/search/src/test/resources/test_documents/images.different-licenses.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-06-16T10:05:58.836Z",
+  "createdAt" : "2022-06-17T14:17:35.887553Z",
   "id" : "wo5jm0ho",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/rmb.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "pdm"
-          },
-          "credit" : "Credit line: 0mTuYpq7",
-          "linkText" : "Link text: rgJFxmIguP",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,160 +4290,93 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "hpbqg2ob",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "hpbqg2ob",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "NN4HeBQmTz"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-eLyswNqtmi",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "NN4HeBQmTz"
+            "value" : "yPzvBDbfov"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-eLyswNqtmi",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "yPzvBDbfov"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "XVL49NpX5T"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "title" : null,
-              "note" : null,
-              "locations" : [
-                {
-                  "url" : "https://iiif.wellcomecollection.org/image/rmb.jpg/info.json",
-                  "locationType" : {
-                    "id" : "iiif-image"
-                  },
-                  "license" : {
-                    "id" : "pdm"
-                  },
-                  "credit" : "Credit line: 0mTuYpq7",
-                  "linkText" : "Link text: rgJFxmIguP",
-                  "accessConditions" : [
-                  ],
-                  "type" : "DigitalLocation"
-                }
-              ]
-            }
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 33
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "ekmstdjd",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "lynuiTWWIA"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-xGKvFlyO73",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "3pd7OY36iB"
+            "value" : "XVL49NpX5T"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+          {
+            "id" : {
+              "type" : "Unidentifiable"
             },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "Zc1LY2Oe1N"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 84
+            "title" : null,
+            "note" : null,
+            "locations" : [
+              {
+                "url" : "https://iiif.wellcomecollection.org/image/rmb.jpg/info.json",
+                "locationType" : {
+                  "id" : "iiif-image"
+                },
+                "license" : {
+                  "id" : "pdm"
+                },
+                "credit" : "Credit line: 0mTuYpq7",
+                "linkText" : "Link text: rgJFxmIguP",
+                "accessConditions" : [
+                ],
+                "type" : "DigitalLocation"
+              }
+            ]
+          }
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 33,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2037-03-03T00:46:01Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.everything.json
+++ b/common/search/src/test/resources/test_documents/images.everything.json
@@ -1,6 +1,6 @@
 {
   "description" : "an image with every include",
-  "createdAt" : "2022-06-16T10:05:59.267Z",
+  "createdAt" : "2022-06-17T14:17:37.395235Z",
   "id" : "alwtbvyg",
   "document" : {
     "version" : 1,
@@ -4272,25 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/GC3.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: f0VBIgS96L",
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-          "Person:Adrian Aardvark",
-          "Person:Beatrice Buffalo"
-        ]
       }
     },
     "locations" : [
@@ -4309,215 +4290,148 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "v39xo2l4",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "t1EzdSUck8"
+      "id" : {
+        "canonicalId" : "v39xo2l4",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "t1EzdSUck8"
         },
-        "data" : {
-          "title" : "Apple agitator",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-            {
-              "label" : "Crumbly cabbages",
-              "concepts" : [
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "VTMxwlsU4ID8FJO",
-                  "type" : "Concept"
-                },
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "smLVneLxGixuwYM",
-                  "type" : "Concept"
-                },
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "WEKRGOyVEETAXu2",
-                  "type" : "Concept"
-                }
-              ]
-            },
-            {
-              "label" : "Deadly durians",
-              "concepts" : [
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "wVgSyRdeyNrYD8Z",
-                  "type" : "Concept"
-                },
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "5K6TPbywqiK3tTT",
-                  "type" : "Concept"
-                },
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "s2UdfxnodZzKVgW",
-                  "type" : "Concept"
-                }
-              ]
-            }
-          ],
-          "contributors" : [
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "agent" : {
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "Apple agitator",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+          {
+            "label" : "Crumbly cabbages",
+            "concepts" : [
+              {
                 "id" : {
                   "type" : "Unidentifiable"
                 },
-                "label" : "Adrian Aardvark",
-                "prefix" : null,
-                "numeration" : null,
-                "type" : "Person"
+                "label" : "VTMxwlsU4ID8FJO",
+                "type" : "Concept"
               },
-              "roles" : [
-              ]
-            },
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "agent" : {
+              {
                 "id" : {
                   "type" : "Unidentifiable"
                 },
-                "label" : "Beatrice Buffalo",
-                "prefix" : null,
-                "numeration" : null,
-                "type" : "Person"
+                "label" : "smLVneLxGixuwYM",
+                "type" : "Concept"
               },
-              "roles" : [
-              ]
-            }
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-            {
-              "id" : "eng",
-              "label" : "English"
-            },
-            {
-              "id" : "tur",
-              "label" : "Turkish"
-            }
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 48
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "uny5ux57",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "30bd5gexA7"
+              {
+                "id" : {
+                  "type" : "Unidentifiable"
+                },
+                "label" : "WEKRGOyVEETAXu2",
+                "type" : "Concept"
+              }
+            ]
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-j4jY5Am96n",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
+          {
+            "label" : "Deadly durians",
+            "concepts" : [
+              {
+                "id" : {
+                  "type" : "Unidentifiable"
+                },
+                "label" : "wVgSyRdeyNrYD8Z",
+                "type" : "Concept"
               },
-              "ontologyType" : "Work",
-              "value" : "j8AMk9kGqF"
+              {
+                "id" : {
+                  "type" : "Unidentifiable"
+                },
+                "label" : "5K6TPbywqiK3tTT",
+                "type" : "Concept"
+              },
+              {
+                "id" : {
+                  "type" : "Unidentifiable"
+                },
+                "label" : "s2UdfxnodZzKVgW",
+                "type" : "Concept"
+              }
+            ]
+          }
+        ],
+        "contributors" : [
+          {
+            "id" : {
+              "type" : "Unidentifiable"
             },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
+            "agent" : {
+              "id" : {
+                "type" : "Unidentifiable"
               },
-              "ontologyType" : "Work",
-              "value" : "iZStet5BWz"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 44
+              "label" : "Adrian Aardvark",
+              "prefix" : null,
+              "numeration" : null,
+              "type" : "Person"
+            },
+            "roles" : [
+            ]
+          },
+          {
+            "id" : {
+              "type" : "Unidentifiable"
+            },
+            "agent" : {
+              "id" : {
+                "type" : "Unidentifiable"
+              },
+              "label" : "Beatrice Buffalo",
+              "prefix" : null,
+              "numeration" : null,
+              "type" : "Person"
+            },
+            "roles" : [
+            ]
+          }
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+          {
+            "id" : "eng",
+            "label" : "English"
+          },
+          {
+            "id" : "tur",
+            "label" : "Turkish"
+          }
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 48,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1955-08-08T03:38:40Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.bread-baguette.json
+++ b/common/search/src/test/resources/test_documents/images.examples.bread-baguette.json
@@ -1,6 +1,6 @@
 {
   "description" : "an example of images with work metadata for the API tests",
-  "createdAt" : "2022-06-16T10:05:59.299Z",
+  "createdAt" : "2022-06-17T14:17:37.493257Z",
   "id" : "raqyttz2",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/7xD.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: e5tEmO",
-          "linkText" : "Link text: 3kEQPI16",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,123 +4290,56 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "d7frptjr",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "calm-record-id"
-            },
-            "ontologyType" : "Work",
-            "value" : "sx2oArj0tz"
+      "id" : {
+        "canonicalId" : "d7frptjr",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "calm-record-id"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "sx2oArj0tz"
         },
-        "data" : {
-          "title" : "Baguette is a French style of bread; it's a long, thin bread; other countries also make this bread",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 51
+        "otherIdentifiers" : [
+        ]
       },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "rpngbg6v",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "esfGksBtxD"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-91hz0jNQLV",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "Dz3JiDxuSU"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "YiVh4P1vMi"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 94
+      "data" : {
+        "title" : "Baguette is a French style of bread; it's a long, thin bread; other countries also make this bread",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 51,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1957-10-26T00:32:14Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.bread-focaccia.json
+++ b/common/search/src/test/resources/test_documents/images.examples.bread-focaccia.json
@@ -1,6 +1,6 @@
 {
   "description" : "an example of images with work metadata for the API tests",
-  "createdAt" : "2022-06-16T10:05:59.303Z",
+  "createdAt" : "2022-06-17T14:17:37.506316Z",
   "id" : "3903uugw",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/7hV.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: RVAMoYA4",
-          "linkText" : "Link text: aCaEmtI",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,123 +4290,56 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "tipn8axj",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "zUwx61CbJh"
+      "id" : {
+        "canonicalId" : "tipn8axj",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "zUwx61CbJh"
         },
-        "data" : {
-          "title" : "A Ligurian style of bread, Focaccia is a flat Italian bread",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 75
+        "otherIdentifiers" : [
+        ]
       },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "nwgro5wt",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "vyGdXHKt7z"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-OSy2FbBzGl",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "lLmURysHhS"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "8FvpZVyq4R"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 27
+      "data" : {
+        "title" : "A Ligurian style of bread, Focaccia is a flat Italian bread",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 75,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2007-10-07T21:15:47Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.bread-mantou.json
+++ b/common/search/src/test/resources/test_documents/images.examples.bread-mantou.json
@@ -1,6 +1,6 @@
 {
   "description" : "an example of images with work metadata for the API tests",
-  "createdAt" : "2022-06-16T10:05:59.310Z",
+  "createdAt" : "2022-06-17T14:17:37.531610Z",
   "id" : "hylz2v15",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/3H9.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: JwLsx4",
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,123 +4290,56 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "zu4e5ax7",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "calm-record-id"
-            },
-            "ontologyType" : "Work",
-            "value" : "eml0fHqxBM"
+      "id" : {
+        "canonicalId" : "zu4e5ax7",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "calm-record-id"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "eml0fHqxBM"
         },
-        "data" : {
-          "title" : "Mantou is a steamed bread associated with Northern China",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 36
+        "otherIdentifiers" : [
+        ]
       },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "mzotnjml",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "iGeaBTO0XI"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-11ix0dz6tk",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "rCG0TA5wSZ"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "7H0lacfd94"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 69
+      "data" : {
+        "title" : "Mantou is a steamed bread associated with Northern China",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 36,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1950-12-03T16:01:32Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.bread-schiacciata.json
+++ b/common/search/src/test/resources/test_documents/images.examples.bread-schiacciata.json
@@ -1,6 +1,6 @@
 {
   "description" : "an example of images with work metadata for the API tests",
-  "createdAt" : "2022-06-16T10:05:59.307Z",
+  "createdAt" : "2022-06-17T14:17:37.518802Z",
   "id" : "iwc9jla6",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/fUj.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,109 +4290,56 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "jdan0vxr",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "VM7iATb3H4"
+      "id" : {
+        "canonicalId" : "jdan0vxr",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "VM7iATb3H4"
         },
-        "data" : {
-          "title" : "Schiacciata is a Tuscan focaccia",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 94
+        "otherIdentifiers" : [
+        ]
       },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "orcvgfde",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "miro-image-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "G5r25AIwOY"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "A Tuscan bread",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 74
+      "data" : {
+        "title" : "Schiacciata is a Tuscan focaccia",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 94,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2054-05-11T17:14:22Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.color-filter-tests.blue.json
+++ b/common/search/src/test/resources/test_documents/images.examples.color-filter-tests.blue.json
@@ -1,6 +1,6 @@
 {
   "description" : "example for the color filter tests",
-  "createdAt" : "2022-06-16T10:05:59.258Z",
+  "createdAt" : "2022-06-17T14:17:37.359106Z",
   "id" : "nltbd6z9",
   "document" : {
     "version" : 1,
@@ -4191,23 +4191,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/4yy.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : "Link text: 0s3BzC",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4226,137 +4209,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "rpk26bqs",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "rpk26bqs",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "IxvjTt23fL"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-PPk1wiHWln",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "IxvjTt23fL"
+            "value" : "FUXO1Fspls"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-PPk1wiHWln",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "FUXO1Fspls"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "vfwEbRNkbC"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 49
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "eyc1fcr3",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "Y9FAEd9hJv"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-E5wPtNKPtk",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "9FfIUaJDea"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "M3FBGMVfNB"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 85
+            "value" : "vfwEbRNkbC"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 49,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1967-08-20T13:26:22Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.color-filter-tests.even-less-red.json
+++ b/common/search/src/test/resources/test_documents/images.examples.color-filter-tests.even-less-red.json
@@ -1,6 +1,6 @@
 {
   "description" : "example for the color filter tests",
-  "createdAt" : "2022-06-16T10:05:59.251Z",
+  "createdAt" : "2022-06-17T14:17:37.336371Z",
   "id" : "rpetyapi",
   "document" : {
     "version" : 1,
@@ -4176,23 +4176,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/7ud.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: CqQmtEy",
-          "linkText" : "Link text: YSfBHe19sw",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4211,137 +4194,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "bd92fwtn",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "bd92fwtn",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "u8xNQU1X3h"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-3G4QrVdCDs",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "u8xNQU1X3h"
+            "value" : "dxhRMMVj4w"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-3G4QrVdCDs",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "dxhRMMVj4w"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "FUqJbYeKOL"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 82
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "sukvlljm",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "aSugogpeN7"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-Te97iq0pYM",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "O9LJce8H4i"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "Gejo2T5lAZ"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 12
+            "value" : "FUqJbYeKOL"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 82,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2068-07-25T11:07:26Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.color-filter-tests.red.json
+++ b/common/search/src/test/resources/test_documents/images.examples.color-filter-tests.red.json
@@ -1,6 +1,6 @@
 {
   "description" : "example for the color filter tests",
-  "createdAt" : "2022-06-16T10:05:59.243Z",
+  "createdAt" : "2022-06-17T14:17:37.310046Z",
   "id" : "jh411m3a",
   "document" : {
     "version" : 1,
@@ -4182,23 +4182,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/QGE.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: xKIisJIr4",
-          "linkText" : "Link text: 5PM1AB",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4217,137 +4200,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "h6j8p9h5",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "h6j8p9h5",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "q1cRZNUSgP"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-9Zp5R7Cdd8",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "q1cRZNUSgP"
+            "value" : "xURDBfWV0y"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-9Zp5R7Cdd8",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "xURDBfWV0y"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "uunKUgxpHu"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 6
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "p4minena",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "rlpJbyW2dt"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-CWOKvfYp7J",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "1o7LznlDNn"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "hVoDrjNQEb"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 67
+            "value" : "uunKUgxpHu"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 6,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1948-03-11T04:37:08Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.color-filter-tests.slightly-less-red.json
+++ b/common/search/src/test/resources/test_documents/images.examples.color-filter-tests.slightly-less-red.json
@@ -1,6 +1,6 @@
 {
   "description" : "example for the color filter tests",
-  "createdAt" : "2022-06-16T10:05:59.247Z",
+  "createdAt" : "2022-06-17T14:17:37.323792Z",
   "id" : "yfpzabzr",
   "document" : {
     "version" : 1,
@@ -4177,23 +4177,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/9KX.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4212,137 +4195,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "u6w35wmf",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "u6w35wmf",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "p64Sfx7VPc"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-pubCzCVlHb",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "p64Sfx7VPc"
+            "value" : "KGvW6Fk7NT"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-pubCzCVlHb",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "KGvW6Fk7NT"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "VGBXFiyAuI"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 7
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "kjqancd0",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "siOUqA2Gdx"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-Jw2m4Y4Ojk",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "01W4lkXpXb"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "M7GQ5nOY7D"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 58
+            "value" : "VGBXFiyAuI"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 7,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1933-05-03T22:58:22Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.contributor-filter-tests.0.json
+++ b/common/search/src/test/resources/test_documents/images.examples.contributor-filter-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-06-16T10:05:59.196Z",
+  "createdAt" : "2022-06-17T14:17:37.173018Z",
   "id" : "7avdcsvd",
   "document" : {
     "version" : 1,
@@ -4272,24 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/M39.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: vNHj5n",
-          "linkText" : "Link text: JZtclMgBE",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-          "Person:Machiavelli, Niccolo"
-        ]
       }
     },
     "locations" : [
@@ -4308,139 +4290,72 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "lm3xkgmq",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "ACVnzrp3sz"
+      "id" : {
+        "canonicalId" : "lm3xkgmq",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "ACVnzrp3sz"
         },
-        "data" : {
-          "title" : "title-yDB1dDDYEN",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-            {
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-yDB1dDDYEN",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+          {
+            "id" : {
+              "type" : "Unidentifiable"
+            },
+            "agent" : {
               "id" : {
                 "type" : "Unidentifiable"
               },
-              "agent" : {
-                "id" : {
-                  "type" : "Unidentifiable"
-                },
-                "label" : "Machiavelli, Niccolo",
-                "prefix" : null,
-                "numeration" : null,
-                "type" : "Person"
-              },
-              "roles" : [
-              ]
-            }
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 58
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "wtt752qw",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
+              "label" : "Machiavelli, Niccolo",
+              "prefix" : null,
+              "numeration" : null,
+              "type" : "Person"
             },
-            "ontologyType" : "Work",
-            "value" : "BbKnQ5NeAM"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-rhQ1yqAAPL",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "S76CtNxJEI"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "lzvPPopLGo"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 17
+            "roles" : [
+            ]
+          }
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 58,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2040-06-15T09:50:49Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.contributor-filter-tests.1.json
+++ b/common/search/src/test/resources/test_documents/images.examples.contributor-filter-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-06-16T10:05:59.197Z",
+  "createdAt" : "2022-06-17T14:17:37.173925Z",
   "id" : "sod8ij3c",
   "document" : {
     "version" : 1,
@@ -4272,24 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/VY2.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-          "Person:Edward Said"
-        ]
       }
     },
     "locations" : [
@@ -4308,139 +4290,72 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "snibbgdn",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "calm-record-id"
-            },
-            "ontologyType" : "Work",
-            "value" : "7xHtrD1qTo"
+      "id" : {
+        "canonicalId" : "snibbgdn",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "calm-record-id"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "7xHtrD1qTo"
         },
-        "data" : {
-          "title" : "title-COvwVoGlOn",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-            {
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-COvwVoGlOn",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+          {
+            "id" : {
+              "type" : "Unidentifiable"
+            },
+            "agent" : {
               "id" : {
                 "type" : "Unidentifiable"
               },
-              "agent" : {
-                "id" : {
-                  "type" : "Unidentifiable"
-                },
-                "label" : "Edward Said",
-                "prefix" : null,
-                "numeration" : null,
-                "type" : "Person"
-              },
-              "roles" : [
-              ]
-            }
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 71
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "in3eoskc",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
+              "label" : "Edward Said",
+              "prefix" : null,
+              "numeration" : null,
+              "type" : "Person"
             },
-            "ontologyType" : "Work",
-            "value" : "sp1DiCfAX8"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-W2GCQLe2BF",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "mDJiMrR5fD"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "PfcjxarpqK"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 66
+            "roles" : [
+            ]
+          }
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 71,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2015-03-17T09:54:31Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.contributor-filter-tests.2.json
+++ b/common/search/src/test/resources/test_documents/images.examples.contributor-filter-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-06-16T13:22:34.312770Z",
+  "createdAt" : "2022-06-17T14:17:37.174542Z",
   "id" : "prsdh2ux",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/dUR.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,139 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "jyclobfb",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "jyclobfb",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "LS9JRLzitb"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-oQp59XpMDX",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "LS9JRLzitb"
+            "value" : "ePeodWcw6L"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-oQp59XpMDX",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "ePeodWcw6L"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "gzqCPb4Q7b"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 75
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "uuvqa0np",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "miro-image-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "3vOjlh3ibU"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-iYz6LnJY3J",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "agent" : {
-                "id" : {
-                  "type" : "Unidentifiable"
-                },
-                "label" : "Hypatia",
-                "prefix" : null,
-                "numeration" : null,
-                "type" : "Person"
-              },
-              "roles" : [
-              ]
-            }
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 96
+            "value" : "gzqCPb4Q7b"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 75,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1950-07-06T14:11:05Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.genre-filter-tests.0.json
+++ b/common/search/src/test/resources/test_documents/images.examples.genre-filter-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre filter tests",
-  "createdAt" : "2022-06-16T10:05:59.223Z",
+  "createdAt" : "2022-06-17T14:17:37.262212Z",
   "id" : "qcyfsx6m",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/JnY.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,149 +4290,82 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "rqwaqzmg",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "HsbumHNEvs"
+      "id" : {
+        "canonicalId" : "rqwaqzmg",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "HsbumHNEvs"
         },
-        "data" : {
-          "title" : "title-lrVi93g38g",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-            {
-              "label" : "Carrot counselling",
-              "concepts" : [
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "ea5UpWtdr8nwDiK",
-                  "type" : "Concept"
-                },
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "4kAuMEb4s4uH6iq",
-                  "type" : "Concept"
-                },
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "btUlOrD0NLgMOTW",
-                  "type" : "Concept"
-                }
-              ]
-            }
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 93
+        "otherIdentifiers" : [
+        ]
       },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "vy88fah4",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "Uo2c8D1QNm"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-LveorWrMXW",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
+      "data" : {
+        "title" : "title-lrVi93g38g",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+          {
+            "label" : "Carrot counselling",
+            "concepts" : [
+              {
+                "id" : {
+                  "type" : "Unidentifiable"
+                },
+                "label" : "ea5UpWtdr8nwDiK",
+                "type" : "Concept"
               },
-              "ontologyType" : "Work",
-              "value" : "W3zyzTFqqc"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
+              {
+                "id" : {
+                  "type" : "Unidentifiable"
+                },
+                "label" : "4kAuMEb4s4uH6iq",
+                "type" : "Concept"
               },
-              "ontologyType" : "Work",
-              "value" : "FlP3xluREc"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 4
+              {
+                "id" : {
+                  "type" : "Unidentifiable"
+                },
+                "label" : "btUlOrD0NLgMOTW",
+                "type" : "Concept"
+              }
+            ]
+          }
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 93,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2028-03-31T06:43:22Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.genre-filter-tests.1.json
+++ b/common/search/src/test/resources/test_documents/images.examples.genre-filter-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre filter tests",
-  "createdAt" : "2022-06-16T13:22:34.386952Z",
+  "createdAt" : "2022-06-17T14:17:37.262966Z",
   "id" : "lzykmofa",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/Cs1.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: DyA9FXJVs",
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,149 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "uhvc0wsj",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "uhvc0wsj",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "nXuQN3sRwm"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-Oi4EeXo6bC",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "nXuQN3sRwm"
+            "value" : "BfqgGiu1XN"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-Oi4EeXo6bC",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "BfqgGiu1XN"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "oIGIxIwfaE"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 87
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "ytpvh6y6",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "calm-record-id"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "f7xAldBr9g"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-uN8gmcFlUj",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-            {
-              "label" : "Dodo divination",
-              "concepts" : [
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "wxR3LuXUSwmwg8R",
-                  "type" : "Concept"
-                },
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "ah8ruH4gW92lY0W",
-                  "type" : "Concept"
-                },
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "YB5Iv2EQNO6HWaO",
-                  "type" : "Concept"
-                }
-              ]
-            }
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 73
+            "value" : "oIGIxIwfaE"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 87,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1940-05-31T19:25:04Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.genre-filter-tests.2.json
+++ b/common/search/src/test/resources/test_documents/images.examples.genre-filter-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre filter tests",
-  "createdAt" : "2022-06-16T10:05:59.224Z",
+  "createdAt" : "2022-06-17T14:17:37.264474Z",
   "id" : "a5vdwjyw",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/dgW.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: tG2Ppoj2Pk",
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,175 +4290,108 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "ybvhvhmm",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "d3F3T3c2Ex"
+      "id" : {
+        "canonicalId" : "ybvhvhmm",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "d3F3T3c2Ex"
         },
-        "data" : {
-          "title" : "title-FoY49Amdcn",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-            {
-              "label" : "Emu entrepreneurship",
-              "concepts" : [
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "u7ZcdvICxoSK1Dr",
-                  "type" : "Concept"
-                },
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "j431aOG9wNgvIxQ",
-                  "type" : "Concept"
-                },
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "sPO5NW41ZZ2VTHa",
-                  "type" : "Concept"
-                }
-              ]
-            },
-            {
-              "label" : "Falcon finances",
-              "concepts" : [
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "orJvBB7A7s6BgvM",
-                  "type" : "Concept"
-                },
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "PyqMVLhLFJmbaaq",
-                  "type" : "Concept"
-                },
-                {
-                  "id" : {
-                    "type" : "Unidentifiable"
-                  },
-                  "label" : "rFzY1hfYkJfAizG",
-                  "type" : "Concept"
-                }
-              ]
-            }
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 77
+        "otherIdentifiers" : [
+        ]
       },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "rlaqhgrm",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "8IWg5VyDYz"
+      "data" : {
+        "title" : "title-FoY49Amdcn",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+          {
+            "label" : "Emu entrepreneurship",
+            "concepts" : [
+              {
+                "id" : {
+                  "type" : "Unidentifiable"
+                },
+                "label" : "u7ZcdvICxoSK1Dr",
+                "type" : "Concept"
+              },
+              {
+                "id" : {
+                  "type" : "Unidentifiable"
+                },
+                "label" : "j431aOG9wNgvIxQ",
+                "type" : "Concept"
+              },
+              {
+                "id" : {
+                  "type" : "Unidentifiable"
+                },
+                "label" : "sPO5NW41ZZ2VTHa",
+                "type" : "Concept"
+              }
+            ]
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-L2YzDbGxZD",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
+          {
+            "label" : "Falcon finances",
+            "concepts" : [
+              {
+                "id" : {
+                  "type" : "Unidentifiable"
+                },
+                "label" : "orJvBB7A7s6BgvM",
+                "type" : "Concept"
               },
-              "ontologyType" : "Work",
-              "value" : "KjURDhjNiX"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
+              {
+                "id" : {
+                  "type" : "Unidentifiable"
+                },
+                "label" : "PyqMVLhLFJmbaaq",
+                "type" : "Concept"
               },
-              "ontologyType" : "Work",
-              "value" : "aSPptKYsrx"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 12
+              {
+                "id" : {
+                  "type" : "Unidentifiable"
+                },
+                "label" : "rFzY1hfYkJfAizG",
+                "type" : "Concept"
+              }
+            ]
+          }
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 77,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2008-11-21T17:51:58Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.linked-with-another-work.json
+++ b/common/search/src/test/resources/test_documents/images.examples.linked-with-another-work.json
@@ -1,6 +1,6 @@
 {
   "description" : "images linked with another work",
-  "createdAt" : "2022-06-16T10:05:59.292Z",
+  "createdAt" : "2022-06-17T14:17:37.475948Z",
   "id" : "pv9twlun",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/mge.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "5flxr1rc",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "5flxr1rc",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "tiAOroLCxj"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-8FHEE5trHI",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "tiAOroLCxj"
+            "value" : "tPhowmMUFH"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-8FHEE5trHI",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "tPhowmMUFH"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "A0uq9QSaeC"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 40
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "cimtgqv5",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "k5hJ4W1Rjd"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-vHgb0sfZd5",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "BrVTOfehT6"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "FZMb17FgV3"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 81
+            "value" : "A0uq9QSaeC"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 40,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1951-09-19T15:21:32Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.linked-with-the-same-work.0.json
+++ b/common/search/src/test/resources/test_documents/images.examples.linked-with-the-same-work.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images linked with the same work",
-  "createdAt" : "2022-06-16T10:05:59.277Z",
+  "createdAt" : "2022-06-17T14:17:37.418236Z",
   "id" : "itepdebl",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/BLC.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "q5rilm5u",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "q5rilm5u",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "ZZNBn5yp9S"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-3QUhCfD8KT",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "ZZNBn5yp9S"
+            "value" : "VSEe950IoQ"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-3QUhCfD8KT",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "VSEe950IoQ"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "3uWcXB2Lpw"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 42
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "nia0ccje",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "XphHLfvwLB"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-2mZyJtsjdD",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "3Vluwa0Yfo"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "vLwuJjsiyB"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 89
+            "value" : "3uWcXB2Lpw"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 42,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1948-07-19T20:20:20Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.linked-with-the-same-work.1.json
+++ b/common/search/src/test/resources/test_documents/images.examples.linked-with-the-same-work.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images linked with the same work",
-  "createdAt" : "2022-06-16T10:05:59.277Z",
+  "createdAt" : "2022-06-17T14:17:37.419198Z",
   "id" : "eum5hdh8",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/H0t.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: BzJXc47yb",
-          "linkText" : "Link text: 0mJrqtX",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "q5rilm5u",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "q5rilm5u",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "ZZNBn5yp9S"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-3QUhCfD8KT",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "ZZNBn5yp9S"
+            "value" : "VSEe950IoQ"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-3QUhCfD8KT",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "VSEe950IoQ"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "3uWcXB2Lpw"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 42
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "h6dk4icr",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "lJgoorbUcB"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-pgK6Ez5fiC",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "1cmhijbtbB"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "BGpIi3Wi1F"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 35
+            "value" : "3uWcXB2Lpw"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 42,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1977-05-29T10:06:51Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.linked-with-the-same-work.2.json
+++ b/common/search/src/test/resources/test_documents/images.examples.linked-with-the-same-work.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images linked with the same work",
-  "createdAt" : "2022-06-16T10:05:59.277Z",
+  "createdAt" : "2022-06-17T14:17:37.419712Z",
   "id" : "ca2bzfap",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/FJ9.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: bGMmkT0cv",
-          "linkText" : "Link text: mfB7SF",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "q5rilm5u",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "q5rilm5u",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "ZZNBn5yp9S"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-3QUhCfD8KT",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "ZZNBn5yp9S"
+            "value" : "VSEe950IoQ"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-3QUhCfD8KT",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "VSEe950IoQ"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "3uWcXB2Lpw"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 42
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "wxzpesch",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "k7URAlOP7B"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-5VHtsry5TY",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "W0jMD06aqA"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "ycDSSYfBVc"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 32
+            "value" : "3uWcXB2Lpw"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 42,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2010-08-18T06:10:02Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.examples.linked-with-the-same-work.3.json
+++ b/common/search/src/test/resources/test_documents/images.examples.linked-with-the-same-work.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "images linked with the same work",
-  "createdAt" : "2022-06-16T10:05:59.278Z",
+  "createdAt" : "2022-06-17T14:17:37.420416Z",
   "id" : "vbclfca8",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/3Z0.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : "Link text: 7rLspf",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "q5rilm5u",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "q5rilm5u",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "ZZNBn5yp9S"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-3QUhCfD8KT",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "ZZNBn5yp9S"
+            "value" : "VSEe950IoQ"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-3QUhCfD8KT",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "VSEe950IoQ"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "3uWcXB2Lpw"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 42
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "qeakiigx",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "31OZpc7WPE"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-MWh3GkIVJ2",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "Sxrp1p94aY"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "hmXdgtY1kt"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 28
+            "value" : "3uWcXB2Lpw"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 42,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2067-12-25T20:15:17Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.genres.0.json
+++ b/common/search/src/test/resources/test_documents/images.genres.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different genres",
-  "createdAt" : "2022-06-16T10:05:59.027Z",
+  "createdAt" : "2022-06-17T14:17:36.774374Z",
   "id" : "j2kzh3nk",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/Lqd.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : "Link text: ZBvAtX",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,128 +4290,61 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "knpqsu1i",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "miro-image-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "Vbl3GPrTBa"
+      "id" : {
+        "canonicalId" : "knpqsu1i",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "miro-image-number"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "Vbl3GPrTBa"
         },
-        "data" : {
-          "title" : "title-KW7LwA4X3s",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-            {
-              "label" : "Carrot counselling",
-              "concepts" : [
-              ]
-            }
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 51
+        "otherIdentifiers" : [
+        ]
       },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "a2zyy2l6",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "bsU5j58SPp"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-JNkNFej9S4",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "bxNw6CjGBQ"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "V7uZKJdf3T"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 68
+      "data" : {
+        "title" : "title-KW7LwA4X3s",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+          {
+            "label" : "Carrot counselling",
+            "concepts" : [
+            ]
+          }
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 51,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1977-04-17T05:50:13Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.genres.1.json
+++ b/common/search/src/test/resources/test_documents/images.genres.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different genres",
-  "createdAt" : "2022-06-16T13:22:34.069560Z",
+  "createdAt" : "2022-06-17T14:17:36.775400Z",
   "id" : "0e6ywtkv",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/XZ0.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: AQrHxtIxm",
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,128 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "shuyd9d9",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "shuyd9d9",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "Upa5XSdSCa"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-1Eani7wEXC",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "Upa5XSdSCa"
+            "value" : "PcdYJTJjgv"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-1Eani7wEXC",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "PcdYJTJjgv"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "0DR4bczh4D"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 97
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "vzh7twjd",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "calm-record-id"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "rIPmsLxNS6"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-KBNF1RBEzj",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-            {
-              "label" : "Dodo divination",
-              "concepts" : [
-              ]
-            }
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 57
+            "value" : "0DR4bczh4D"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 97,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1983-12-19T07:44:31Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.genres.2.json
+++ b/common/search/src/test/resources/test_documents/images.genres.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different genres",
-  "createdAt" : "2022-06-16T10:05:59.029Z",
+  "createdAt" : "2022-06-17T14:17:36.776518Z",
   "id" : "93ppiboa",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/RdA.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,138 +4290,71 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "jg1envol",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "calm-record-id"
-            },
-            "ontologyType" : "Work",
-            "value" : "ffU7rWFuZ5"
+      "id" : {
+        "canonicalId" : "jg1envol",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "calm-record-id"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "ffU7rWFuZ5"
         },
-        "data" : {
-          "title" : "title-9LgUkLJbXx",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-            {
-              "label" : "Emu entrepreneurship",
-              "concepts" : [
-              ]
-            },
-            {
-              "label" : "Falcon finances",
-              "concepts" : [
-              ]
-            },
-            {
-              "label" : "Carrot counselling",
-              "concepts" : [
-              ]
-            }
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 20
+        "otherIdentifiers" : [
+        ]
       },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "gl7spuby",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "ynyefHr4pr"
+      "data" : {
+        "title" : "title-9LgUkLJbXx",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+          {
+            "label" : "Emu entrepreneurship",
+            "concepts" : [
+            ]
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-nhAG2LJXoY",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "dfLc8CMFXa"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "SDX2jNOLTq"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 38
+          {
+            "label" : "Falcon finances",
+            "concepts" : [
+            ]
+          },
+          {
+            "label" : "Carrot counselling",
+            "concepts" : [
+            ]
+          }
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 20,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1993-04-06T16:54:43Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.inferred-data.none.json
+++ b/common/search/src/test/resources/test_documents/images.inferred-data.none.json
@@ -1,6 +1,6 @@
 {
   "description" : "an image without any inferred data",
-  "createdAt" : "2022-06-16T10:05:59.172Z",
+  "createdAt" : "2022-06-17T14:17:37.108764Z",
   "id" : "3qfljen1",
   "document" : {
     "version" : 1,
@@ -13,24 +13,7 @@
         "value" : "EeP0YtzZkm"
       },
       "canonicalId" : "3qfljen1",
-      "inferredData" : null,
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/B4K.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: 0y3zkJPxq",
-          "linkText" : "Link text: iGWWhPuT",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
-      }
+      "inferredData" : null
     },
     "locations" : [
       {
@@ -48,137 +31,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "83lbmnbq",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "83lbmnbq",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "1frEihcKHF"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-RzQWwkxYvQ",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "1frEihcKHF"
+            "value" : "7VU1RiUuNm"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-RzQWwkxYvQ",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "7VU1RiUuNm"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "iayrdzvFv6"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 90
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "8yiwkawp",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "FNdK9ccvvw"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-1BEXExZJjg",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "iUZMYKYU0H"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "2KPZok3DUj"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 50
+            "value" : "iayrdzvFv6"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 90,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1940-03-10T12:48:30Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.inferred-data.wrong-format.json
+++ b/common/search/src/test/resources/test_documents/images.inferred-data.wrong-format.json
@@ -1,6 +1,6 @@
 {
   "description" : "an image with inferred data in the wrong format",
-  "createdAt" : "2022-06-16T10:05:59.176Z",
+  "createdAt" : "2022-06-17T14:17:37.119481Z",
   "id" : "s2crnicc",
   "document" : {
     "version" : 1,
@@ -4258,23 +4258,6 @@
           1.0
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/LAI.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4293,137 +4276,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "hczczvlx",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "hczczvlx",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "rgpy024kxw"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-nS1xEFg03c",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "rgpy024kxw"
+            "value" : "w2XdkRUpGr"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-nS1xEFg03c",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "w2XdkRUpGr"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "dGWLfGqPf4"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 1
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "vumaj26a",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "Q2PbcY4vrZ"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-NZf1DfXrMN",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "mAkdIuEPQ3"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "CrZZofCNKf"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 18
+            "value" : "dGWLfGqPf4"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 1,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2030-05-17T13:15:40Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.0.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-06-16T10:05:59.065Z",
+  "createdAt" : "2022-06-17T14:17:36.840092Z",
   "id" : "a5lj9duc",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/RlZ.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : "Link text: 4N3l8IuPN0",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "anys7vbv",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "anys7vbv",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "eT3Wot5CJh"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-vpbsaVsvTg",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "eT3Wot5CJh"
+            "value" : "kPR9lGhQZG"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-vpbsaVsvTg",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "kPR9lGhQZG"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "6MtBF0iLaf"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 50
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "rnvogt9x",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "VXSqG8BkfK"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-UaNMHaGNOW",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "RMhSIJX4qc"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "lPVXq0dxH0"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 84
+            "value" : "6MtBF0iLaf"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 50,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1967-12-20T13:17:31Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.1.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-06-16T10:05:59.066Z",
+  "createdAt" : "2022-06-17T14:17:36.841083Z",
   "id" : "dqlalauc",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/I2D.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "j4l3wsjt",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "j4l3wsjt",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "jhpOEFGyJh"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-Q8uNY7ZOEu",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "jhpOEFGyJh"
+            "value" : "u5hFTvjRl0"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-Q8uNY7ZOEu",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "u5hFTvjRl0"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "dmSkfS4HR7"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 70
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "xswobwyj",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "hwVyrBcNh1"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-if60BpXKy5",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "r781XNHW33"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "N0pmK6GyXN"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 37
+            "value" : "dmSkfS4HR7"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 70,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2015-05-25T06:00:26Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.2.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-06-16T10:05:59.066Z",
+  "createdAt" : "2022-06-17T14:17:36.841914Z",
   "id" : "fp9x20si",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/WIk.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: 7SWk3TTSq0",
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "othidyxy",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "othidyxy",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "R5nXJ8LU0O"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-pEAVa4Rz7i",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "R5nXJ8LU0O"
+            "value" : "5Gc2H6DBq6"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-pEAVa4Rz7i",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "5Gc2H6DBq6"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "DMA5Nbp7gh"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 39
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "cjy8c7it",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "QudiExqLL5"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-ISwByIXDzH",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "FkmDNF7wRF"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "4nv58B7OZQ"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 68
+            "value" : "DMA5Nbp7gh"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 39,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1965-08-27T13:12:51Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.3.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-06-16T10:05:59.067Z",
+  "createdAt" : "2022-06-17T14:17:36.842804Z",
   "id" : "fsq3gsq0",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/T69.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: u1A2IYFqOO",
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "80trgzaf",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "80trgzaf",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "GGLQ3iRnuX"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-AOCEgK2yRE",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "GGLQ3iRnuX"
+            "value" : "nLAEt0hmeJ"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-AOCEgK2yRE",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "nLAEt0hmeJ"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "xOsyhrktFF"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 85
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "exhb55fs",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "HHZ8S2LjCU"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-9wuBLD4OfZ",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "AQBDY7Uhnt"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "12eZNNtj0Q"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 31
+            "value" : "xOsyhrktFF"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 85,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2059-10-04T07:50:39Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.4.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-06-16T10:05:59.068Z",
+  "createdAt" : "2022-06-17T14:17:36.843545Z",
   "id" : "vcflqowx",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/yw2.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: iMzNq5f99",
-          "linkText" : "Link text: Z6HmsHmLL",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "ov8cs7dy",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "ov8cs7dy",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "8KV3FdO6Nv"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-U90KOXEeRV",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "8KV3FdO6Nv"
+            "value" : "xRFVk3DJKb"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-U90KOXEeRV",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "xRFVk3DJKb"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "JMawpDZ3hD"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 38
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "djvppfnh",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "HpTB2KrFOO"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-BtHA8cMlcj",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "xtbDt9CpZL"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "slouwebRCs"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 96
+            "value" : "JMawpDZ3hD"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 38,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1953-11-07T05:44:18Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.5.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-06-16T10:05:59.068Z",
+  "createdAt" : "2022-06-17T14:17:36.844220Z",
   "id" : "wfdcghky",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/lHZ.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: daywHchuw",
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "hs3nzqux",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "hs3nzqux",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "BVlucvdPgC"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-lPUpm8UfHO",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "BVlucvdPgC"
+            "value" : "V5DzWZrL98"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-lPUpm8UfHO",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "V5DzWZrL98"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "TO4Od9aTWk"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 51
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "74mawllu",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "iOw9482Bdo"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-KAq5KW7vmp",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "IFXJ3CPuZd"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "Mgx9KAm2z6"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 32
+            "value" : "TO4Od9aTWk"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 51,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2058-05-27T11:20:52Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-features.0.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-06-16T10:05:59.112Z",
+  "createdAt" : "2022-06-17T14:17:36.934671Z",
   "id" : "avn4splt",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/gRU.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: 0E7PyTlgnF",
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "udimdxnm",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "udimdxnm",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "CUckD7U3SU"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-SAstkO6d67",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "CUckD7U3SU"
+            "value" : "h2ldsrjm9S"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-SAstkO6d67",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "h2ldsrjm9S"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "jI12Zh0235"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 23
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "09havvht",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "3bjIUfT4IY"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-2Zh68KxTIM",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "CvjzuChhbl"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "sqhVDPZqzv"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 86
+            "value" : "jI12Zh0235"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 23,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1974-08-12T21:41:35Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-features.1.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-06-16T10:05:59.113Z",
+  "createdAt" : "2022-06-17T14:17:36.935605Z",
   "id" : "pg4glndt",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/k7d.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: rZwWNxllWp",
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "dx3dxn4f",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "dx3dxn4f",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "HEJkEsEnea"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-zrA90sIKcC",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "HEJkEsEnea"
+            "value" : "RRZKrOKEyg"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-zrA90sIKcC",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "RRZKrOKEyg"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "LfpmRlBQN7"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 89
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "a0lm6svh",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "2Bsv7WIsKo"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-MGwwXxcGOQ",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "xkTMrAyQlA"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "TrNG3ecu2u"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 52
+            "value" : "LfpmRlBQN7"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 89,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2024-12-30T05:07:50Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-features.2.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-06-16T10:05:59.113Z",
+  "createdAt" : "2022-06-17T14:17:36.936484Z",
   "id" : "as90yzzb",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/w1x.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: hQH1jdZR",
-          "linkText" : "Link text: VnfjXQ4",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "jlk1ajcg",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "jlk1ajcg",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "kJr0AvGWG5"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-1N8IA7dbNc",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "kJr0AvGWG5"
+            "value" : "k1A6TyPY4B"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-1N8IA7dbNc",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "k1A6TyPY4B"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "70LkatHsS9"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 96
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "patgkk5u",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "9F7x4ikZwT"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-jDU2xpQiy3",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "ZxMi98ZjFh"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "w2WNpz9NAU"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 77
+            "value" : "70LkatHsS9"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 96,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2020-02-01T08:49:23Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-features.3.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-06-16T10:05:59.114Z",
+  "createdAt" : "2022-06-17T14:17:36.937253Z",
   "id" : "e7h0ngrc",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/pj3.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: kIVOsu3kyj",
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "yzkcyo8a",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "yzkcyo8a",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "MOzoQk6iId"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-lnrm0uU03m",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "MOzoQk6iId"
+            "value" : "13IRjAl5ax"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-lnrm0uU03m",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "13IRjAl5ax"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "ryRMcQ8Dpp"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 96
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "imflm5n9",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "udK6oa7tYQ"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-COHPUrEtf5",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "QDRotyRn7M"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "n3rGyoGyA2"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 92
+            "value" : "ryRMcQ8Dpp"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 96,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1955-10-22T05:43:23Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-features.4.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-06-16T10:05:59.115Z",
+  "createdAt" : "2022-06-17T14:17:36.938072Z",
   "id" : "yspicvrr",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/4R3.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : "Link text: m6RLta",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "gpcnavlf",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "gpcnavlf",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "84oKxNfkfi"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-zQer0e2qKz",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "84oKxNfkfi"
+            "value" : "7na0ZZl4fD"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-zQer0e2qKz",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "7na0ZZl4fD"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "2jkdq7aJbJ"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 37
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "9zsdkyj1",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "UABYZNnhJ9"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-J8g52RfcNr",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "pV3pJJH0Pz"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "w5mGbbAM78"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 15
+            "value" : "2jkdq7aJbJ"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 37,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2037-05-29T00:47:41Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-features.5.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-06-16T10:05:59.115Z",
+  "createdAt" : "2022-06-17T14:17:36.938680Z",
   "id" : "ysyk8jmh",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/BmE.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: 5oebc7ii9",
-          "linkText" : "Link text: 6yXDs5nG",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "tgvflupr",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "tgvflupr",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "Lx0Zo2WXqx"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-YIKodlLnLq",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "Lx0Zo2WXqx"
+            "value" : "bD4RflvL6k"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-YIKodlLnLq",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "bD4RflvL6k"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "d7pTm2U5jO"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 24
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "xuhww69s",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "ZHpxzBbMw7"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-rkNP61mE2u",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "2EIdKMu6Ec"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "CJDIYXbJjv"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 48
+            "value" : "d7pTm2U5jO"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 24,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2026-12-01T17:43:55Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-palettes.0.json
+++ b/common/search/src/test/resources/test_documents/images.similar-palettes.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-06-16T10:05:59.148Z",
+  "createdAt" : "2022-06-17T14:17:37.033283Z",
   "id" : "ugow7dpj",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/rkd.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "ah74nuba",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "ah74nuba",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "i3ahqbqPU5"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-i4Lw8upNgg",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "i3ahqbqPU5"
+            "value" : "2YzxbUE7AI"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-i4Lw8upNgg",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "2YzxbUE7AI"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "VGs3XmlsOW"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 32
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "hrxir7wf",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "LqUVbP449Z"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-ImkDQxOvW5",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "Iyi72qqEV6"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "fMleJca71H"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 77
+            "value" : "VGs3XmlsOW"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 32,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1958-05-13T00:31:32Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-palettes.1.json
+++ b/common/search/src/test/resources/test_documents/images.similar-palettes.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-06-16T10:05:59.149Z",
+  "createdAt" : "2022-06-17T14:17:37.033929Z",
   "id" : "o2fdybit",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/4QL.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : "Link text: Fl9VrODZy",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "pyhklpry",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "pyhklpry",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "FCURICpaae"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-rQmMYtpbz1",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "FCURICpaae"
+            "value" : "lDCWSqM16b"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-rQmMYtpbz1",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "lDCWSqM16b"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "jHlKSF0YUj"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 9
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "nmow5k33",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "706t7mv7ka"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-vz6nnqJywn",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "0ROPVMoAMm"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "ioWNbDYqhV"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 77
+            "value" : "jHlKSF0YUj"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 9,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2052-07-30T06:44:32Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-palettes.2.json
+++ b/common/search/src/test/resources/test_documents/images.similar-palettes.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-06-16T10:05:59.149Z",
+  "createdAt" : "2022-06-17T14:17:37.034771Z",
   "id" : "mjpos4im",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/71l.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "3rl99ijt",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "3rl99ijt",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "TPPslPrvWu"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-kjWRHDMRRi",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "TPPslPrvWu"
+            "value" : "i4OiBzFGMV"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-kjWRHDMRRi",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "i4OiBzFGMV"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "NYpJObUzfE"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 82
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "hvgdfyzr",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "iYBI45xtes"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-V6x0yduCy7",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "jt5Iy0ZJ1o"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "NSjyDwL3zu"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 18
+            "value" : "NYpJObUzfE"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 82,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1936-01-27T06:28:37Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-palettes.3.json
+++ b/common/search/src/test/resources/test_documents/images.similar-palettes.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-06-16T10:05:59.150Z",
+  "createdAt" : "2022-06-17T14:17:37.035293Z",
   "id" : "lsw9sbu8",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/23S.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: f89Kn3",
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "50v1mskl",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "50v1mskl",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "8Xl9VcOro5"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-BaVKuyDC49",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "8Xl9VcOro5"
+            "value" : "lhxyMEPgr0"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-BaVKuyDC49",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "lhxyMEPgr0"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "xMgPd8HZiW"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 96
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "uv9wjvit",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "XPVK6LstMr"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-STU6GN5kzg",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "YhiDFEb3tY"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "lZ9SODGv83"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 75
+            "value" : "xMgPd8HZiW"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 96,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1971-09-22T22:04:19Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-palettes.4.json
+++ b/common/search/src/test/resources/test_documents/images.similar-palettes.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-06-16T10:05:59.150Z",
+  "createdAt" : "2022-06-17T14:17:37.035906Z",
   "id" : "xkvk6o8c",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/6NJ.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : "Link text: qzSZVIHUd",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "nx2evtp1",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "nx2evtp1",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "8fRRQHYvyg"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-kJQyNEOteB",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "8fRRQHYvyg"
+            "value" : "ZbisTdgGZu"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-kJQyNEOteB",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "ZbisTdgGZu"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "X3piQiuwnC"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 99
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "izioypbg",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "d5ByDvkLUB"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-gFSJ5YA62R",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "dzJYtjbV7O"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "h8rX2MsNYY"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 27
+            "value" : "X3piQiuwnC"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 99,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1968-08-19T19:01:35Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.similar-palettes.5.json
+++ b/common/search/src/test/resources/test_documents/images.similar-palettes.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-06-16T10:05:59.151Z",
+  "createdAt" : "2022-06-17T14:17:37.036507Z",
   "id" : "jchfkdrz",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/OjP.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : "Link text: SZeA46Q0X",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,137 +4290,70 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "kbyunwpo",
-          "sourceIdentifier" : {
+      "id" : {
+        "canonicalId" : "kbyunwpo",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "sierra-system-number"
+          },
+          "ontologyType" : "Work",
+          "value" : "4myqlbiwHO"
+        },
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-OIeTcSbJAC",
+        "otherIdentifiers" : [
+          {
             "identifierType" : {
               "id" : "sierra-system-number"
             },
             "ontologyType" : "Work",
-            "value" : "4myqlbiwHO"
+            "value" : "On2KFb2Mgl"
           },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-OIeTcSbJAC",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "On2KFb2Mgl"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "sEoJWOQC0i"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 84
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "fvslzoef",
-          "sourceIdentifier" : {
+          {
             "identifierType" : {
-              "id" : "sierra-system-number"
+              "id" : "sierra-identifier"
             },
             "ontologyType" : "Work",
-            "value" : "emEBEnQ1qZ"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-rIhcZ1TjSL",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "Nvz0FPv0zK"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "mEwoEXZK3X"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 29
+            "value" : "sEoJWOQC0i"
+          }
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 84,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2011-09-08T14:48:17Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.subjects.screwdrivers-1.json
+++ b/common/search/src/test/resources/test_documents/images.subjects.screwdrivers-1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-06-16T13:22:34.577062Z",
+  "createdAt" : "2022-06-17T14:17:37.580230Z",
   "id" : "e4perwdd",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/rF7.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : "Link text: a0I0RfQ",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,141 +4290,74 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "ywof9b5g",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "calm-record-id"
-            },
-            "ontologyType" : "Work",
-            "value" : "QysWHmvjbt"
+      "id" : {
+        "canonicalId" : "ywof9b5g",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "calm-record-id"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "QysWHmvjbt"
         },
-        "data" : {
-          "title" : "title-bWGUlHzXp8",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-            {
-              "id" : {
-                "canonicalId" : "subject1",
-                "sourceIdentifier" : {
-                  "identifierType" : {
-                    "id" : "calm-record-id"
-                  },
-                  "ontologyType" : "Work",
-                  "value" : "6LCDqmBFKE"
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-bWGUlHzXp8",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+          {
+            "id" : {
+              "canonicalId" : "subject1",
+              "sourceIdentifier" : {
+                "identifierType" : {
+                  "id" : "calm-record-id"
                 },
-                "otherIdentifiers" : [
-                ],
-                "type" : "Identified"
+                "ontologyType" : "Work",
+                "value" : "6LCDqmBFKE"
               },
-              "label" : "Simple screwdrivers",
-              "concepts" : [
-              ]
-            }
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 11
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "xwoxaywr",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
+              "otherIdentifiers" : [
+              ],
+              "type" : "Identified"
             },
-            "ontologyType" : "Work",
-            "value" : "1U9oZIIVpF"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-IRxp1jy5Ai",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "3ImHfJDVxI"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "ozr9w2e7VW"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 34
+            "label" : "Simple screwdrivers",
+            "concepts" : [
+            ]
+          }
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 11,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1978-04-07T19:39:17Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.subjects.screwdrivers-2.json
+++ b/common/search/src/test/resources/test_documents/images.subjects.screwdrivers-2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-06-16T13:22:34.585775Z",
+  "createdAt" : "2022-06-17T14:17:37.593619Z",
   "id" : "xlfyrof0",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/cpH.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: fOEeLsDxVk",
-          "linkText" : "Link text: z848hRH",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,141 +4290,74 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "bw9e8exh",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "miro-image-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "pbGXS2tKwO"
+      "id" : {
+        "canonicalId" : "bw9e8exh",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "miro-image-number"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "pbGXS2tKwO"
         },
-        "data" : {
-          "title" : "title-xQFFUAnwSg",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-            {
-              "id" : {
-                "canonicalId" : "subject1",
-                "sourceIdentifier" : {
-                  "identifierType" : {
-                    "id" : "calm-record-id"
-                  },
-                  "ontologyType" : "Work",
-                  "value" : "6LCDqmBFKE"
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-xQFFUAnwSg",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+          {
+            "id" : {
+              "canonicalId" : "subject1",
+              "sourceIdentifier" : {
+                "identifierType" : {
+                  "id" : "calm-record-id"
                 },
-                "otherIdentifiers" : [
-                ],
-                "type" : "Identified"
+                "ontologyType" : "Work",
+                "value" : "6LCDqmBFKE"
               },
-              "label" : "Simple screwdrivers",
-              "concepts" : [
-              ]
-            }
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 62
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "d9qf5r50",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
+              "otherIdentifiers" : [
+              ],
+              "type" : "Identified"
             },
-            "ontologyType" : "Work",
-            "value" : "wS8uGSqVia"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-voIkCzfLY2",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "byQOTrSAyw"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "02VTLrjN4e"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 16
+            "label" : "Simple screwdrivers",
+            "concepts" : [
+            ]
+          }
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 62,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2025-05-11T01:49:47Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.subjects.sounds.json
+++ b/common/search/src/test/resources/test_documents/images.subjects.sounds.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-06-16T10:05:59.318Z",
+  "createdAt" : "2022-06-17T14:17:37.566871Z",
   "id" : "xnb29lxt",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/Icx.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,131 +4290,64 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "eealituc",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "calm-record-id"
-            },
-            "ontologyType" : "Work",
-            "value" : "owxVMjyVJV"
+      "id" : {
+        "canonicalId" : "eealituc",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "calm-record-id"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "owxVMjyVJV"
         },
-        "data" : {
-          "title" : "title-CsSvOQ3XSc",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "label" : "Square sounds",
-              "concepts" : [
-              ]
-            }
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 42
+        "otherIdentifiers" : [
+        ]
       },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "ghmqbwou",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
+      "data" : {
+        "title" : "title-CsSvOQ3XSc",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+          {
+            "id" : {
+              "type" : "Unidentifiable"
             },
-            "ontologyType" : "Work",
-            "value" : "XxgrKEqaqV"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-dP0VhGgFs0",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "P44IOCqGU7"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "Ynm8jVkxmY"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 73
+            "label" : "Square sounds",
+            "concepts" : [
+            ]
+          }
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 42,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "1969-04-15T08:20:29Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.subjects.squirrel,sample.json
+++ b/common/search/src/test/resources/test_documents/images.subjects.squirrel,sample.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-06-16T13:22:34.594087Z",
+  "createdAt" : "2022-06-17T14:17:37.606745Z",
   "id" : "hszkjtb7",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/qkQ.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : null,
-          "linkText" : null,
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,149 +4290,82 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "oaegix5d",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "miro-image-number"
-            },
-            "ontologyType" : "Work",
-            "value" : "LvUtwxDf0F"
+      "id" : {
+        "canonicalId" : "oaegix5d",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "miro-image-number"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "LvUtwxDf0F"
         },
-        "data" : {
-          "title" : "title-aCK1XcqcTe",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "label" : "Squashed squirrels",
-              "concepts" : [
-              ]
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-aCK1XcqcTe",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+          {
+            "id" : {
+              "type" : "Unidentifiable"
             },
-            {
-              "id" : {
-                "canonicalId" : "subject2",
-                "sourceIdentifier" : {
-                  "identifierType" : {
-                    "id" : "sierra-system-number"
-                  },
-                  "ontologyType" : "Work",
-                  "value" : "b5OTITpYOx"
+            "label" : "Squashed squirrels",
+            "concepts" : [
+            ]
+          },
+          {
+            "id" : {
+              "canonicalId" : "subject2",
+              "sourceIdentifier" : {
+                "identifierType" : {
+                  "id" : "sierra-system-number"
                 },
-                "otherIdentifiers" : [
-                ],
-                "type" : "Identified"
+                "ontologyType" : "Work",
+                "value" : "b5OTITpYOx"
               },
-              "label" : "Struck samples",
-              "concepts" : [
-              ]
-            }
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 77
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "sriqjwbn",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
+              "otherIdentifiers" : [
+              ],
+              "type" : "Identified"
             },
-            "ontologyType" : "Work",
-            "value" : "whYEBZGM9X"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-fbRZ78oL82",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "gNIfUHFX98"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "vfrF2zfUhm"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 90
+            "label" : "Struck samples",
+            "concepts" : [
+            ]
+          }
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 77,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2023-02-21T17:37:02Z",
     "display" : {

--- a/common/search/src/test/resources/test_documents/images.subjects.squirrel,screwdriver.json
+++ b/common/search/src/test/resources/test_documents/images.subjects.squirrel,screwdriver.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-06-16T13:22:34.608855Z",
+  "createdAt" : "2022-06-17T14:17:37.620662Z",
   "id" : "yuy15ulc",
   "document" : {
     "version" : 1,
@@ -4272,23 +4272,6 @@
           0.6996027
         ],
         "aspectRatio" : 0.9475815
-      },
-      "derivedData" : {
-        "thumbnail" : {
-          "url" : "https://iiif.wellcomecollection.org/image/ZFv.jpg/info.json",
-          "locationType" : {
-            "id" : "iiif-image"
-          },
-          "license" : {
-            "id" : "cc-by"
-          },
-          "credit" : "Credit line: cYSJenKay",
-          "linkText" : "Link text: jw60Fae",
-          "accessConditions" : [
-          ]
-        },
-        "sourceContributorAgents" : [
-        ]
       }
     },
     "locations" : [
@@ -4307,149 +4290,82 @@
       }
     ],
     "source" : {
-      "canonicalWork" : {
-        "id" : {
-          "canonicalId" : "trcvf8l5",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "calm-record-id"
-            },
-            "ontologyType" : "Work",
-            "value" : "gK4Ob24nqL"
+      "id" : {
+        "canonicalId" : "trcvf8l5",
+        "sourceIdentifier" : {
+          "identifierType" : {
+            "id" : "calm-record-id"
           },
-          "otherIdentifiers" : [
-          ]
+          "ontologyType" : "Work",
+          "value" : "gK4Ob24nqL"
         },
-        "data" : {
-          "title" : "title-4xmgFbck8a",
-          "otherIdentifiers" : [
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-            {
-              "id" : {
-                "type" : "Unidentifiable"
-              },
-              "label" : "Squashed squirrels",
-              "concepts" : [
-              ]
+        "otherIdentifiers" : [
+        ]
+      },
+      "data" : {
+        "title" : "title-4xmgFbck8a",
+        "otherIdentifiers" : [
+        ],
+        "alternativeTitles" : [
+        ],
+        "format" : null,
+        "description" : null,
+        "physicalDescription" : null,
+        "lettering" : null,
+        "createdDate" : null,
+        "subjects" : [
+          {
+            "id" : {
+              "type" : "Unidentifiable"
             },
-            {
-              "id" : {
-                "canonicalId" : "subject1",
-                "sourceIdentifier" : {
-                  "identifierType" : {
-                    "id" : "calm-record-id"
-                  },
-                  "ontologyType" : "Work",
-                  "value" : "6LCDqmBFKE"
+            "label" : "Squashed squirrels",
+            "concepts" : [
+            ]
+          },
+          {
+            "id" : {
+              "canonicalId" : "subject1",
+              "sourceIdentifier" : {
+                "identifierType" : {
+                  "id" : "calm-record-id"
                 },
-                "otherIdentifiers" : [
-                ],
-                "type" : "Identified"
+                "ontologyType" : "Work",
+                "value" : "6LCDqmBFKE"
               },
-              "label" : "Simple screwdrivers",
-              "concepts" : [
-              ]
-            }
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 40
-      },
-      "redirectedWork" : {
-        "id" : {
-          "canonicalId" : "l8royjuw",
-          "sourceIdentifier" : {
-            "identifierType" : {
-              "id" : "sierra-system-number"
+              "otherIdentifiers" : [
+              ],
+              "type" : "Identified"
             },
-            "ontologyType" : "Work",
-            "value" : "5Y38TESOeV"
-          },
-          "otherIdentifiers" : [
-          ]
-        },
-        "data" : {
-          "title" : "title-eYB6PMOgRy",
-          "otherIdentifiers" : [
-            {
-              "identifierType" : {
-                "id" : "sierra-system-number"
-              },
-              "ontologyType" : "Work",
-              "value" : "kFLZGnj01z"
-            },
-            {
-              "identifierType" : {
-                "id" : "sierra-identifier"
-              },
-              "ontologyType" : "Work",
-              "value" : "cWotUQCunp"
-            }
-          ],
-          "alternativeTitles" : [
-          ],
-          "format" : null,
-          "description" : null,
-          "physicalDescription" : null,
-          "lettering" : null,
-          "createdDate" : null,
-          "subjects" : [
-          ],
-          "genres" : [
-          ],
-          "contributors" : [
-          ],
-          "thumbnail" : null,
-          "production" : [
-          ],
-          "languages" : [
-          ],
-          "edition" : null,
-          "notes" : [
-          ],
-          "duration" : null,
-          "items" : [
-          ],
-          "holdings" : [
-          ],
-          "collectionPath" : null,
-          "referenceNumber" : null,
-          "imageData" : [
-          ],
-          "workType" : "Standard"
-        },
-        "version" : 55
+            "label" : "Simple screwdrivers",
+            "concepts" : [
+            ]
+          }
+        ],
+        "genres" : [
+        ],
+        "contributors" : [
+        ],
+        "thumbnail" : null,
+        "production" : [
+        ],
+        "languages" : [
+        ],
+        "edition" : null,
+        "notes" : [
+        ],
+        "duration" : null,
+        "items" : [
+        ],
+        "holdings" : [
+        ],
+        "collectionPath" : null,
+        "referenceNumber" : null,
+        "imageData" : [
+        ],
+        "workType" : "Standard"
       },
-      "type" : "ParentWorks"
+      "version" : 40,
+      "type" : "ParentWork"
     },
     "modifiedTime" : "2037-08-30T11:57:22Z",
     "display" : {

--- a/concepts/config.ts
+++ b/concepts/config.ts
@@ -10,7 +10,7 @@ const environmentSchema = z.object({
 const environment = environmentSchema.parse(process.env);
 
 const config = {
-  pipelineDate: "2022-06-17",
+  pipelineDate: "2022-06-18",
   serviceName: "catalogue_api", // TODO provision an elasticsearch user for the concepts API
   publicRootUrl: new URL(environment.PUBLIC_ROOT_URL),
 } as const;

--- a/search/src/main/scala/weco/api/search/elasticsearch/ImagesQuery.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/ImagesQuery.scala
@@ -41,25 +41,20 @@ case object ImageSimilarity {
 
 case object ImagesMultiMatcher {
 
-  def toWorkField(
-    field: String
-  ): Seq[String] =
-    Seq(s"source.canonicalWork.$field", s"source.redirectedWork.$field")
-
-  def boostedWorkFields(
+  private def boostedWorkFields(
     boost: Option[Double] = None,
     fields: Seq[String]
   ): Seq[FieldWithOptionalBoost] =
-    fields.flatMap(toWorkField).map(FieldWithOptionalBoost(_, boost))
+    fields.map(f => FieldWithOptionalBoost(s"source.$f", boost))
 
-  val titleFields = Seq(
+  private val titleFields = Seq(
     "data.alternativeTitles",
     "data.title.english",
     "data.title.shingles",
     "data.title"
   )
 
-  val idFields: Seq[FieldWithOptionalBoost] = boostedWorkFields(
+  private val idFields: Seq[FieldWithOptionalBoost] = boostedWorkFields(
     fields = Seq(
       "id.canonicalId",
       "id.sourceIdentifier.value",
@@ -70,7 +65,7 @@ case object ImagesMultiMatcher {
     "state.sourceIdentifier.value"
   ).map(FieldWithOptionalBoost(_, None))
 
-  val dataFields: Seq[FieldWithOptionalBoost] = boostedWorkFields(
+  private val dataFields: Seq[FieldWithOptionalBoost] = boostedWorkFields(
     boost = Some(1000.0),
     fields = Seq("data.contributors.agent.label")
   ) ++
@@ -117,19 +112,11 @@ case object ImagesMultiMatcher {
         dismax(
           queries = Seq(
             BoolQuery(
-              queryName = Some("redirected title prefix"),
-              boost = Some(1000.0),
-              must = List(
-                prefixQuery("source.redirectedWork.data.title.keyword", q),
-                matchPhraseQuery("source.redirectedWork.data.title", q)
-              )
-            ),
-            BoolQuery(
               queryName = Some("canonical title prefix"),
               boost = Some(1000.0),
               must = List(
-                prefixQuery("source.canonicalWork.data.title.keyword", q),
-                matchPhraseQuery("source.canonicalWork.data.title", q)
+                prefixQuery("source.data.title.keyword", q),
+                matchPhraseQuery("source.data.title", q)
               )
             ),
             MultiMatchQuery(

--- a/search/src/main/scala/weco/api/search/services/ImagesRequestBuilder.scala
+++ b/search/src/main/scala/weco/api/search/services/ImagesRequestBuilder.scala
@@ -99,7 +99,7 @@ class ImagesRequestBuilder(queryConfig: QueryConfig)
         termsQuery(field = "locations.license.id", values = licenseIds)
       case ContributorsFilter(contributorQueries) =>
         termsQuery(
-          "source.canonicalWork.data.contributors.agent.label.keyword",
+          "source.data.contributors.agent.label.keyword",
           contributorQueries
         )
       case GenreFilter(genreLabels) =>

--- a/search/src/main/scala/weco/api/search/services/WorksService.scala
+++ b/search/src/main/scala/weco/api/search/services/WorksService.scala
@@ -60,6 +60,7 @@ class WorksService(val elasticsearchService: ElasticsearchService)(
       case Right(resp) =>
         Right(
           resp.aggregations
+//            .getAgg("work_type")
             .decodeAgg[String]("work_type")
             .get
             .buckets

--- a/search/src/main/scala/weco/api/search/services/WorksService.scala
+++ b/search/src/main/scala/weco/api/search/services/WorksService.scala
@@ -60,7 +60,6 @@ class WorksService(val elasticsearchService: ElasticsearchService)(
       case Right(resp) =>
         Right(
           resp.aggregations
-//            .getAgg("work_type")
             .decodeAgg[String]("work_type")
             .get
             .buckets

--- a/search/src/test/resources/ImagesMultiMatcherQuery.json
+++ b/search/src/test/resources/ImagesMultiMatcherQuery.json
@@ -5,12 +5,9 @@
            "query": "{{query}}",
            "_name": "identifiers",
            "fields": [
-             "source.canonicalWork.id.canonicalId",
-             "source.redirectedWork.id.canonicalId",
-             "source.canonicalWork.id.sourceIdentifier.value",
-             "source.redirectedWork.id.sourceIdentifier.value",
-             "source.canonicalWork.data.otherIdentifiers.value",
-             "source.redirectedWork.data.otherIdentifiers.value",
+             "source.id.canonicalId",
+             "source.id.sourceIdentifier.value",
+             "source.data.otherIdentifiers.value",
              "state.canonicalId",
              "state.sourceIdentifier.value"
            ],
@@ -25,26 +22,16 @@
           "_name": "data",
            "query": "{{query}}",
            "fields": [
-             "source.canonicalWork.data.contributors.agent.label^1000.0",
-             "source.redirectedWork.data.contributors.agent.label^1000.0",
-             "source.canonicalWork.data.subjects.concepts.label^10.0",
-             "source.redirectedWork.data.subjects.concepts.label^10.0",
-             "source.canonicalWork.data.genres.concepts.label^10.0",
-             "source.redirectedWork.data.genres.concepts.label^10.0",
-             "source.canonicalWork.data.production.*.label^10.0",
-             "source.redirectedWork.data.production.*.label^10.0",
-             "source.canonicalWork.data.description",
-             "source.redirectedWork.data.description",
-             "source.canonicalWork.data.physicalDescription",
-             "source.redirectedWork.data.physicalDescription",
-             "source.canonicalWork.data.language.label",
-             "source.redirectedWork.data.language.label",
-             "source.canonicalWork.data.edition",
-             "source.redirectedWork.data.edition",
-             "source.canonicalWork.data.collectionPath.path",
-             "source.redirectedWork.data.collectionPath.path",
-             "source.canonicalWork.data.collectionPath.label",
-             "source.redirectedWork.data.collectionPath.label"
+             "source.data.contributors.agent.label^1000.0",
+             "source.data.subjects.concepts.label^10.0",
+             "source.data.genres.concepts.label^10.0",
+             "source.data.production.*.label^10.0",
+             "source.data.description",
+             "source.data.physicalDescription",
+             "source.data.language.label",
+             "source.data.edition",
+             "source.data.collectionPath.path",
+             "source.data.collectionPath.label"
            ],
            "type": "cross_fields",
            "operator": "And"
@@ -52,41 +39,21 @@
        },
        {
          "dis_max": {
-           "queries": [{
-               "bool": {
-                 "_name": "redirected title prefix",
-                 "boost": 1000.0,
-                 "must": [{
-                     "prefix": {
-                       "source.redirectedWork.data.title.keyword": {
-                         "value": "{{query}}"
-                       }
-                     }
-                   },
-                   {
-                     "match_phrase": {
-                       "source.redirectedWork.data.title": {
-                         "query": "{{query}}"
-                       }
-                     }
-                   }
-                 ]
-               }
-             },
+           "queries": [
              {
                "bool": {
                  "_name": "canonical title prefix",
                  "boost": 1000.0,
                  "must": [{
                      "prefix": {
-                       "source.canonicalWork.data.title.keyword": {
+                       "source.data.title.keyword": {
                          "value": "{{query}}"
                        }
                      }
                    },
                    {
                      "match_phrase": {
-                       "source.canonicalWork.data.title": {
+                       "source.data.title": {
                          "query": "{{query}}"
                        }
                      }
@@ -98,14 +65,10 @@
                "multi_match": {
                  "_name": "title exact spellings",
                  "fields": [
-                   "source.canonicalWork.data.alternativeTitles^100.0",
-                   "source.redirectedWork.data.alternativeTitles^100.0",
-                   "source.canonicalWork.data.title.english^100.0",
-                   "source.redirectedWork.data.title.english^100.0",
-                   "source.canonicalWork.data.title.shingles^100.0",
-                   "source.redirectedWork.data.title.shingles^100.0",
-                   "source.canonicalWork.data.title^100.0",
-                   "source.redirectedWork.data.title^100.0"
+                   "source.data.alternativeTitles^100.0",
+                   "source.data.title.english^100.0",
+                   "source.data.title.shingles^100.0",
+                   "source.data.title^100.0"
                  ],
                  "operator": "And",
                  "query": "{{query}}",
@@ -116,42 +79,24 @@
                "multi_match": {
                  "_name": "non-english text",
                  "fields": [
-                   "source.canonicalWork.data.title.arabic^100.0",
-                   "source.redirectedWork.data.title.arabic^100.0",
-                   "source.canonicalWork.data.notes.arabic^100.0",
-                   "source.redirectedWork.data.notes.arabic^100.0",
-                   "source.canonicalWork.data.lettering.arabic^100.0",
-                   "source.redirectedWork.data.lettering.arabic^100.0",
-                   "source.canonicalWork.data.title.bengali^100.0",
-                   "source.redirectedWork.data.title.bengali^100.0",
-                   "source.canonicalWork.data.notes.bengali^100.0",
-                   "source.redirectedWork.data.notes.bengali^100.0",
-                   "source.canonicalWork.data.lettering.bengali^100.0",
-                   "source.redirectedWork.data.lettering.bengali^100.0",
-                   "source.canonicalWork.data.title.french^100.0",
-                   "source.redirectedWork.data.title.french^100.0",
-                   "source.canonicalWork.data.notes.french^100.0",
-                   "source.redirectedWork.data.notes.french^100.0",
-                   "source.canonicalWork.data.lettering.french^100.0",
-                   "source.redirectedWork.data.lettering.french^100.0",
-                   "source.canonicalWork.data.title.german^100.0",
-                   "source.redirectedWork.data.title.german^100.0",
-                   "source.canonicalWork.data.notes.german^100.0",
-                   "source.redirectedWork.data.notes.german^100.0",
-                   "source.canonicalWork.data.lettering.german^100.0",
-                   "source.redirectedWork.data.lettering.german^100.0",
-                   "source.canonicalWork.data.title.hindi^100.0",
-                   "source.redirectedWork.data.title.hindi^100.0",
-                   "source.canonicalWork.data.notes.hindi^100.0",
-                   "source.redirectedWork.data.notes.hindi^100.0",
-                   "source.canonicalWork.data.lettering.hindi^100.0",
-                   "source.redirectedWork.data.lettering.hindi^100.0",
-                   "source.canonicalWork.data.title.italian^100.0",
-                   "source.redirectedWork.data.title.italian^100.0",
-                   "source.canonicalWork.data.notes.italian^100.0",
-                   "source.redirectedWork.data.notes.italian^100.0",
-                   "source.canonicalWork.data.lettering.italian^100.0",
-                   "source.redirectedWork.data.lettering.italian^100.0"
+                   "source.data.title.arabic^100.0",
+                   "source.data.notes.arabic^100.0",
+                   "source.data.lettering.arabic^100.0",
+                   "source.data.title.bengali^100.0",
+                   "source.data.notes.bengali^100.0",
+                   "source.data.lettering.bengali^100.0",
+                   "source.data.title.french^100.0",
+                   "source.data.notes.french^100.0",
+                   "source.data.lettering.french^100.0",
+                   "source.data.title.german^100.0",
+                   "source.data.notes.german^100.0",
+                   "source.data.lettering.german^100.0",
+                   "source.data.title.hindi^100.0",
+                   "source.data.notes.hindi^100.0",
+                   "source.data.lettering.hindi^100.0",
+                   "source.data.title.italian^100.0",
+                   "source.data.notes.italian^100.0",
+                   "source.data.lettering.italian^100.0"
                  ],
                  "query": "{{query}}",
                  "operator": "And",

--- a/search/src/test/scala/weco/api/search/images/ImagesFiltersTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesFiltersTest.scala
@@ -44,24 +44,6 @@ class ImagesFiltersTest extends ApiImagesTestBase {
       }
     }
 
-    it("does not filter by contributors from the redirected source work") {
-      withImagesApi {
-        case (imagesIndex, routes) =>
-          indexTestDocuments(
-            imagesIndex,
-            (0 to 2)
-              .map(i => s"images.examples.contributor-filter-tests.$i"): _*
-          )
-
-          assertJsonResponse(
-            routes,
-            path = s"$rootPath/images?source.contributors.agent.label=Hypatia"
-          ) {
-            Status.OK -> emptyJsonResult
-          }
-      }
-    }
-
     it("filters by multiple contributors") {
       withImagesApi {
         case (imagesIndex, routes) =>

--- a/search/src/test/scala/weco/api/search/images/ImagesTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesTest.scala
@@ -99,33 +99,4 @@ class ImagesTest extends ApiImagesTestBase {
         }
     }
   }
-
-  it("returns matching results when using workdata from the redirected work") {
-    withImagesApi {
-      case (imagesIndex, routes) =>
-        indexTestDocuments(
-          imagesIndex,
-          "images.examples.bread-baguette",
-          "images.examples.bread-focaccia",
-          "images.examples.bread-schiacciata"
-        )
-
-        assertJsonResponse(routes, s"$rootPath/images?query=bread") {
-          Status.OK -> imagesListResponse(
-            ids = List(
-              "images.examples.bread-schiacciata",
-              "images.examples.bread-baguette",
-              "images.examples.bread-focaccia"
-            ),
-            strictOrdering = true
-          )
-        }
-
-        assertJsonResponse(routes, s"$rootPath/images?query=schiacciata") {
-          Status.OK -> imagesListResponse(
-            ids = List("images.examples.bread-schiacciata")
-          )
-        }
-    }
-  }
 }


### PR DESCRIPTION
Accompanies https://github.com/wellcomecollection/catalogue-pipeline/pull/2131; closes https://github.com/wellcomecollection/platform/issues/5561

In particular, images in the index now have source data from the primary work, and not the canonical/redirected work separately. This slightly simplifies the queries we need to make in the API.