### PR TITLE
Filter subject/genre labels from the query fields

### DIFF
--- a/search/src/main/scala/weco/api/search/services/WorksRequestBuilder.scala
+++ b/search/src/main/scala/weco/api/search/services/WorksRequestBuilder.scala
@@ -157,10 +157,10 @@ object WorksRequestBuilder
       case LanguagesFilter(languageIds) =>
         termsQuery("query.languages.id", languageIds)
       case GenreFilter(genreQueries) =>
-        termsQuery("data.genres.label.keyword", genreQueries)
+        termsQuery("query.genres.label.keyword", genreQueries)
 
       case SubjectLabelFilter(labels) =>
-        termsQuery("data.subjects.label.keyword", labels)
+        termsQuery("query.subjects.label.keyword", labels)
 
       case ContributorsFilter(contributorQueries) =>
         termsQuery("query.contributors.agent.label.keyword", contributorQueries)


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5550; I think these fields went in on the last reindex, and I just never switched to using them in the API.