### PR TITLE
Bump test cluster versions to 8.3.3

### DIFF
--- a/common/search/docker-compose.yml
+++ b/common/search/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.5"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.3.3"
     ports:
       - "9200:9200"
       - "9300:9300"

--- a/search/docker-compose.yml
+++ b/search/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.5"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.3.3"
     ports:
       - "9200:9200"
       - "9300:9300"

--- a/snapshots/snapshot_generator/docker-compose.yml
+++ b/snapshots/snapshot_generator/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "33333:8000"
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.5"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.3.3"
     ports:
       - "9200:9200"
       - "9300:9300"


### PR DESCRIPTION
Following https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-api-compatibility.html#_rest_api_compatibility_workflow