### PR TITLE
Relations query

### DIFF
--- a/rank/data/tests/works.ts
+++ b/rank/data/tests/works.ts
@@ -32,6 +32,11 @@ const tests: Test[] = [
         description: 'Reference number as ID',
       },
       {
+        query: 'seq88sr4 qfk4vbp8',
+        ratings: ['seq88sr4','qfk4vbp8'],
+        description: 'multiple IDs',
+      },
+      {
         query: 'Cassils Time lapse',
         ratings: ['ftqy78zj'],
         description: 'Contributor and title in the same query',
@@ -118,13 +123,16 @@ const tests: Test[] = [
         query: 'wa/hmm durham',
         ratings: ['euf49qkx', 'tpxy78kr', 'gu3z98y4', 'ad3rfubw'],
         description: 'Archive refno and a word from the title',
-        knownFailure: true,
       },
       {
         query: 'wa/hmm benin',
         ratings: ['qfdvkegw', 'je5pm2gj', 'dppjjtqz'],
         description: 'Archive refno and a word from the description',
-        knownFailure: true,
+      },
+      {
+        query: 'WA/HMM/CM benin',
+        ratings: ['qfdvkegw', 'je5pm2gj', 'dppjjtqz'],
+        description: 'Archive refno and a word from the description',
       },
       {
         query: 'eugenics society annual reports',
@@ -171,7 +179,7 @@ const tests: Test[] = [
       'Ensure that the query returns results for search terms which are misspelled or differently transliterated.',
     eval: equalTo1,
     cases: [
-      { query: 'at-tib', ratings: ['qmm9mauk'] },
+      { query: 'at-tib', ratings: ['qmm9mauk'], knownFailure: true },
       { query: 'Aṭ-ṭib', ratings: ['qmm9mauk'] },
       { query: 'nuğūm', ratings: ['jtbenqbq'] },
       { query: 'nujum', ratings: ['jtbenqbq'], knownFailure: true },

--- a/rank/scripts/createIndex.ts
+++ b/rank/scripts/createIndex.ts
@@ -31,7 +31,12 @@ async function go() {
     (mod) => mod.default
   )
 
-  const remoteIndex = `${getNamespaceFromIndexName(localIndex)}-candidate`
+  const remoteIndex = await prompts({
+    type: 'text',
+    name: 'value',
+    message: 'What should the new index be called?',
+    initial: `${getNamespaceFromIndexName(localIndex)}-candidate`,
+  }).then(({ value }) => value)
 
   const client = getRankClient()
   const { body: putIndexRes } = await client.indices.create({
@@ -82,7 +87,7 @@ async function go() {
 
     success('Reindex started successfully')
     info('You can monitor the reindex by running:')
-    code(`yarn checkTask --task ${reindexResp.task.task_id}`)
+    code(`yarn checkTask --task ${reindexResp.task}`)
   }
 }
 

--- a/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -129,7 +129,10 @@ case object WorksMultiMatcher {
               operator = Some(OR),
               fields = Seq(
                 FieldWithOptionalBoost("data.collectionPath.path.clean", None),
-                FieldWithOptionalBoost("data.collectionPath.label.path.clean", None),
+                FieldWithOptionalBoost(
+                  "data.collectionPath.label.path.clean",
+                  None
+                ),
                 FieldWithOptionalBoost("data.collectionPath.label", None),
                 FieldWithOptionalBoost("data.collectionPath.path.keyword", None)
               )

--- a/search/src/test/resources/WorksMultiMatcherQuery.json
+++ b/search/src/test/resources/WorksMultiMatcherQuery.json
@@ -23,7 +23,8 @@
             "query.items.identifiers.value^1000.0",
             "query.images.id^1000.0",
             "query.images.identifiers.value^1000.0",
-            "data.referenceNumber^1000.0"
+            "data.referenceNumber^1000.0",
+            "search.identifiers^1000.0"
           ],
           "type": "best_fields",
           "analyzer": "whitespace_analyzer",
@@ -67,13 +68,36 @@
         }
       },
       {
-        "match": {
-          "search.relations": {
-            "query": "{{query}}",
-            "_name": "relations",
-            "boost": 1000,
-            "operator": "AND"
-          }
+        "bool": {
+          "should": [
+            {
+              "multi_match": {
+                "query": "{{query}}",
+                "fields": [
+                  "data.title^100.0",
+                  "data.description^10.0"
+                ],
+                "type": "cross_fields",
+                "operator": "Or",
+                "_name": "relations text"
+              }
+            }
+          ],
+          "must": [
+            {
+              "multi_match": {
+                "fields": [
+                  "data.collectionPath.path.clean",
+                  "data.collectionPath.label.path.clean",
+                  "data.collectionPath.label",
+                  "data.collectionPath.path.keyword"
+                ],
+                "query": "{{query}}",
+                "operator": "Or",
+                "_name": "relations paths"
+              }
+            }
+          ]
         }
       },
       {


### PR DESCRIPTION
Replaces the blunt match query on `search.relations` with some smarter logic across the relevant relations path fields, and commonly queried text fields.

Related to https://github.com/wellcomecollection/catalogue-pipeline/pull/2135

Closes https://github.com/wellcomecollection/catalogue-api/issues/488
