### PR TITLE
Ignore failures for some alternative-spellings rank tests

### DIFF
--- a/rank/data/tests/images.ts
+++ b/rank/data/tests/images.ts
@@ -95,8 +95,8 @@ const tests: Test[] = [
     eval: equalTo1,
     cases: [
       { query: 'arbeiten', ratings: ['sr4kxmk3', 'utbtee43'] },
-      { query: 'conosco', ratings: ['nnh3nh47'] },
-      { query: 'allons', ratings: ['et7c29ub'], knownFailure: true },
+      { query: 'conosco', ratings: ['nnh3nh47'], knownFailure: true },
+      { query: 'allons', ratings: ['dqnapkdx'], knownFailure: true },
     ],
     metric: {
       recall: {

--- a/rank/data/tests/images.ts
+++ b/rank/data/tests/images.ts
@@ -96,7 +96,7 @@ const tests: Test[] = [
     cases: [
       { query: 'arbeiten', ratings: ['sr4kxmk3', 'utbtee43'] },
       { query: 'conosco', ratings: ['nnh3nh47'] },
-      { query: 'allons', ratings: ['dqnapkdx'] },
+      { query: 'allons', ratings: ['et7c29ub'], knownFailure: true },
     ],
     metric: {
       recall: {

--- a/rank/data/tests/works.ts
+++ b/rank/data/tests/works.ts
@@ -33,7 +33,7 @@ const tests: Test[] = [
       },
       {
         query: 'seq88sr4 qfk4vbp8',
-        ratings: ['seq88sr4','qfk4vbp8'],
+        ratings: ['seq88sr4', 'qfk4vbp8'],
         description: 'multiple IDs',
       },
       {
@@ -179,10 +179,10 @@ const tests: Test[] = [
       'Ensure that the query returns results for search terms which are misspelled or differently transliterated.',
     eval: equalTo1,
     cases: [
-      { query: 'at-tib', ratings: ['qmm9mauk'], knownFailure: true },
-      { query: 'Aṭ-ṭib', ratings: ['qmm9mauk'] },
-      { query: 'nuğūm', ratings: ['jtbenqbq'] },
-      { query: 'nujum', ratings: ['jtbenqbq'], knownFailure: true },
+      { query: 'al-tibb', ratings: ['t4jqq9ue'], knownFailure: true },
+      { query: 'Al-ṭibb', ratings: ['t4jqq9ue'], knownFailure: true },
+      { query: 'nuğūm', ratings: ['m94cyux7'], knownFailure: true },
+      { query: 'nujum', ratings: ['m94cyux7'], knownFailure: true },
       { query: 'arbeiten', ratings: ['xn7yyrqf'] },
       // we know that something strange has happened to the french and italian
       // stemming tests, but stemming _is_ still happening. These tests aren't


### PR DESCRIPTION
The works issues are tracked by https://github.com/wellcomecollection/catalogue-api/issues/524
