### PR TITLE
Flag different result counts

### DIFF
--- a/diff_tool/diff_tool.py
+++ b/diff_tool/diff_tool.py
@@ -136,10 +136,16 @@ def _display_in_console(stats, diffs):
     click.echo(
         tabulate(
             [
-                ["Production"] + list(stats["prod"]["work_types"].values()),
-                ["Staging"] + list(stats["staging"]["work_types"].values()),
+                ["Production"]
+                + [humanize.intcomma(v) for v in stats["prod"]["work_types"].values()],
+                ["Staging"]
+                + [
+                    humanize.intcomma(v)
+                    for v in stats["staging"]["work_types"].values()
+                ],
             ],
             headers=stats["prod"]["work_types"].keys(),
+            colalign=("left", "right", "right", "right", "right", "right"),
         )
     )
 


### PR DESCRIPTION
Makes a couple of improvements to the console-esque diff tool (which is what we get in Buildkite):

* It now distinguishes between a different result count (i.e. different `totalPages` and `totalResults`, which we usually don't mind) and more significant differences in the rest of the JSON
* The stats table is now comma-separated for readability

<img width="1167" alt="Screenshot 2022-07-27 at 09 43 33" src="https://user-images.githubusercontent.com/301220/181203306-88d8e464-395f-4575-8047-281b4cf5dbba.png">