### PR TITLE
Remove the old 'api' repository

### DIFF
--- a/terraform/shared/.terraform.lock.hcl
+++ b/terraform/shared/.terraform.lock.hcl
@@ -1,27 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/elastic/ec" {
-  version     = "0.2.1"
-  constraints = "0.2.1"
-  hashes = [
-    "h1:Njh3l0Del+s0OKnOwuKvPZLcTPSdwx7fnLa8Ex/VJrg=",
-    "zh:145414eaa5015fcad546eb17bd78a14720cadcfcca781a46c9a6493722eb3ba8",
-    "zh:1cb7bacfe088c1145834e0a7d053f7aa7a8897a3554d040becad004774aa45f4",
-    "zh:20e245ae46316853ad18d2eff9107aec3e0ffcaa5407b2aa422669d80a872761",
-    "zh:4c9c52e4ee089d71a9f58f0f53173ded7a65012466dbb857b15e7697f25fdb40",
-    "zh:52877b6e934e932aa27d85868e055a907172df9b0ca6bcc4a2c820cc6890b152",
-    "zh:52cabbd5826ac10b5f4f9be25435f970ae0b9caed3cd3cdf42c71ee773c956ac",
-    "zh:999963c9f6ee6d61f3aea2c76d0e842d963662f71b04b9cf4e003d88bd849d0e",
-    "zh:9bd93ffef87de87b3f04bb8b572098ccb8d363a62a4c7fe43f74447ee4ee023f",
-    "zh:a39bdff8f72d1479a9fa6a2399dab687bf775bcb7a1c4db0e5ef87fbbf66bfa9",
-    "zh:aa3cd16eeae66ccaab372f3a6a819fe117516a4c96bc216663bc244983e11100",
-    "zh:c5d3cc19dcf190bea741e75c4f90e1cda4673bef7a6b86f2b7f2eb1fd926dce0",
-    "zh:fcdb180ef082876458ede8d1cdb2e703330120552c5d80268388d8437c9716fb",
-    "zh:fd595f502fcd0ca8ada078114fbf5341880ac8e53493105c42309560654f3729",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/aws" {
   version = "3.46.0"
   hashes = [
@@ -37,41 +16,5 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:da6c412927a514e46ff81e4044ce29617b7c11d33db99ff959a761f97ca09fce",
     "zh:e670cda0e9ffcd791d94bb1822c26e2a1d26cb0e7a7b655019f4375a14e04e90",
     "zh:ebf9c5ef3eceebc1c21bcd31e535e5c323c3bf6ca5918959e297e9a6617d8094",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/null" {
-  version = "3.1.0"
-  hashes = [
-    "h1:xhbHC6in3nQryvTQBWKxebi3inG5OCgHgc4fRxL0ymc=",
-    "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
-    "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
-    "zh:5f9200bf708913621d0f6514179d89700e9aa3097c77dac730e8ba6e5901d521",
-    "zh:9ebf4d9704faba06b3ec7242c773c0fbfe12d62db7d00356d4f55385fc69bfb2",
-    "zh:a6576c81adc70326e4e1c999c04ad9ca37113a6e925aefab4765e5a5198efa7e",
-    "zh:a8a42d13346347aff6c63a37cda9b2c6aa5cc384a55b2fe6d6adfa390e609c53",
-    "zh:c797744d08a5307d50210e0454f91ca4d1c7621c68740441cf4579390452321d",
-    "zh:cecb6a304046df34c11229f20a80b24b1603960b794d68361a67c5efe58e62b8",
-    "zh:e1371aa1e502000d9974cfaff5be4cfa02f47b17400005a16f14d2ef30dc2a70",
-    "zh:fc39cc1fe71234a0b0369d5c5c7f876c71b956d23d7d6f518289737a001ba69b",
-    "zh:fea4227271ebf7d9e2b61b89ce2328c7262acd9fd190e1fd6d15a591abfa848e",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/random" {
-  version = "3.1.0"
-  hashes = [
-    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
-    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
-    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
-    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
-    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
-    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
-    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
-    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
-    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
-    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
-    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
-    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
   ]
 }

--- a/terraform/shared/ecr.tf
+++ b/terraform/shared/ecr.tf
@@ -25,14 +25,6 @@ resource "aws_ecr_repository" "search" {
   }
 }
 
-resource "aws_ecr_repository" "api" {
-  name = "uk.ac.wellcome/api"
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
 resource "aws_ecr_repository" "concepts" {
   name = "uk.ac.wellcome/concepts"
 

--- a/terraform/shared/outputs.tf
+++ b/terraform/shared/outputs.tf
@@ -1,7 +1,3 @@
-output "ecr_api_repository_url" {
-  value = aws_ecr_repository.api.repository_url
-}
-
 output "ecr_search_repository_url" {
   value = aws_ecr_repository.search.repository_url
 }


### PR DESCRIPTION
We hadn't pushed to it in over a year and a half, and nothing is using it.