### PR TITLE
Bump the size of the API tasks in prod

### DIFF
--- a/terraform/modules/stack/services.tf
+++ b/terraform/modules/stack/services.tf
@@ -36,8 +36,8 @@ module "search_api" {
     metrics_namespace = "search-api"
   }
 
-  app_cpu    = 256
-  app_memory = 512
+  app_cpu    = var.environment_name == "prod" ? 512 : 256
+  app_memory = var.environment_name == "prod" ? 1024 : 512
 
   secrets = var.apm_secret_config
 


### PR DESCRIPTION
After I downsized the tasks, we started seeing errors in CloudFront. I haven't done a deep investigation to work out if this is the issue, but it's a smoking gun and a cheap and easy change.