### PR TITLE
Add threshold image similarity scores

### DIFF
--- a/search/src/main/scala/weco/api/search/services/ImagesRequestBuilder.scala
+++ b/search/src/main/scala/weco/api/search/services/ImagesRequestBuilder.scala
@@ -117,11 +117,13 @@ class ImagesRequestBuilder(queryConfig: QueryConfig)
         colorQuery(field = "state.inferredData.palette", hexColors)
     }
 
-  def requestWithBlendedSimilarity: (Index, String, Int, Double) => SearchRequest =
+  def requestWithBlendedSimilarity
+    : (Index, String, Int, Double) => SearchRequest =
     similarityRequest(ImageSimilarity.blended)
 
-  def requestWithSimilarFeatures: (Index, String, Int, Double) => SearchRequest =
-    similarityRequest( ImageSimilarity.features)
+  def requestWithSimilarFeatures
+    : (Index, String, Int, Double) => SearchRequest =
+    similarityRequest(ImageSimilarity.features)
 
   def requestWithSimilarColors: (Index, String, Int, Double) => SearchRequest =
     similarityRequest(ImageSimilarity.color)

--- a/search/src/main/scala/weco/api/search/services/ImagesRequestBuilder.scala
+++ b/search/src/main/scala/weco/api/search/services/ImagesRequestBuilder.scala
@@ -117,19 +117,20 @@ class ImagesRequestBuilder(queryConfig: QueryConfig)
         colorQuery(field = "state.inferredData.palette", hexColors)
     }
 
-  def requestWithBlendedSimilarity: (Index, String, Int) => SearchRequest =
+  def requestWithBlendedSimilarity: (Index, String, Int, Double) => SearchRequest =
     similarityRequest(ImageSimilarity.blended)
 
-  def requestWithSimilarFeatures: (Index, String, Int) => SearchRequest =
-    similarityRequest(ImageSimilarity.features)
+  def requestWithSimilarFeatures: (Index, String, Int, Double) => SearchRequest =
+    similarityRequest( ImageSimilarity.features)
 
-  def requestWithSimilarColors: (Index, String, Int) => SearchRequest =
+  def requestWithSimilarColors: (Index, String, Int, Double) => SearchRequest =
     similarityRequest(ImageSimilarity.color)
 
   private def similarityRequest(
     query: (String, Index) => Query
-  )(index: Index, id: String, n: Int): SearchRequest =
+  )(index: Index, id: String, n: Int, minScore: Double): SearchRequest =
     search(index)
       .query(query(id, index))
       .size(n)
+      .minScore(minScore)
 }

