### PR TITLE
Allow looking up contributors and other non-subject types in the concepts API

### DIFF
--- a/concepts/src/controllers/concept.ts
+++ b/concepts/src/controllers/concept.ts
@@ -37,7 +37,7 @@ const conceptController = (
             id,
             label: subject.label,
             identifiers: subject.identifiers,
-            type: "Subject",
+            type: subject.type,
           });
           return;
         }

--- a/concepts/src/controllers/concept.ts
+++ b/concepts/src/controllers/concept.ts
@@ -21,11 +21,23 @@ const conceptController = (
       index,
       body: {
         size: 1,
-        _source: ["display.subjects"],
+        _source: ["display.contributors.agent", "display.subjects"],
         query: {
-          term: {
-            "query.subjects.id": id,
-          },
+          bool: {
+            should: [
+              {
+                term: {
+                  "query.subjects.id": id
+                }
+              },
+              {
+                term: {
+                  "query.contributors.agent.id": id
+                }
+              }
+            ],
+            minimum_should_match: 1
+          }
         },
       },
     });
@@ -38,6 +50,18 @@ const conceptController = (
             label: subject.label,
             identifiers: subject.identifiers,
             type: subject.type,
+          });
+          return;
+        }
+      }
+
+      for (const contributor of work._source.display.contributors) {
+        if (contributor.agent.id === id) {
+          res.status(200).json({
+            id,
+            label: contributor.agent.label,
+            identifiers: contributor.agent.identifiers,
+            type: contributor.agent.type,
           });
           return;
         }


### PR DESCRIPTION
This data isn't fully populated in the indexes, but you can see one example here (when running locally): http://localhost:3000/concepts/bref4d5q

For https://github.com/wellcomecollection/platform/issues/5603