### PR TITLE
Adjust the size and count of API tasks

### DIFF
--- a/terraform/catalogue_api/main.tf
+++ b/terraform/catalogue_api/main.tf
@@ -45,9 +45,9 @@ module "catalogue_api_stage" {
   }
 
   desired_task_counts = {
-    search   = 1
-    items    = 1
-    concepts = 1
+    search   = 3
+    items    = 3
+    concepts = 3
   }
 
   vpc_id                   = local.vpc_id

--- a/terraform/modules/service/variables.tf
+++ b/terraform/modules/service/variables.tf
@@ -73,11 +73,9 @@ variable "deployment_service_env" {
 }
 
 variable "app_cpu" {
-  type    = number
-  default = 512
+  type = number
 }
 
 variable "app_memory" {
-  type    = number
-  default = 1024
+  type = number
 }

--- a/terraform/modules/stack/services.tf
+++ b/terraform/modules/stack/services.tf
@@ -36,6 +36,9 @@ module "search_api" {
     metrics_namespace = "search-api"
   }
 
+  app_cpu    = 256
+  app_memory = 512
+
   secrets = var.apm_secret_config
 
   # Below this line is boilerplate that should be the same across
@@ -75,6 +78,9 @@ module "items_api" {
   }
 
   secrets = merge(var.apm_secret_config, var.sierra_secret_config)
+
+  app_cpu    = 256
+  app_memory = 512
 
   # Below this line is boilerplate that should be the same across
   # all Fargate services.


### PR DESCRIPTION
I'm seeing persistent failures in the e2e tasks, which I suspect may be caused by us only running the stage API tasks in a single availability zone -- AWS recommend you run at least one task in each AZ, or you see substantial latency when the load balancer serving the request and the task are in each zone.

To offset the extra cost, I've reduced the CPU/memory of each task. I looked at the max usage for the tasks over the last 12 months; they very rarely pass 25% in most cases, so we can turn them down until we start seeing issues from resource constraints.