--- a/search/src/main/scala/weco/api/search/services/ImagesService.scala
+++ b/search/src/main/scala/weco/api/search/services/ImagesService.scala
@@ -42,7 +42,8 @@ class ImagesService(
   def retrieveSimilarImages(
     index: Index,
     imageId: String,
-    similarityMetric: SimilarityMetric = SimilarityMetric.Blended
+    similarityMetric: SimilarityMetric = SimilarityMetric.Blended,
+    minScore: Option[Double] = None
   ): Future[List[IndexedImage]] = {
     val builder = similarityMetric match {
       case SimilarityMetric.Blended =>
@@ -53,7 +54,16 @@ class ImagesService(
         requestBuilder.requestWithSimilarColors
     }
 
-    val searchRequest = builder(index, imageId, nVisuallySimilarImages)
+    val defaultMinScore: Double = similarityMetric match {
+      case SimilarityMetric.Blended  => 300
+      case SimilarityMetric.Features => 300
+      case SimilarityMetric.Colors   => 20
+    }
+
+    val minScoreValue: Double = minScore.getOrElse(defaultMinScore)
+
+    val searchRequest =
+      builder(index, imageId, nVisuallySimilarImages, minScoreValue)
 
     elasticsearchService
       .findBySearch(searchRequest)(decoder)

--- a/search/src/main/scala/weco/api/search/services/ImagesService.scala
+++ b/search/src/main/scala/weco/api/search/services/ImagesService.scala
@@ -54,6 +54,8 @@ class ImagesService(
         requestBuilder.requestWithSimilarColors
     }
 
+    // default minimum scores for each similarity metric determined using this notebook
+    // https://github.com/wellcomecollection/data-science/blob/47245826c70bf2d76c63d2c4b3ace6c824673784/notebooks/similarity_problems/notebooks/01-similarity-scores.ipynb
     val defaultMinScore: Double = similarityMetric match {
       case SimilarityMetric.Blended  => 300
       case SimilarityMetric.Features => 300

--- a/search/src/test/resources/expected_responses/visually-similar-features-and-palettes.json
+++ b/search/src/test/resources/expected_responses/visually-similar-features-and-palettes.json
@@ -1,284 +1,46 @@
 {
-  "id" : "a5lj9duc",
-  "locations" : [
+  "id": "a5lj9duc",
+  "locations": [
     {
-      "accessConditions" : [
-      ],
-      "license" : {
-        "id" : "cc-by",
-        "label" : "Attribution 4.0 International (CC BY 4.0)",
-        "type" : "License",
-        "url" : "http://creativecommons.org/licenses/by/4.0/"
+      "accessConditions": [],
+      "license": {
+        "id": "cc-by",
+        "label": "Attribution 4.0 International (CC BY 4.0)",
+        "type": "License",
+        "url": "http://creativecommons.org/licenses/by/4.0/"
       },
-      "linkText" : "Link text: 4N3l8IuPN0",
-      "locationType" : {
-        "id" : "iiif-image",
-        "label" : "IIIF Image API",
-        "type" : "LocationType"
+      "linkText": "Link text: 4N3l8IuPN0",
+      "locationType": {
+        "id": "iiif-image",
+        "label": "IIIF Image API",
+        "type": "LocationType"
       },
-      "type" : "DigitalLocation",
-      "url" : "https://iiif.wellcomecollection.org/image/RlZ.jpg/info.json"
+      "type": "DigitalLocation",
+      "url": "https://iiif.wellcomecollection.org/image/RlZ.jpg/info.json"
     }
   ],
-  "source" : {
-    "id" : "anys7vbv",
-    "title" : "title-vpbsaVsvTg",
-    "type" : "Work"
+  "source": {
+    "id": "anys7vbv",
+    "title": "title-vpbsaVsvTg",
+    "type": "Work"
   },
-  "thumbnail" : {
-    "accessConditions" : [
-    ],
-    "license" : {
-      "id" : "cc-by",
-      "label" : "Attribution 4.0 International (CC BY 4.0)",
-      "type" : "License",
-      "url" : "http://creativecommons.org/licenses/by/4.0/"
+  "thumbnail": {
+    "accessConditions": [],
+    "license": {
+      "id": "cc-by",
+      "label": "Attribution 4.0 International (CC BY 4.0)",
+      "type": "License",
+      "url": "http://creativecommons.org/licenses/by/4.0/"
     },
-    "linkText" : "Link text: 4N3l8IuPN0",
-    "locationType" : {
-      "id" : "iiif-image",
-      "label" : "IIIF Image API",
-      "type" : "LocationType"
+    "linkText": "Link text: 4N3l8IuPN0",
+    "locationType": {
+      "id": "iiif-image",
+      "label": "IIIF Image API",
+      "type": "LocationType"
     },
-    "type" : "DigitalLocation",
-    "url" : "https://iiif.wellcomecollection.org/image/RlZ.jpg/info.json"
+    "type": "DigitalLocation",
+    "url": "https://iiif.wellcomecollection.org/image/RlZ.jpg/info.json"
   },
-  "type" : "Image",
-  "visuallySimilar" : [
-    {
-      "id" : "dqlalauc",
-      "locations" : [
-        {
-          "accessConditions" : [
-          ],
-          "license" : {
-            "id" : "cc-by",
-            "label" : "Attribution 4.0 International (CC BY 4.0)",
-            "type" : "License",
-            "url" : "http://creativecommons.org/licenses/by/4.0/"
-          },
-          "locationType" : {
-            "id" : "iiif-image",
-            "label" : "IIIF Image API",
-            "type" : "LocationType"
-          },
-          "type" : "DigitalLocation",
-          "url" : "https://iiif.wellcomecollection.org/image/I2D.jpg/info.json"
-        }
-      ],
-      "source" : {
-        "id" : "j4l3wsjt",
-        "title" : "title-Q8uNY7ZOEu",
-        "type" : "Work"
-      },
-      "thumbnail" : {
-        "accessConditions" : [
-        ],
-        "license" : {
-          "id" : "cc-by",
-          "label" : "Attribution 4.0 International (CC BY 4.0)",
-          "type" : "License",
-          "url" : "http://creativecommons.org/licenses/by/4.0/"
-        },
-        "locationType" : {
-          "id" : "iiif-image",
-          "label" : "IIIF Image API",
-          "type" : "LocationType"
-        },
-        "type" : "DigitalLocation",
-        "url" : "https://iiif.wellcomecollection.org/image/I2D.jpg/info.json"
-      },
-      "type" : "Image"
-    },
-    {
-      "id" : "fp9x20si",
-      "locations" : [
-        {
-          "accessConditions" : [
-          ],
-          "credit" : "Credit line: 7SWk3TTSq0",
-          "license" : {
-            "id" : "cc-by",
-            "label" : "Attribution 4.0 International (CC BY 4.0)",
-            "type" : "License",
-            "url" : "http://creativecommons.org/licenses/by/4.0/"
-          },
-          "locationType" : {
-            "id" : "iiif-image",
-            "label" : "IIIF Image API",
-            "type" : "LocationType"
-          },
-          "type" : "DigitalLocation",
-          "url" : "https://iiif.wellcomecollection.org/image/WIk.jpg/info.json"
-        }
-      ],
-      "source" : {
-        "id" : "othidyxy",
-        "title" : "title-pEAVa4Rz7i",
-        "type" : "Work"
-      },
-      "thumbnail" : {
-        "accessConditions" : [
-        ],
-        "credit" : "Credit line: 7SWk3TTSq0",
-        "license" : {
-          "id" : "cc-by",
-          "label" : "Attribution 4.0 International (CC BY 4.0)",
-          "type" : "License",
-          "url" : "http://creativecommons.org/licenses/by/4.0/"
-        },
-        "locationType" : {
-          "id" : "iiif-image",
-          "label" : "IIIF Image API",
-          "type" : "LocationType"
-        },
-        "type" : "DigitalLocation",
-        "url" : "https://iiif.wellcomecollection.org/image/WIk.jpg/info.json"
-      },
-      "type" : "Image"
-    },
-    {
-      "id" : "fsq3gsq0",
-      "locations" : [
-        {
-          "accessConditions" : [
-          ],
-          "credit" : "Credit line: u1A2IYFqOO",
-          "license" : {
-            "id" : "cc-by",
-            "label" : "Attribution 4.0 International (CC BY 4.0)",
-            "type" : "License",
-            "url" : "http://creativecommons.org/licenses/by/4.0/"
-          },
-          "locationType" : {
-            "id" : "iiif-image",
-            "label" : "IIIF Image API",
-            "type" : "LocationType"
-          },
-          "type" : "DigitalLocation",
-          "url" : "https://iiif.wellcomecollection.org/image/T69.jpg/info.json"
-        }
-      ],
-      "source" : {
-        "id" : "80trgzaf",
-        "title" : "title-AOCEgK2yRE",
-        "type" : "Work"
-      },
-      "thumbnail" : {
-        "accessConditions" : [
-        ],
-        "credit" : "Credit line: u1A2IYFqOO",
-        "license" : {
-          "id" : "cc-by",
-          "label" : "Attribution 4.0 International (CC BY 4.0)",
-          "type" : "License",
-          "url" : "http://creativecommons.org/licenses/by/4.0/"
-        },
-        "locationType" : {
-          "id" : "iiif-image",
-          "label" : "IIIF Image API",
-          "type" : "LocationType"
-        },
-        "type" : "DigitalLocation",
-        "url" : "https://iiif.wellcomecollection.org/image/T69.jpg/info.json"
-      },
-      "type" : "Image"
-    },
-    {
-      "id" : "vcflqowx",
-      "locations" : [
-        {
-          "accessConditions" : [
-          ],
-          "credit" : "Credit line: iMzNq5f99",
-          "license" : {
-            "id" : "cc-by",
-            "label" : "Attribution 4.0 International (CC BY 4.0)",
-            "type" : "License",
-            "url" : "http://creativecommons.org/licenses/by/4.0/"
-          },
-          "linkText" : "Link text: Z6HmsHmLL",
-          "locationType" : {
-            "id" : "iiif-image",
-            "label" : "IIIF Image API",
-            "type" : "LocationType"
-          },
-          "type" : "DigitalLocation",
-          "url" : "https://iiif.wellcomecollection.org/image/yw2.jpg/info.json"
-        }
-      ],
-      "source" : {
-        "id" : "ov8cs7dy",
-        "title" : "title-U90KOXEeRV",
-        "type" : "Work"
-      },
-      "thumbnail" : {
-        "accessConditions" : [
-        ],
-        "credit" : "Credit line: iMzNq5f99",
-        "license" : {
-          "id" : "cc-by",
-          "label" : "Attribution 4.0 International (CC BY 4.0)",
-          "type" : "License",
-          "url" : "http://creativecommons.org/licenses/by/4.0/"
-        },
-        "linkText" : "Link text: Z6HmsHmLL",
-        "locationType" : {
-          "id" : "iiif-image",
-          "label" : "IIIF Image API",
-          "type" : "LocationType"
-        },
-        "type" : "DigitalLocation",
-        "url" : "https://iiif.wellcomecollection.org/image/yw2.jpg/info.json"
-      },
-      "type" : "Image"
-    },
-    {
-      "id" : "wfdcghky",
-      "locations" : [
-        {
-          "accessConditions" : [
-          ],
-          "credit" : "Credit line: daywHchuw",
-          "license" : {
-            "id" : "cc-by",
-            "label" : "Attribution 4.0 International (CC BY 4.0)",
-            "type" : "License",
-            "url" : "http://creativecommons.org/licenses/by/4.0/"
-          },
-          "locationType" : {
-            "id" : "iiif-image",
-            "label" : "IIIF Image API",
-            "type" : "LocationType"
-          },
-          "type" : "DigitalLocation",
-          "url" : "https://iiif.wellcomecollection.org/image/lHZ.jpg/info.json"
-        }
-      ],
-      "source" : {
-        "id" : "hs3nzqux",
-        "title" : "title-lPUpm8UfHO",
-        "type" : "Work"
-      },
-      "thumbnail" : {
-        "accessConditions" : [
-        ],
-        "credit" : "Credit line: daywHchuw",
-        "license" : {
-          "id" : "cc-by",
-          "label" : "Attribution 4.0 International (CC BY 4.0)",
-          "type" : "License",
-          "url" : "http://creativecommons.org/licenses/by/4.0/"
-        },
-        "locationType" : {
-          "id" : "iiif-image",
-          "label" : "IIIF Image API",
-          "type" : "LocationType"
-        },
-        "type" : "DigitalLocation",
-        "url" : "https://iiif.wellcomecollection.org/image/lHZ.jpg/info.json"
-      },
-      "type" : "Image"
-    }
-  ]
+  "type": "Image",
+  "visuallySimilar": []
 }

--- a/search/src/test/resources/expected_responses/visually-similar-features.json
+++ b/search/src/test/resources/expected_responses/visually-similar-features.json
@@ -1,288 +1,46 @@
 {
-  "id" : "avn4splt",
-  "locations" : [
+  "id": "avn4splt",
+  "locations": [
     {
-      "accessConditions" : [
-      ],
-      "credit" : "Credit line: 0E7PyTlgnF",
-      "license" : {
-        "id" : "cc-by",
-        "label" : "Attribution 4.0 International (CC BY 4.0)",
-        "type" : "License",
-        "url" : "http://creativecommons.org/licenses/by/4.0/"
+      "accessConditions": [],
+      "credit": "Credit line: 0E7PyTlgnF",
+      "license": {
+        "id": "cc-by",
+        "label": "Attribution 4.0 International (CC BY 4.0)",
+        "type": "License",
+        "url": "http://creativecommons.org/licenses/by/4.0/"
       },
-      "locationType" : {
-        "id" : "iiif-image",
-        "label" : "IIIF Image API",
-        "type" : "LocationType"
+      "locationType": {
+        "id": "iiif-image",
+        "label": "IIIF Image API",
+        "type": "LocationType"
       },
-      "type" : "DigitalLocation",
-      "url" : "https://iiif.wellcomecollection.org/image/gRU.jpg/info.json"
+      "type": "DigitalLocation",
+      "url": "https://iiif.wellcomecollection.org/image/gRU.jpg/info.json"
     }
   ],
-  "source" : {
-    "id" : "udimdxnm",
-    "title" : "title-SAstkO6d67",
-    "type" : "Work"
+  "source": {
+    "id": "udimdxnm",
+    "title": "title-SAstkO6d67",
+    "type": "Work"
   },
-  "thumbnail" : {
-    "accessConditions" : [
-    ],
-    "credit" : "Credit line: 0E7PyTlgnF",
-    "license" : {
-      "id" : "cc-by",
-      "label" : "Attribution 4.0 International (CC BY 4.0)",
-      "type" : "License",
-      "url" : "http://creativecommons.org/licenses/by/4.0/"
+  "thumbnail": {
+    "accessConditions": [],
+    "credit": "Credit line: 0E7PyTlgnF",
+    "license": {
+      "id": "cc-by",
+      "label": "Attribution 4.0 International (CC BY 4.0)",
+      "type": "License",
+      "url": "http://creativecommons.org/licenses/by/4.0/"
     },
-    "locationType" : {
-      "id" : "iiif-image",
-      "label" : "IIIF Image API",
-      "type" : "LocationType"
+    "locationType": {
+      "id": "iiif-image",
+      "label": "IIIF Image API",
+      "type": "LocationType"
     },
-    "type" : "DigitalLocation",
-    "url" : "https://iiif.wellcomecollection.org/image/gRU.jpg/info.json"
+    "type": "DigitalLocation",
+    "url": "https://iiif.wellcomecollection.org/image/gRU.jpg/info.json"
   },
-  "type" : "Image",
-  "withSimilarFeatures" : [
-    {
-      "id" : "pg4glndt",
-      "locations" : [
-        {
-          "accessConditions" : [
-          ],
-          "credit" : "Credit line: rZwWNxllWp",
-          "license" : {
-            "id" : "cc-by",
-            "label" : "Attribution 4.0 International (CC BY 4.0)",
-            "type" : "License",
-            "url" : "http://creativecommons.org/licenses/by/4.0/"
-          },
-          "locationType" : {
-            "id" : "iiif-image",
-            "label" : "IIIF Image API",
-            "type" : "LocationType"
-          },
-          "type" : "DigitalLocation",
-          "url" : "https://iiif.wellcomecollection.org/image/k7d.jpg/info.json"
-        }
-      ],
-      "source" : {
-        "id" : "dx3dxn4f",
-        "title" : "title-zrA90sIKcC",
-        "type" : "Work"
-      },
-      "thumbnail" : {
-        "accessConditions" : [
-        ],
-        "credit" : "Credit line: rZwWNxllWp",
-        "license" : {
-          "id" : "cc-by",
-          "label" : "Attribution 4.0 International (CC BY 4.0)",
-          "type" : "License",
-          "url" : "http://creativecommons.org/licenses/by/4.0/"
-        },
-        "locationType" : {
-          "id" : "iiif-image",
-          "label" : "IIIF Image API",
-          "type" : "LocationType"
-        },
-        "type" : "DigitalLocation",
-        "url" : "https://iiif.wellcomecollection.org/image/k7d.jpg/info.json"
-      },
-      "type" : "Image"
-    },
-    {
-      "id" : "as90yzzb",
-      "locations" : [
-        {
-          "accessConditions" : [
-          ],
-          "credit" : "Credit line: hQH1jdZR",
-          "license" : {
-            "id" : "cc-by",
-            "label" : "Attribution 4.0 International (CC BY 4.0)",
-            "type" : "License",
-            "url" : "http://creativecommons.org/licenses/by/4.0/"
-          },
-          "linkText" : "Link text: VnfjXQ4",
-          "locationType" : {
-            "id" : "iiif-image",
-            "label" : "IIIF Image API",
-            "type" : "LocationType"
-          },
-          "type" : "DigitalLocation",
-          "url" : "https://iiif.wellcomecollection.org/image/w1x.jpg/info.json"
-        }
-      ],
-      "source" : {
-        "id" : "jlk1ajcg",
-        "title" : "title-1N8IA7dbNc",
-        "type" : "Work"
-      },
-      "thumbnail" : {
-        "accessConditions" : [
-        ],
-        "credit" : "Credit line: hQH1jdZR",
-        "license" : {
-          "id" : "cc-by",
-          "label" : "Attribution 4.0 International (CC BY 4.0)",
-          "type" : "License",
-          "url" : "http://creativecommons.org/licenses/by/4.0/"
-        },
-        "linkText" : "Link text: VnfjXQ4",
-        "locationType" : {
-          "id" : "iiif-image",
-          "label" : "IIIF Image API",
-          "type" : "LocationType"
-        },
-        "type" : "DigitalLocation",
-        "url" : "https://iiif.wellcomecollection.org/image/w1x.jpg/info.json"
-      },
-      "type" : "Image"
-    },
-    {
-      "id" : "e7h0ngrc",
-      "locations" : [
-        {
-          "accessConditions" : [
-          ],
-          "credit" : "Credit line: kIVOsu3kyj",
-          "license" : {
-            "id" : "cc-by",
-            "label" : "Attribution 4.0 International (CC BY 4.0)",
-            "type" : "License",
-            "url" : "http://creativecommons.org/licenses/by/4.0/"
-          },
-          "locationType" : {
-            "id" : "iiif-image",
-            "label" : "IIIF Image API",
-            "type" : "LocationType"
-          },
-          "type" : "DigitalLocation",
-          "url" : "https://iiif.wellcomecollection.org/image/pj3.jpg/info.json"
-        }
-      ],
-      "source" : {
-        "id" : "yzkcyo8a",
-        "title" : "title-lnrm0uU03m",
-        "type" : "Work"
-      },
-      "thumbnail" : {
-        "accessConditions" : [
-        ],
-        "credit" : "Credit line: kIVOsu3kyj",
-        "license" : {
-          "id" : "cc-by",
-          "label" : "Attribution 4.0 International (CC BY 4.0)",
-          "type" : "License",
-          "url" : "http://creativecommons.org/licenses/by/4.0/"
-        },
-        "locationType" : {
-          "id" : "iiif-image",
-          "label" : "IIIF Image API",
-          "type" : "LocationType"
-        },
-        "type" : "DigitalLocation",
-        "url" : "https://iiif.wellcomecollection.org/image/pj3.jpg/info.json"
-      },
-      "type" : "Image"
-    },
-    {
-      "id" : "yspicvrr",
-      "locations" : [
-        {
-          "accessConditions" : [
-          ],
-          "license" : {
-            "id" : "cc-by",
-            "label" : "Attribution 4.0 International (CC BY 4.0)",
-            "type" : "License",
-            "url" : "http://creativecommons.org/licenses/by/4.0/"
-          },
-          "linkText" : "Link text: m6RLta",
-          "locationType" : {
-            "id" : "iiif-image",
-            "label" : "IIIF Image API",
-            "type" : "LocationType"
-          },
-          "type" : "DigitalLocation",
-          "url" : "https://iiif.wellcomecollection.org/image/4R3.jpg/info.json"
-        }
-      ],
-      "source" : {
-        "id" : "gpcnavlf",
-        "title" : "title-zQer0e2qKz",
-        "type" : "Work"
-      },
-      "thumbnail" : {
-        "accessConditions" : [
-        ],
-        "license" : {
-          "id" : "cc-by",
-          "label" : "Attribution 4.0 International (CC BY 4.0)",
-          "type" : "License",
-          "url" : "http://creativecommons.org/licenses/by/4.0/"
-        },
-        "linkText" : "Link text: m6RLta",
-        "locationType" : {
-          "id" : "iiif-image",
-          "label" : "IIIF Image API",
-          "type" : "LocationType"
-        },
-        "type" : "DigitalLocation",
-        "url" : "https://iiif.wellcomecollection.org/image/4R3.jpg/info.json"
-      },
-      "type" : "Image"
-    },
-    {
-      "id" : "ysyk8jmh",
-      "locations" : [
-        {
-          "accessConditions" : [
-          ],
-          "credit" : "Credit line: 5oebc7ii9",
-          "license" : {
-            "id" : "cc-by",
-            "label" : "Attribution 4.0 International (CC BY 4.0)",
-            "type" : "License",
-            "url" : "http://creativecommons.org/licenses/by/4.0/"
-          },
-          "linkText" : "Link text: 6yXDs5nG",
-          "locationType" : {
-            "id" : "iiif-image",
-            "label" : "IIIF Image API",
-            "type" : "LocationType"
-          },
-          "type" : "DigitalLocation",
-          "url" : "https://iiif.wellcomecollection.org/image/BmE.jpg/info.json"
-        }
-      ],
-      "source" : {
-        "id" : "tgvflupr",
-        "title" : "title-YIKodlLnLq",
-        "type" : "Work"
-      },
-      "thumbnail" : {
-        "accessConditions" : [
-        ],
-        "credit" : "Credit line: 5oebc7ii9",
-        "license" : {
-          "id" : "cc-by",
-          "label" : "Attribution 4.0 International (CC BY 4.0)",
-          "type" : "License",
-          "url" : "http://creativecommons.org/licenses/by/4.0/"
-        },
-        "linkText" : "Link text: 6yXDs5nG",
-        "locationType" : {
-          "id" : "iiif-image",
-          "label" : "IIIF Image API",
-          "type" : "LocationType"
-        },
-        "type" : "DigitalLocation",
-        "url" : "https://iiif.wellcomecollection.org/image/BmE.jpg/info.json"
-      },
-      "type" : "Image"
-    }
-  ]
+  "type": "Image",
+  "withSimilarFeatures": []
 }

--- a/search/src/test/resources/expected_responses/visually-similar-palettes.json
+++ b/search/src/test/resources/expected_responses/visually-similar-palettes.json
@@ -1,280 +1,44 @@
 {
-  "id" : "ugow7dpj",
-  "locations" : [
+  "id": "ugow7dpj",
+  "locations": [
     {
-      "accessConditions" : [
-      ],
-      "license" : {
-        "id" : "cc-by",
-        "label" : "Attribution 4.0 International (CC BY 4.0)",
-        "type" : "License",
-        "url" : "http://creativecommons.org/licenses/by/4.0/"
+      "accessConditions": [],
+      "license": {
+        "id": "cc-by",
+        "label": "Attribution 4.0 International (CC BY 4.0)",
+        "type": "License",
+        "url": "http://creativecommons.org/licenses/by/4.0/"
       },
-      "locationType" : {
-        "id" : "iiif-image",
-        "label" : "IIIF Image API",
-        "type" : "LocationType"
+      "locationType": {
+        "id": "iiif-image",
+        "label": "IIIF Image API",
+        "type": "LocationType"
       },
-      "type" : "DigitalLocation",
-      "url" : "https://iiif.wellcomecollection.org/image/rkd.jpg/info.json"
+      "type": "DigitalLocation",
+      "url": "https://iiif.wellcomecollection.org/image/rkd.jpg/info.json"
     }
   ],
-  "source" : {
-    "id" : "ah74nuba",
-    "title" : "title-i4Lw8upNgg",
-    "type" : "Work"
+  "source": {
+    "id": "ah74nuba",
+    "title": "title-i4Lw8upNgg",
+    "type": "Work"
   },
-  "thumbnail" : {
-    "accessConditions" : [
-    ],
-    "license" : {
-      "id" : "cc-by",
-      "label" : "Attribution 4.0 International (CC BY 4.0)",
-      "type" : "License",
-      "url" : "http://creativecommons.org/licenses/by/4.0/"
+  "thumbnail": {
+    "accessConditions": [],
+    "license": {
+      "id": "cc-by",
+      "label": "Attribution 4.0 International (CC BY 4.0)",
+      "type": "License",
+      "url": "http://creativecommons.org/licenses/by/4.0/"
     },
-    "locationType" : {
-      "id" : "iiif-image",
-      "label" : "IIIF Image API",
-      "type" : "LocationType"
+    "locationType": {
+      "id": "iiif-image",
+      "label": "IIIF Image API",
+      "type": "LocationType"
     },
-    "type" : "DigitalLocation",
-    "url" : "https://iiif.wellcomecollection.org/image/rkd.jpg/info.json"
+    "type": "DigitalLocation",
+    "url": "https://iiif.wellcomecollection.org/image/rkd.jpg/info.json"
   },
-  "type" : "Image",
-  "withSimilarColors" : [
-    {
-      "id" : "o2fdybit",
-      "locations" : [
-        {
-          "accessConditions" : [
-          ],
-          "license" : {
-            "id" : "cc-by",
-            "label" : "Attribution 4.0 International (CC BY 4.0)",
-            "type" : "License",
-            "url" : "http://creativecommons.org/licenses/by/4.0/"
-          },
-          "linkText" : "Link text: Fl9VrODZy",
-          "locationType" : {
-            "id" : "iiif-image",
-            "label" : "IIIF Image API",
-            "type" : "LocationType"
-          },
-          "type" : "DigitalLocation",
-          "url" : "https://iiif.wellcomecollection.org/image/4QL.jpg/info.json"
-        }
-      ],
-      "source" : {
-        "id" : "pyhklpry",
-        "title" : "title-rQmMYtpbz1",
-        "type" : "Work"
-      },
-      "thumbnail" : {
-        "accessConditions" : [
-        ],
-        "license" : {
-          "id" : "cc-by",
-          "label" : "Attribution 4.0 International (CC BY 4.0)",
-          "type" : "License",
-          "url" : "http://creativecommons.org/licenses/by/4.0/"
-        },
-        "linkText" : "Link text: Fl9VrODZy",
-        "locationType" : {
-          "id" : "iiif-image",
-          "label" : "IIIF Image API",
-          "type" : "LocationType"
-        },
-        "type" : "DigitalLocation",
-        "url" : "https://iiif.wellcomecollection.org/image/4QL.jpg/info.json"
-      },
-      "type" : "Image"
-    },
-    {
-      "id" : "mjpos4im",
-      "locations" : [
-        {
-          "accessConditions" : [
-          ],
-          "license" : {
-            "id" : "cc-by",
-            "label" : "Attribution 4.0 International (CC BY 4.0)",
-            "type" : "License",
-            "url" : "http://creativecommons.org/licenses/by/4.0/"
-          },
-          "locationType" : {
-            "id" : "iiif-image",
-            "label" : "IIIF Image API",
-            "type" : "LocationType"
-          },
-          "type" : "DigitalLocation",
-          "url" : "https://iiif.wellcomecollection.org/image/71l.jpg/info.json"
-        }
-      ],
-      "source" : {
-        "id" : "3rl99ijt",
-        "title" : "title-kjWRHDMRRi",
-        "type" : "Work"
-      },
-      "thumbnail" : {
-        "accessConditions" : [
-        ],
-        "license" : {
-          "id" : "cc-by",
-          "label" : "Attribution 4.0 International (CC BY 4.0)",
-          "type" : "License",
-          "url" : "http://creativecommons.org/licenses/by/4.0/"
-        },
-        "locationType" : {
-          "id" : "iiif-image",
-          "label" : "IIIF Image API",
-          "type" : "LocationType"
-        },
-        "type" : "DigitalLocation",
-        "url" : "https://iiif.wellcomecollection.org/image/71l.jpg/info.json"
-      },
-      "type" : "Image"
-    },
-    {
-      "id" : "lsw9sbu8",
-      "locations" : [
-        {
-          "accessConditions" : [
-          ],
-          "credit" : "Credit line: f89Kn3",
-          "license" : {
-            "id" : "cc-by",
-            "label" : "Attribution 4.0 International (CC BY 4.0)",
-            "type" : "License",
-            "url" : "http://creativecommons.org/licenses/by/4.0/"
-          },
-          "locationType" : {
-            "id" : "iiif-image",
-            "label" : "IIIF Image API",
-            "type" : "LocationType"
-          },
-          "type" : "DigitalLocation",
-          "url" : "https://iiif.wellcomecollection.org/image/23S.jpg/info.json"
-        }
-      ],
-      "source" : {
-        "id" : "50v1mskl",
-        "title" : "title-BaVKuyDC49",
-        "type" : "Work"
-      },
-      "thumbnail" : {
-        "accessConditions" : [
-        ],
-        "credit" : "Credit line: f89Kn3",
-        "license" : {
-          "id" : "cc-by",
-          "label" : "Attribution 4.0 International (CC BY 4.0)",
-          "type" : "License",
-          "url" : "http://creativecommons.org/licenses/by/4.0/"
-        },
-        "locationType" : {
-          "id" : "iiif-image",
-          "label" : "IIIF Image API",
-          "type" : "LocationType"
-        },
-        "type" : "DigitalLocation",
-        "url" : "https://iiif.wellcomecollection.org/image/23S.jpg/info.json"
-      },
-      "type" : "Image"
-    },
-    {
-      "id" : "xkvk6o8c",
-      "locations" : [
-        {
-          "accessConditions" : [
-          ],
-          "license" : {
-            "id" : "cc-by",
-            "label" : "Attribution 4.0 International (CC BY 4.0)",
-            "type" : "License",
-            "url" : "http://creativecommons.org/licenses/by/4.0/"
-          },
-          "linkText" : "Link text: qzSZVIHUd",
-          "locationType" : {
-            "id" : "iiif-image",
-            "label" : "IIIF Image API",
-            "type" : "LocationType"
-          },
-          "type" : "DigitalLocation",
-          "url" : "https://iiif.wellcomecollection.org/image/6NJ.jpg/info.json"
-        }
-      ],
-      "source" : {
-        "id" : "nx2evtp1",
-        "title" : "title-kJQyNEOteB",
-        "type" : "Work"
-      },
-      "thumbnail" : {
-        "accessConditions" : [
-        ],
-        "license" : {
-          "id" : "cc-by",
-          "label" : "Attribution 4.0 International (CC BY 4.0)",
-          "type" : "License",
-          "url" : "http://creativecommons.org/licenses/by/4.0/"
-        },
-        "linkText" : "Link text: qzSZVIHUd",
-        "locationType" : {
-          "id" : "iiif-image",
-          "label" : "IIIF Image API",
-          "type" : "LocationType"
-        },
-        "type" : "DigitalLocation",
-        "url" : "https://iiif.wellcomecollection.org/image/6NJ.jpg/info.json"
-      },
-      "type" : "Image"
-    },
-    {
-      "id" : "jchfkdrz",
-      "locations" : [
-        {
-          "accessConditions" : [
-          ],
-          "license" : {
-            "id" : "cc-by",
-            "label" : "Attribution 4.0 International (CC BY 4.0)",
-            "type" : "License",
-            "url" : "http://creativecommons.org/licenses/by/4.0/"
-          },
-          "linkText" : "Link text: SZeA46Q0X",
-          "locationType" : {
-            "id" : "iiif-image",
-            "label" : "IIIF Image API",
-            "type" : "LocationType"
-          },
-          "type" : "DigitalLocation",
-          "url" : "https://iiif.wellcomecollection.org/image/OjP.jpg/info.json"
-        }
-      ],
-      "source" : {
-        "id" : "kbyunwpo",
-        "title" : "title-OIeTcSbJAC",
-        "type" : "Work"
-      },
-      "thumbnail" : {
-        "accessConditions" : [
-        ],
-        "license" : {
-          "id" : "cc-by",
-          "label" : "Attribution 4.0 International (CC BY 4.0)",
-          "type" : "License",
-          "url" : "http://creativecommons.org/licenses/by/4.0/"
-        },
-        "linkText" : "Link text: SZeA46Q0X",
-        "locationType" : {
-          "id" : "iiif-image",
-          "label" : "IIIF Image API",
-          "type" : "LocationType"
-        },
-        "type" : "DigitalLocation",
-        "url" : "https://iiif.wellcomecollection.org/image/OjP.jpg/info.json"
-      },
-      "type" : "Image"
-    }
-  ]
+  "type": "Image",
+  "withSimilarColors": []
 }

--- a/search/src/test/scala/weco/api/search/services/ImagesServiceTest.scala
+++ b/search/src/test/scala/weco/api/search/services/ImagesServiceTest.scala
@@ -95,7 +95,8 @@ class ImagesServiceTest
         val future =
           imagesService.retrieveSimilarImages(
             index,
-            imageId = getTestImageId("images.similar-features-and-palettes.0")
+            imageId = getTestImageId("images.similar-features-and-palettes.0"),
+            minScore = Some(0)
           )
 
         whenReady(future) {
@@ -123,7 +124,8 @@ class ImagesServiceTest
             .retrieveSimilarImages(
               index,
               imageId = getTestImageId("images.similar-features.0"),
-              similarityMetric = SimilarityMetric.Features
+              similarityMetric = SimilarityMetric.Features,
+              minScore = Some(0)
             )
 
         whenReady(future) {
@@ -151,7 +153,8 @@ class ImagesServiceTest
             .retrieveSimilarImages(
               index,
               imageId = getTestImageId("images.similar-palettes.0"),
-              similarityMetric = SimilarityMetric.Colors
+              similarityMetric = SimilarityMetric.Colors,
+              minScore = Some(0)
             )
 
         whenReady(future) {
@@ -171,13 +174,15 @@ class ImagesServiceTest
           .retrieveSimilarImages(
             index,
             imageId = getTestImageId("images.similar-features-and-palettes.0"),
-            similarityMetric = SimilarityMetric.Colors
+            similarityMetric = SimilarityMetric.Colors,
+            minScore = Some(0)
           )
         val blendedResultsFuture = imagesService
           .retrieveSimilarImages(
             index,
             imageId = getTestImageId("images.similar-features-and-palettes.0"),
-            similarityMetric = SimilarityMetric.Blended
+            similarityMetric = SimilarityMetric.Blended,
+            minScore = Some(0)
           )
         whenReady(colorResultsFuture) { colorResults =>
           whenReady(blendedResultsFuture) { blendedResults =>
@@ -195,7 +200,8 @@ class ImagesServiceTest
         whenReady(
           imagesService.retrieveSimilarImages(
             index,
-            imageId = getTestImageId("images.everything")
+            imageId = getTestImageId("images.everything"),
+            minScore = Some(0)
           )
         ) {
           _ shouldBe empty
@@ -208,7 +214,8 @@ class ImagesServiceTest
         imagesService
           .retrieveSimilarImages(
             Index("doesn't exist"),
-            imageId = "nopenope"
+            imageId = "nopenope",
+            minScore = Some(0)
           )
 
       whenReady(future) {


### PR DESCRIPTION
This PR sets a threshold similarity score for images so that we can avoid displaying questionable matches. Closes #516 

This change messes with some of our existing tests - the dummy index populated while setting up the tests can't produce the same scores as the fully populated prod index, and the thresholds therefore filter out any results which might have been matched. In some tests I've been able to manually set the `minScore` to 0, but in others which call the API itself, that's not possible.  I feel like these things might be more appropriately tested in `rank`, where tests can be run against a full index and scoring can be properly examined.