### PR TITLE
Use eclipse-temurin:11-jre-alpine for applications

### DIFF
--- a/items/Dockerfile
+++ b/items/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/requests/Dockerfile
+++ b/requests/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/search/Dockerfile
+++ b/search/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 

--- a/snapshots/snapshot_generator/Dockerfile
+++ b/snapshots/snapshot_generator/Dockerfile
@@ -1,6 +1,8 @@
-FROM public.ecr.aws/docker/library/openjdk:11
+FROM public.ecr.aws/docker/library/eclipse-temurin:11-jre-alpine
 
 LABEL maintainer = "Wellcome Collection <digital@wellcomecollection.org>"
+
+RUN apk add --no-cache bash
 
 ADD target/universal/stage /opt/docker
 


### PR DESCRIPTION
Following on from https://github.com/wellcomecollection/platform-infrastructure/pull/313, using the same (smaller and non-deprecated) image for running our applications as we do for compiling them. This being the JVM I don't expect to see any of the potential oddities of Alpine that occur with compiled code, but will keep an eye on things of course.