### PR TITLE
Use the newest fields in the query object

### DIFF
--- a/common/search/src/test/resources/WorksIndexConfig.json
+++ b/common/search/src/test/resources/WorksIndexConfig.json
@@ -646,6 +646,18 @@
               }
             }
           },
+          "description": {
+            "type": "text",
+            "fields": {
+              "english": {
+                "type": "text",
+                "analyzer": "english_analyzer"
+              }
+            }
+          },
+          "edition": {
+            "type": "text"
+          },
           "genres": {
             "properties": {
               "concepts": {
@@ -770,6 +782,69 @@
             "properties": {
               "id": {
                 "type": "keyword"
+              },
+              "label": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword"
+                  },
+                  "lowercaseKeyword": {
+                    "type": "keyword",
+                    "normalizer": "lowercase_normalizer"
+                  }
+                },
+                "analyzer": "asciifolding_analyzer"
+              }
+            }
+          },
+          "lettering": {
+            "type": "text",
+            "fields": {
+              "arabic": {
+                "type": "text",
+                "analyzer": "arabic_analyzer"
+              },
+              "bengali": {
+                "type": "text",
+                "analyzer": "bengali_analyzer"
+              },
+              "english": {
+                "type": "text",
+                "analyzer": "english_analyzer"
+              },
+              "french": {
+                "type": "text",
+                "analyzer": "french_analyzer"
+              },
+              "german": {
+                "type": "text",
+                "analyzer": "german_analyzer"
+              },
+              "hindi": {
+                "type": "text",
+                "analyzer": "hindi_analyzer"
+              },
+              "italian": {
+                "type": "text",
+                "analyzer": "italian_analyzer"
+              },
+              "shingles": {
+                "type": "text",
+                "analyzer": "shingle_asciifolding_analyzer"
+              }
+            }
+          },
+          "notes": {
+            "properties": {
+              "contents": {
+                "type": "text",
+                "fields": {
+                  "english": {
+                    "type": "text",
+                    "analyzer": "english_analyzer"
+                  }
+                }
               }
             }
           },
@@ -822,6 +897,18 @@
               }
             }
           },
+          "physicalDescription": {
+            "type": "text",
+            "fields": {
+              "english": {
+                "type": "text",
+                "analyzer": "english_analyzer"
+              },
+              "keyword": {
+                "type": "keyword"
+              }
+            }
+          },
           "subjects": {
             "properties": {
               "concepts": {
@@ -857,6 +944,47 @@
               "id": {
                 "type": "keyword",
                 "normalizer": "lowercase_normalizer"
+              }
+            }
+          },
+          "title": {
+            "type": "text",
+            "fields": {
+              "arabic": {
+                "type": "text",
+                "analyzer": "arabic_analyzer"
+              },
+              "bengali": {
+                "type": "text",
+                "analyzer": "bengali_analyzer"
+              },
+              "english": {
+                "type": "text",
+                "analyzer": "english_analyzer"
+              },
+              "french": {
+                "type": "text",
+                "analyzer": "french_analyzer"
+              },
+              "german": {
+                "type": "text",
+                "analyzer": "german_analyzer"
+              },
+              "hindi": {
+                "type": "text",
+                "analyzer": "hindi_analyzer"
+              },
+              "italian": {
+                "type": "text",
+                "analyzer": "italian_analyzer"
+              },
+              "keyword": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer"
+              },
+              "shingles": {
+                "type": "text",
+                "analyzer": "shingle_asciifolding_analyzer"
               }
             }
           }

--- a/common/search/src/test/resources/test_documents/work-production.1098.json
+++ b/common/search/src/test/resources/test_documents/work-production.1098.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1098",
-  "createdAt" : "2022-09-20T13:36:01.074859Z",
+  "createdAt" : "2022-09-26T11:29:27.282394Z",
   "id" : "guav7chy",
   "document" : {
     "debug" : {
@@ -169,6 +169,13 @@
       "identifiers.value" : [
         "W9fptfa5Xn"
       ],
+      "title" : "Production event in 1098",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -194,6 +201,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-production.1900.json
+++ b/common/search/src/test/resources/test_documents/work-production.1900.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1900",
-  "createdAt" : "2022-09-20T13:36:01.015079Z",
+  "createdAt" : "2022-09-26T11:29:27.244442Z",
   "id" : "rbnro6wx",
   "document" : {
     "debug" : {
@@ -169,6 +169,13 @@
       "identifiers.value" : [
         "akaUmx5H3i"
       ],
+      "title" : "Production event in 1900",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -194,6 +201,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-production.1904.json
+++ b/common/search/src/test/resources/test_documents/work-production.1904.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1904",
-  "createdAt" : "2022-09-20T13:36:01.047034Z",
+  "createdAt" : "2022-09-26T11:29:27.266410Z",
   "id" : "aiv95swj",
   "document" : {
     "debug" : {
@@ -169,6 +169,13 @@
       "identifiers.value" : [
         "h0QyLvGt20"
       ],
+      "title" : "Production event in 1904",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -194,6 +201,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-production.1976.json
+++ b/common/search/src/test/resources/test_documents/work-production.1976.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1976",
-  "createdAt" : "2022-09-20T13:36:01.031290Z",
+  "createdAt" : "2022-09-26T11:29:27.257410Z",
   "id" : "5vjghupy",
   "document" : {
     "debug" : {
@@ -169,6 +169,13 @@
       "identifiers.value" : [
         "xrdlOL8J49"
       ],
+      "title" : "Production event in 1976",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -194,6 +201,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-production.2020.json
+++ b/common/search/src/test/resources/test_documents/work-production.2020.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 2020",
-  "createdAt" : "2022-09-20T13:36:01.060521Z",
+  "createdAt" : "2022-09-26T11:29:27.274530Z",
   "id" : "0fucriyr",
   "document" : {
     "debug" : {
@@ -169,6 +169,13 @@
       "identifiers.value" : [
         "KgSH5dUX0Z"
       ],
+      "title" : "Production event in 2020",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -194,6 +201,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-thumbnail.json
+++ b/common/search/src/test/resources/test_documents/work-thumbnail.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a thumbnail",
-  "createdAt" : "2022-09-20T13:36:00.897791Z",
+  "createdAt" : "2022-09-26T11:29:27.167985Z",
   "id" : "sahqcluh",
   "document" : {
     "debug" : {
@@ -163,6 +163,13 @@
       "identifiers.value" : [
         "rRRYGQYiF7"
       ],
+      "title" : "title-LSfnjHB2TS",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -188,6 +195,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-title-dodo.json
+++ b/common/search/src/test/resources/test_documents/work-title-dodo.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'dodo' in the title",
-  "createdAt" : "2022-09-20T13:36:00.914143Z",
+  "createdAt" : "2022-09-26T11:29:27.180235Z",
   "id" : "ezagik4b",
   "document" : {
     "debug" : {
@@ -135,6 +135,13 @@
       "identifiers.value" : [
         "xg9OuzGali"
       ],
+      "title" : "A drawing of a dodo",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : "A line of legible ligatures",
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -160,6 +167,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-title-mouse.json
+++ b/common/search/src/test/resources/test_documents/work-title-mouse.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'mouse' in the title",
-  "createdAt" : "2022-09-20T13:36:00.927265Z",
+  "createdAt" : "2022-09-26T11:29:27.187468Z",
   "id" : "lnn17cwk",
   "document" : {
     "debug" : {
@@ -135,6 +135,13 @@
       "identifiers.value" : [
         "EhPpSB8mq7"
       ],
+      "title" : "A mezzotint of a mouse",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : "A print of proportional penmanship",
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -160,6 +167,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-with-edition-and-duration.json
+++ b/common/search/src/test/resources/test_documents/work-with-edition-and-duration.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with optional top-level fields",
-  "createdAt" : "2022-09-20T13:36:00.801840Z",
+  "createdAt" : "2022-09-26T11:29:27.107456Z",
   "id" : "gsruvqwf",
   "document" : {
     "debug" : {
@@ -136,6 +136,13 @@
       "identifiers.value" : [
         "7YNi35xO0f"
       ],
+      "title" : "title-4pIj0kgXrt",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : "Special edition",
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -161,6 +168,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work.items-with-location-types.0.json
+++ b/common/search/src/test/resources/test_documents/work.items-with-location-types.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-09-20T13:36:02.683637Z",
+  "createdAt" : "2022-09-26T11:29:28.189533Z",
   "id" : "kdwct2lf",
   "document" : {
     "debug" : {
@@ -201,6 +201,13 @@
       "identifiers.value" : [
         "vUprsjrX3O"
       ],
+      "title" : "title-sLaubb73X6",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -230,6 +237,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work.items-with-location-types.1.json
+++ b/common/search/src/test/resources/test_documents/work.items-with-location-types.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-09-20T13:36:02.684755Z",
+  "createdAt" : "2022-09-26T11:29:28.190576Z",
   "id" : "sgatphra",
   "document" : {
     "debug" : {
@@ -233,6 +233,13 @@
       "identifiers.value" : [
         "GsIdzZyGYB"
       ],
+      "title" : "title-GkJTZWwn4A",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -264,6 +271,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work.items-with-location-types.2.json
+++ b/common/search/src/test/resources/test_documents/work.items-with-location-types.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-09-20T13:36:02.686314Z",
+  "createdAt" : "2022-09-26T11:29:28.191463Z",
   "id" : "wt6pclbs",
   "document" : {
     "debug" : {
@@ -209,6 +209,13 @@
       "identifiers.value" : [
         "D31AdK5EfQ"
       ],
+      "title" : "title-e4jqB3DBkI",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -238,6 +245,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work.visible.everything.0.json
+++ b/common/search/src/test/resources/test_documents/work.visible.everything.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-09-20T13:36:01.476500Z",
+  "createdAt" : "2022-09-26T11:29:27.526306Z",
   "id" : "tmdfbk5k",
   "document" : {
     "debug" : {
@@ -1001,6 +1001,17 @@
         "Aic5qOhRoS",
         "UfcQYSxE7g"
       ],
+      "title" : "A work with all the include-able fields",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+        "hy1sdDDR",
+        "KLQFKzgro",
+        "PkIHAHMj",
+        "FaY5fj9BpO"
+      ],
+      "lettering" : null,
       "images.id" : [
         "eoedbdmz",
         "w1yfrq9a"
@@ -1059,6 +1070,11 @@
         "qbV",
         "2DH",
         "yMV"
+      ],
+      "languages.label" : [
+        "83c9SMhIH",
+        "Ap8e8Su",
+        "QTT2Ir"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work.visible.everything.1.json
+++ b/common/search/src/test/resources/test_documents/work.visible.everything.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-09-20T13:36:01.567542Z",
+  "createdAt" : "2022-09-26T11:29:27.571095Z",
   "id" : "nlqnlwch",
   "document" : {
     "debug" : {
@@ -1070,6 +1070,17 @@
         "jfcicmGMGK",
         "aGKxAEeG0H"
       ],
+      "title" : "A work with all the include-able fields",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+        "LHOqPv8Cs",
+        "YxC3RLI",
+        "6KqXfdMBn",
+        "MM9NU3A"
+      ],
+      "lettering" : null,
       "images.id" : [
         "do1dzyoo",
         "jfro7laj"
@@ -1128,6 +1139,11 @@
         "yc6",
         "hi6",
         "GkI"
+      ],
+      "languages.label" : [
+        "AydChzs",
+        "ux209O7",
+        "x8vXQy"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work.visible.everything.2.json
+++ b/common/search/src/test/resources/test_documents/work.visible.everything.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-09-20T13:36:01.583178Z",
+  "createdAt" : "2022-09-26T11:29:27.577852Z",
   "id" : "jfzz4ou9",
   "document" : {
     "debug" : {
@@ -1079,6 +1079,17 @@
         "Is1ajgcgP8",
         "FhqVjVef8B"
       ],
+      "title" : "A work with all the include-able fields",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+        "6uOUAu",
+        "0NVp7GvR",
+        "RE2canCUR",
+        "No7cLokW4L"
+      ],
+      "lettering" : null,
       "images.id" : [
         "y3fstphe",
         "whuucljo"
@@ -1137,6 +1148,11 @@
         "6hh",
         "EHn",
         "7Jx"
+      ],
+      "languages.label" : [
+        "PPssCoB",
+        "ZViPXHQHS",
+        "9xrQ6L"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.collection-path.NUFFINK.json
+++ b/common/search/src/test/resources/test_documents/works.collection-path.NUFFINK.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a collection path",
-  "createdAt" : "2022-09-20T13:36:02.366939Z",
+  "createdAt" : "2022-09-26T11:29:27.997100Z",
   "id" : "dtqmc0yn",
   "document" : {
     "debug" : {
@@ -137,6 +137,13 @@
       "identifiers.value" : [
         "Lq95TrUx7A"
       ],
+      "title" : "title-boqbXNAi3a",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -162,6 +169,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.collection-path.PPCRI.json
+++ b/common/search/src/test/resources/test_documents/works.collection-path.PPCRI.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a collection path",
-  "createdAt" : "2022-09-20T13:36:02.351453Z",
+  "createdAt" : "2022-09-26T11:29:27.985572Z",
   "id" : "mlqs2qbd",
   "document" : {
     "debug" : {
@@ -137,6 +137,13 @@
       "identifiers.value" : [
         "yQb1GgWKF4"
       ],
+      "title" : "title-X1EiWSsi1c",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -162,6 +169,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.contributor.0.json
+++ b/common/search/src/test/resources/test_documents/works.contributor.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-09-20T13:36:02.224414Z",
+  "createdAt" : "2022-09-26T11:29:27.909515Z",
   "id" : "gvkz3vff",
   "document" : {
     "debug" : {
@@ -159,6 +159,13 @@
       "identifiers.value" : [
         "5CJlp05MGl"
       ],
+      "title" : "title-Wh4OVfDtEV",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -184,6 +191,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.contributor.1.json
+++ b/common/search/src/test/resources/test_documents/works.contributor.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-09-20T13:36:02.225721Z",
+  "createdAt" : "2022-09-26T11:29:27.910624Z",
   "id" : "bj9evx0c",
   "document" : {
     "debug" : {
@@ -159,6 +159,13 @@
       "identifiers.value" : [
         "TjLML0MOH1"
       ],
+      "title" : "title-h70mKj49k3",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -184,6 +191,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.contributor.2.json
+++ b/common/search/src/test/resources/test_documents/works.contributor.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-09-20T13:36:02.234046Z",
+  "createdAt" : "2022-09-26T11:29:27.916077Z",
   "id" : "z08k6cnn",
   "document" : {
     "debug" : {
@@ -184,6 +184,13 @@
       "identifiers.value" : [
         "juTufKU2Ye"
       ],
+      "title" : "title-UVMdWdPx74",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -209,6 +216,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.contributor.3.json
+++ b/common/search/src/test/resources/test_documents/works.contributor.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-09-20T13:36:02.235156Z",
+  "createdAt" : "2022-09-26T11:29:27.917335Z",
   "id" : "gtfjchvo",
   "document" : {
     "debug" : {
@@ -184,6 +184,13 @@
       "identifiers.value" : [
         "xKXAvquihJ"
       ],
+      "title" : "title-AJeGRUgE73",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -209,6 +216,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.0.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.382823Z",
+  "createdAt" : "2022-09-26T11:29:28.013931Z",
   "id" : "4njkixz6",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "BApNW5yJ4Q"
       ],
+      "title" : "title-6YygLZHy7Z",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.1.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.383629Z",
+  "createdAt" : "2022-09-26T11:29:28.014484Z",
   "id" : "jugcpduf",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "YysYTJPbhB"
       ],
+      "title" : "title-DhzFoUvfxn",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.10.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.393424Z",
+  "createdAt" : "2022-09-26T11:29:28.019907Z",
   "id" : "4wwgkp4h",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "miNkeZ17CI"
       ],
+      "title" : "title-uALANM5eCQ",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.11.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.394331Z",
+  "createdAt" : "2022-09-26T11:29:28.023792Z",
   "id" : "kkcl3dhq",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "INEpZD4veL"
       ],
+      "title" : "title-ooZVNybADY",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.12.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.395168Z",
+  "createdAt" : "2022-09-26T11:29:28.024679Z",
   "id" : "ilrp0gol",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "TRLxjc4Dv7"
       ],
+      "title" : "title-5MZkkqME2t",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.13.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.395913Z",
+  "createdAt" : "2022-09-26T11:29:28.025349Z",
   "id" : "rdqs25hn",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "fZ9zaDFnzp"
       ],
+      "title" : "title-uQBSkLFL8C",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.14.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.396904Z",
+  "createdAt" : "2022-09-26T11:29:28.026102Z",
   "id" : "124qx5km",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "LCpWDX84If"
       ],
+      "title" : "title-WpmMJGY9dh",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.15.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.397606Z",
+  "createdAt" : "2022-09-26T11:29:28.026845Z",
   "id" : "tlc5rq9a",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "mz25207khU"
       ],
+      "title" : "title-jNr737MdPw",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.16.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.398459Z",
+  "createdAt" : "2022-09-26T11:29:28.027416Z",
   "id" : "sdb22mdv",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "qjgnqBCXUR"
       ],
+      "title" : "title-8D1YQhdjF0",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.17.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.399191Z",
+  "createdAt" : "2022-09-26T11:29:28.028074Z",
   "id" : "9tar4kg6",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "WpfpIxjlf3"
       ],
+      "title" : "title-zifN5hzpvx",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.18.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.400222Z",
+  "createdAt" : "2022-09-26T11:29:28.028774Z",
   "id" : "au6tjof0",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "vISRu7MtEo"
       ],
+      "title" : "title-GajAY87vuu",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.19.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.401095Z",
+  "createdAt" : "2022-09-26T11:29:28.029343Z",
   "id" : "ogdq417u",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "lq8kfIsxyr"
       ],
+      "title" : "title-7J1fupAzsf",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.2.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.384451Z",
+  "createdAt" : "2022-09-26T11:29:28.015175Z",
   "id" : "fuwvinln",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "40wEIb4rPR"
       ],
+      "title" : "title-8ljlZQFqGf",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.20.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.401927Z",
+  "createdAt" : "2022-09-26T11:29:28.030073Z",
   "id" : "jyum0yf1",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "KzDNfalpwO"
       ],
+      "title" : "title-ImZeIhkjzt",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.21.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.402730Z",
+  "createdAt" : "2022-09-26T11:29:28.030680Z",
   "id" : "cwippax3",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "2PauY4Py8G"
       ],
+      "title" : "title-5qt38YgNxO",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.22.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.403596Z",
+  "createdAt" : "2022-09-26T11:29:28.031194Z",
   "id" : "9rgmu63i",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "3tyy1ghzsQ"
       ],
+      "title" : "title-sDHZ5kGsC2",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.3.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.385417Z",
+  "createdAt" : "2022-09-26T11:29:28.015808Z",
   "id" : "i77xk8vj",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "SZKltFZVRN"
       ],
+      "title" : "title-3TPxT5oi8C",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.4.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.387213Z",
+  "createdAt" : "2022-09-26T11:29:28.016379Z",
   "id" : "xgsosrhr",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "L5s2axrzcV"
       ],
+      "title" : "title-K7J5071Cwm",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.5.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.388772Z",
+  "createdAt" : "2022-09-26T11:29:28.017149Z",
   "id" : "cvdyxyqr",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "LIOVK6f1ni"
       ],
+      "title" : "title-eWPnruNlWw",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.6.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.390056Z",
+  "createdAt" : "2022-09-26T11:29:28.017781Z",
   "id" : "aftvp1wz",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "rMq0Chsgjm"
       ],
+      "title" : "title-K883LiigJ4",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.7.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.390922Z",
+  "createdAt" : "2022-09-26T11:29:28.018332Z",
   "id" : "y8glbwdh",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "NrhJtvfJrH"
       ],
+      "title" : "title-PcZctCb44q",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.8.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.391776Z",
+  "createdAt" : "2022-09-26T11:29:28.018867Z",
   "id" : "4fkr6m6l",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "Ngls6zS4b2"
       ],
+      "title" : "title-uUZlr85jkf",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.9.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-20T13:36:02.392621Z",
+  "createdAt" : "2022-09-26T11:29:28.019371Z",
   "id" : "e2zva5mj",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "2Ap82csHfk"
       ],
+      "title" : "title-AcxE29kiXI",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-20T13:36:03.479676Z",
+  "createdAt" : "2022-09-26T11:29:28.642707Z",
   "id" : "stsp385v",
   "document" : {
     "debug" : {
@@ -226,6 +226,13 @@
       "identifiers.value" : [
         "PD8H80xrR5"
       ],
+      "title" : "title-GLuYXYlnwW",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -256,6 +263,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-20T13:36:03.480750Z",
+  "createdAt" : "2022-09-26T11:29:28.643552Z",
   "id" : "jwvfegzn",
   "document" : {
     "debug" : {
@@ -224,6 +224,13 @@
       "identifiers.value" : [
         "FvAY3kDPeO"
       ],
+      "title" : "title-8X1iQV3o0G",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -254,6 +261,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-20T13:36:03.481784Z",
+  "createdAt" : "2022-09-26T11:29:28.644286Z",
   "id" : "glagakd2",
   "document" : {
     "debug" : {
@@ -224,6 +224,13 @@
       "identifiers.value" : [
         "aCHuXzrv8P"
       ],
+      "title" : "title-zPZAnMiJNW",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -254,6 +261,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-20T13:36:03.482737Z",
+  "createdAt" : "2022-09-26T11:29:28.644983Z",
   "id" : "wys5lz5r",
   "document" : {
     "debug" : {
@@ -233,6 +233,13 @@
       "identifiers.value" : [
         "GWT6gTiZ6K"
       ],
+      "title" : "title-MofTOW5bCv",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -263,6 +270,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-20T13:36:03.483588Z",
+  "createdAt" : "2022-09-26T11:29:28.645621Z",
   "id" : "iqani2su",
   "document" : {
     "debug" : {
@@ -232,6 +232,13 @@
       "identifiers.value" : [
         "jYpuBxuni2"
       ],
+      "title" : "title-7p7NJFW4Dx",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -262,6 +269,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-20T13:36:03.504788Z",
+  "createdAt" : "2022-09-26T11:29:28.660671Z",
   "id" : "yh6sk7pv",
   "document" : {
     "debug" : {
@@ -236,6 +236,13 @@
       "identifiers.value" : [
         "5tbPGXaLqw"
       ],
+      "title" : "title-r7VLiwfab6",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -266,6 +273,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.6.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-20T13:36:03.506198Z",
+  "createdAt" : "2022-09-26T11:29:28.661843Z",
   "id" : "uqhxoxvf",
   "document" : {
     "debug" : {
@@ -228,6 +228,13 @@
       "identifiers.value" : [
         "Ey1hoMJJvc"
       ],
+      "title" : "title-tU496lvqxD",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -258,6 +265,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.721343Z",
+  "createdAt" : "2022-09-26T11:29:28.215713Z",
   "id" : "vqys4hio",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "ESZHkohLBq"
       ],
+      "title" : "title-vwQleJkqVb",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.722519Z",
+  "createdAt" : "2022-09-26T11:29:28.216895Z",
   "id" : "scernate",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "mxTT1Dnad9"
       ],
+      "title" : "title-ZtfG4qEc4M",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.10.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.732727Z",
+  "createdAt" : "2022-09-26T11:29:28.226315Z",
   "id" : "sw2fzgit",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "6gzFFn0MzM"
       ],
+      "title" : "title-5K9RmsgKYJ",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.11.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.733895Z",
+  "createdAt" : "2022-09-26T11:29:28.227296Z",
   "id" : "4elqjncu",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "WyiVFCEDYI"
       ],
+      "title" : "title-pZH75AXbZo",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.12.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.735206Z",
+  "createdAt" : "2022-09-26T11:29:28.228148Z",
   "id" : "8yitytyw",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "a33KTr4gSW"
       ],
+      "title" : "title-3z92KVUKZD",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.13.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.736288Z",
+  "createdAt" : "2022-09-26T11:29:28.228924Z",
   "id" : "66bwuadw",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "t9Z95L7cLo"
       ],
+      "title" : "title-2M9CVkukQI",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.14.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.737549Z",
+  "createdAt" : "2022-09-26T11:29:28.229866Z",
   "id" : "dborzqld",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "xZlpWaXi4Y"
       ],
+      "title" : "title-LN4dq7YPgQ",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.15.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.738517Z",
+  "createdAt" : "2022-09-26T11:29:28.230867Z",
   "id" : "fu0kybma",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "SlRRldG9e4"
       ],
+      "title" : "title-54cIcDQPXI",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.16.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.739556Z",
+  "createdAt" : "2022-09-26T11:29:28.231835Z",
   "id" : "pyub9jxo",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "qajt54m4dW"
       ],
+      "title" : "title-bp7ZbfAOv6",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.17.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.740712Z",
+  "createdAt" : "2022-09-26T11:29:28.232808Z",
   "id" : "izlcv3sm",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "x0zgHgbzqM"
       ],
+      "title" : "title-aNuUq84cRg",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.18.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.741935Z",
+  "createdAt" : "2022-09-26T11:29:28.234053Z",
   "id" : "s4ry14qu",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "Ue8m3HVuer"
       ],
+      "title" : "title-XX1muoI8Tp",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.19.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.743462Z",
+  "createdAt" : "2022-09-26T11:29:28.235237Z",
   "id" : "svr3x3ca",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "FRfKD3vr5o"
       ],
+      "title" : "title-lluSXGQIID",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.723770Z",
+  "createdAt" : "2022-09-26T11:29:28.218197Z",
   "id" : "vpkqafpg",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "dPAcgpfIbf"
       ],
+      "title" : "title-z7am59I9Cw",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.20.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.744804Z",
+  "createdAt" : "2022-09-26T11:29:28.236280Z",
   "id" : "w4lfjuza",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "P7HD59gW9t"
       ],
+      "title" : "title-quWoTqEmJ6",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.21.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.745874Z",
+  "createdAt" : "2022-09-26T11:29:28.237197Z",
   "id" : "5hlmpzzh",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "PyW5z3uVBA"
       ],
+      "title" : "title-JtbkBsxzfE",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.22.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.747030Z",
+  "createdAt" : "2022-09-26T11:29:28.238070Z",
   "id" : "b5lylqvq",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "DIlUXQf0x4"
       ],
+      "title" : "title-SQr2rDSofx",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.725409Z",
+  "createdAt" : "2022-09-26T11:29:28.219698Z",
   "id" : "ivw1mq40",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "zoIhNdLDgG"
       ],
+      "title" : "title-gbiIgGzgYB",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.726506Z",
+  "createdAt" : "2022-09-26T11:29:28.220962Z",
   "id" : "mxssba8u",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "QnFei9OwDH"
       ],
+      "title" : "title-TG3GuW07LA",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.727579Z",
+  "createdAt" : "2022-09-26T11:29:28.221884Z",
   "id" : "pi8hxmce",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "tXxMtg7dko"
       ],
+      "title" : "title-jABF1suXYC",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.6.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.728663Z",
+  "createdAt" : "2022-09-26T11:29:28.222760Z",
   "id" : "lwt2ohte",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "zOTvHYjPJX"
       ],
+      "title" : "title-5AXQEaJ1be",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.7.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.729777Z",
+  "createdAt" : "2022-09-26T11:29:28.223627Z",
   "id" : "a62ffqxh",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "dUrbgrWtto"
       ],
+      "title" : "title-ojQsszds7w",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.8.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.730776Z",
+  "createdAt" : "2022-09-26T11:29:28.224443Z",
   "id" : "atgvzcvy",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "za69e7zAIP"
       ],
+      "title" : "title-WMl0kbMOTy",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.9.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-20T13:36:02.731777Z",
+  "createdAt" : "2022-09-26T11:29:28.225321Z",
   "id" : "mopzrqzu",
   "document" : {
     "debug" : {
@@ -189,6 +189,13 @@
       "identifiers.value" : [
         "DIXUuyd8hW"
       ],
+      "title" : "title-pVU0ULWN0n",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -218,6 +225,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-20T13:36:03.180983Z",
+  "createdAt" : "2022-09-26T11:29:28.474688Z",
   "id" : "h5zn9bqm",
   "document" : {
     "debug" : {
@@ -161,6 +161,13 @@
       "identifiers.value" : [
         "OQ6G6Rkv6Q"
       ],
+      "title" : "title-6Obq6lxZzG",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -186,6 +193,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-20T13:36:03.181612Z",
+  "createdAt" : "2022-09-26T11:29:28.475482Z",
   "id" : "gnuj1it3",
   "document" : {
     "debug" : {
@@ -161,6 +161,13 @@
       "identifiers.value" : [
         "Og3KGy7Mz5"
       ],
+      "title" : "title-c4OR9LzJV7",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -186,6 +193,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-20T13:36:03.182687Z",
+  "createdAt" : "2022-09-26T11:29:28.476364Z",
   "id" : "e1k1l8xu",
   "document" : {
     "debug" : {
@@ -161,6 +161,13 @@
       "identifiers.value" : [
         "Kvqw9fGol7"
       ],
+      "title" : "title-cLZhc35m9C",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -186,6 +193,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-20T13:36:03.183594Z",
+  "createdAt" : "2022-09-26T11:29:28.477016Z",
   "id" : "6q7wkowr",
   "document" : {
     "debug" : {
@@ -161,6 +161,13 @@
       "identifiers.value" : [
         "AgxJAjEybh"
       ],
+      "title" : "title-NOoLbpS5jR",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -186,6 +193,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-20T13:36:03.184470Z",
+  "createdAt" : "2022-09-26T11:29:28.477659Z",
   "id" : "cpwnrkdo",
   "document" : {
     "debug" : {
@@ -188,6 +188,13 @@
       "identifiers.value" : [
         "FqozNGJ9Pf"
       ],
+      "title" : "title-Vp3bULWghZ",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -213,6 +220,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-20T13:36:03.184957Z",
+  "createdAt" : "2022-09-26T11:29:28.478039Z",
   "id" : "bexh6kx6",
   "document" : {
     "debug" : {
@@ -134,6 +134,13 @@
       "identifiers.value" : [
         "5q2ktKEnxz"
       ],
+      "title" : "title-ERuJHArEMd",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -159,6 +166,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.different-work-types.Collection.json
+++ b/common/search/src/test/resources/test_documents/works.examples.different-work-types.Collection.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-09-20T13:36:02.999794Z",
+  "createdAt" : "2022-09-26T11:29:28.376725Z",
   "id" : "2tqcclh1",
   "document" : {
     "debug" : {
@@ -134,6 +134,13 @@
       "identifiers.value" : [
         "ZiS5MlN0hQ"
       ],
+      "title" : "rats",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -159,6 +166,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.different-work-types.Section.json
+++ b/common/search/src/test/resources/test_documents/works.examples.different-work-types.Section.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-09-20T13:36:02.990959Z",
+  "createdAt" : "2022-09-26T11:29:28.370171Z",
   "id" : "iw5fnuyy",
   "document" : {
     "debug" : {
@@ -134,6 +134,13 @@
       "identifiers.value" : [
         "Xo35aec2Io"
       ],
+      "title" : "rats",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -159,6 +166,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.different-work-types.Series.json
+++ b/common/search/src/test/resources/test_documents/works.examples.different-work-types.Series.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-09-20T13:36:03.015064Z",
+  "createdAt" : "2022-09-26T11:29:28.382399Z",
   "id" : "fndkxmxs",
   "document" : {
     "debug" : {
@@ -134,6 +134,13 @@
       "identifiers.value" : [
         "yW6CgVzwIJ"
       ],
+      "title" : "rats",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -159,6 +166,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-20T13:36:03.583681Z",
+  "createdAt" : "2022-09-26T11:29:28.697765Z",
   "id" : "phodmv5g",
   "document" : {
     "debug" : {
@@ -151,6 +151,13 @@
       "identifiers.value" : [
         "kSl7z2IaIy"
       ],
+      "title" : "rats",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -177,6 +184,9 @@
       ],
       "languages.id" : [
         "bak"
+      ],
+      "languages.label" : [
+        "Bashkir"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-20T13:36:03.584655Z",
+  "createdAt" : "2022-09-26T11:29:28.698291Z",
   "id" : "580nnpfa",
   "document" : {
     "debug" : {
@@ -151,6 +151,13 @@
       "identifiers.value" : [
         "wz2OkOJHcs"
       ],
+      "title" : "capybara",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -177,6 +184,9 @@
       ],
       "languages.id" : [
         "mar"
+      ],
+      "languages.label" : [
+        "Marathi"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-20T13:36:03.585804Z",
+  "createdAt" : "2022-09-26T11:29:28.698779Z",
   "id" : "jfnymrg2",
   "document" : {
     "debug" : {
@@ -151,6 +151,13 @@
       "identifiers.value" : [
         "zrSaF1p8IU"
       ],
+      "title" : "tapirs",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -177,6 +184,9 @@
       ],
       "languages.id" : [
         "que"
+      ],
+      "languages.label" : [
+        "Quechua"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-20T13:36:03.586736Z",
+  "createdAt" : "2022-09-26T11:29:28.699339Z",
   "id" : "lpoz1fy9",
   "document" : {
     "debug" : {
@@ -151,6 +151,13 @@
       "identifiers.value" : [
         "FGpPdnmb6i"
       ],
+      "title" : "rats",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -177,6 +184,9 @@
       ],
       "languages.id" : [
         "bak"
+      ],
+      "languages.label" : [
+        "Bashkir"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-20T13:36:03.587628Z",
+  "createdAt" : "2022-09-26T11:29:28.699870Z",
   "id" : "in2u7aru",
   "document" : {
     "debug" : {
@@ -151,6 +151,13 @@
       "identifiers.value" : [
         "OHrklHuS07"
       ],
+      "title" : "capybara",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -177,6 +184,9 @@
       ],
       "languages.id" : [
         "bak"
+      ],
+      "languages.label" : [
+        "Bashkir"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-20T13:36:03.588794Z",
+  "createdAt" : "2022-09-26T11:29:28.700313Z",
   "id" : "wkzjlx5a",
   "document" : {
     "debug" : {
@@ -151,6 +151,13 @@
       "identifiers.value" : [
         "SKphDnojLC"
       ],
+      "title" : "tapirs",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -177,6 +184,9 @@
       ],
       "languages.id" : [
         "bak"
+      ],
+      "languages.label" : [
+        "Bashkir"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.6.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-20T13:36:03.589590Z",
+  "createdAt" : "2022-09-26T11:29:28.700810Z",
   "id" : "iykrudzs",
   "document" : {
     "debug" : {
@@ -151,6 +151,13 @@
       "identifiers.value" : [
         "QnjXRANbEF"
       ],
+      "title" : "rats",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -177,6 +184,9 @@
       ],
       "languages.id" : [
         "que"
+      ],
+      "languages.label" : [
+        "Quechua"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.7.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-20T13:36:03.590967Z",
+  "createdAt" : "2022-09-26T11:29:28.701369Z",
   "id" : "pskvh87t",
   "document" : {
     "debug" : {
@@ -151,6 +151,13 @@
       "identifiers.value" : [
         "lBGTOMLJUB"
       ],
+      "title" : "capybara",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -177,6 +184,9 @@
       ],
       "languages.id" : [
         "mar"
+      ],
+      "languages.label" : [
+        "Marathi"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.8.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-20T13:36:03.591671Z",
+  "createdAt" : "2022-09-26T11:29:28.701927Z",
   "id" : "k57syong",
   "document" : {
     "debug" : {
@@ -151,6 +151,13 @@
       "identifiers.value" : [
         "czKSHpT0IR"
       ],
+      "title" : "tapirs",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -177,6 +184,9 @@
       ],
       "languages.id" : [
         "que"
+      ],
+      "languages.label" : [
+        "Quechua"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.9.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-20T13:36:03.592323Z",
+  "createdAt" : "2022-09-26T11:29:28.702525Z",
   "id" : "lkq8nygj",
   "document" : {
     "debug" : {
@@ -151,6 +151,13 @@
       "identifiers.value" : [
         "UBhh45MMdu"
       ],
+      "title" : "rats",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -177,6 +184,9 @@
       ],
       "languages.id" : [
         "che"
+      ],
+      "languages.label" : [
+        "Chechen"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-20T13:36:03.030340Z",
+  "createdAt" : "2022-09-26T11:29:28.390646Z",
   "id" : "jywtq4xg",
   "document" : {
     "debug" : {
@@ -178,6 +178,13 @@
       "identifiers.value" : [
         "LgGFRAV0Zs"
       ],
+      "title" : "title-ZEnp6i2y6i",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -207,6 +214,8 @@
         "JBs3eSemcGNQXd8"
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-20T13:36:03.031924Z",
+  "createdAt" : "2022-09-26T11:29:28.391574Z",
   "id" : "ahr8n4ei",
   "document" : {
     "debug" : {
@@ -178,6 +178,13 @@
       "identifiers.value" : [
         "g4JnCRDZnk"
       ],
+      "title" : "title-Rew3RmJ48v",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -207,6 +214,8 @@
         "YfNgtG1SKw3klDA"
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-20T13:36:03.033405Z",
+  "createdAt" : "2022-09-26T11:29:28.392276Z",
   "id" : "yhjhxcof",
   "document" : {
     "debug" : {
@@ -178,6 +178,13 @@
       "identifiers.value" : [
         "lydjDVoexx"
       ],
+      "title" : "title-wsvmZKLOsI",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -207,6 +214,8 @@
         "wn4mlLNPr0YHU0g"
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-20T13:36:03.035578Z",
+  "createdAt" : "2022-09-26T11:29:28.393018Z",
   "id" : "1mqutqzm",
   "document" : {
     "debug" : {
@@ -178,6 +178,13 @@
       "identifiers.value" : [
         "EmqhmRoJyr"
       ],
+      "title" : "title-bPJWDqmpbe",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -207,6 +214,8 @@
         "sJ0y4QwQTlrFnQP"
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-20T13:36:03.037276Z",
+  "createdAt" : "2022-09-26T11:29:28.394343Z",
   "id" : "4btprmwn",
   "document" : {
     "debug" : {
@@ -266,6 +266,13 @@
       "identifiers.value" : [
         "C7XCeymDdf"
       ],
+      "title" : "title-iLGpm85YYF",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -303,6 +310,8 @@
         "sJ0y4QwQTlrFnQP"
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-20T13:36:03.038093Z",
+  "createdAt" : "2022-09-26T11:29:28.394959Z",
   "id" : "oo0o5odf",
   "document" : {
     "debug" : {
@@ -134,6 +134,13 @@
       "identifiers.value" : [
         "T9fhswtSuP"
       ],
+      "title" : "title-odercwIWKJ",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -159,6 +166,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-20T13:36:03.103102Z",
+  "createdAt" : "2022-09-26T11:29:28.430885Z",
   "id" : "tayys6jp",
   "document" : {
     "debug" : {
@@ -219,6 +219,13 @@
       "identifiers.value" : [
         "3OfWNE6m5y"
       ],
+      "title" : "title-JiYzJ9DWDL",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -249,6 +256,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-20T13:36:03.104104Z",
+  "createdAt" : "2022-09-26T11:29:28.431846Z",
   "id" : "zwggainv",
   "document" : {
     "debug" : {
@@ -181,6 +181,13 @@
       "identifiers.value" : [
         "RdbNpFC2P5"
       ],
+      "title" : "title-k5aVuGQD3S",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -210,6 +217,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-20T13:36:03.105348Z",
+  "createdAt" : "2022-09-26T11:29:28.432760Z",
   "id" : "mazaizfa",
   "document" : {
     "debug" : {
@@ -181,6 +181,13 @@
       "identifiers.value" : [
         "QFJOR9VqAE"
       ],
+      "title" : "title-vTVR490Vab",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -210,6 +217,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-20T13:36:03.109177Z",
+  "createdAt" : "2022-09-26T11:29:28.433704Z",
   "id" : "b1r485o0",
   "document" : {
     "debug" : {
@@ -203,6 +203,13 @@
       "identifiers.value" : [
         "4zh18D0cbF"
       ],
+      "title" : "title-DxPLXKke6N",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -233,6 +240,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-20T13:36:03.111722Z",
+  "createdAt" : "2022-09-26T11:29:28.435096Z",
   "id" : "gmzc1icz",
   "document" : {
     "debug" : {
@@ -297,6 +297,13 @@
       "identifiers.value" : [
         "Q8QOPJdAXF"
       ],
+      "title" : "title-vNWbRfsAZ5",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -335,6 +342,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-20T13:36:03.115327Z",
+  "createdAt" : "2022-09-26T11:29:28.436784Z",
   "id" : "rbao66qq",
   "document" : {
     "debug" : {
@@ -134,6 +134,13 @@
       "identifiers.value" : [
         "5hoUH5ZhFq"
       ],
+      "title" : "title-bcmHn7act9",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -159,6 +166,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.0.Books.json
+++ b/common/search/src/test/resources/test_documents/works.formats.0.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-20T13:36:01.681752Z",
+  "createdAt" : "2022-09-26T11:29:27.616384Z",
   "id" : "gfw8fs9l",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "wayOhJ3Mha"
       ],
+      "title" : "A work with format Books",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.1.Books.json
+++ b/common/search/src/test/resources/test_documents/works.formats.1.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-20T13:36:01.696826Z",
+  "createdAt" : "2022-09-26T11:29:27.623345Z",
   "id" : "ciweswu5",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "ESu6j0cajz"
       ],
+      "title" : "A work with format Books",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.2.Books.json
+++ b/common/search/src/test/resources/test_documents/works.formats.2.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-20T13:36:01.723273Z",
+  "createdAt" : "2022-09-26T11:29:27.630005Z",
   "id" : "j27g6hhl",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "vyeItSna2X"
       ],
+      "title" : "A work with format Books",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.3.Books.json
+++ b/common/search/src/test/resources/test_documents/works.formats.3.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-20T13:36:01.747044Z",
+  "createdAt" : "2022-09-26T11:29:27.635967Z",
   "id" : "bujceq4p",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "HuLHN83UU0"
       ],
+      "title" : "A work with format Books",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.4.Journals.json
+++ b/common/search/src/test/resources/test_documents/works.formats.4.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-20T13:36:01.767107Z",
+  "createdAt" : "2022-09-26T11:29:27.641905Z",
   "id" : "wqcumcet",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "vc628Sgu9f"
       ],
+      "title" : "A work with format Journals",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.5.Journals.json
+++ b/common/search/src/test/resources/test_documents/works.formats.5.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-20T13:36:01.781944Z",
+  "createdAt" : "2022-09-26T11:29:27.648234Z",
   "id" : "plmmmkup",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "X7kBc19InD"
       ],
+      "title" : "A work with format Journals",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.6.Journals.json
+++ b/common/search/src/test/resources/test_documents/works.formats.6.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-20T13:36:01.793172Z",
+  "createdAt" : "2022-09-26T11:29:27.655877Z",
   "id" : "xc5d7pc4",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "HXsUYY6dN4"
       ],
+      "title" : "A work with format Journals",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.7.Audio.json
+++ b/common/search/src/test/resources/test_documents/works.formats.7.Audio.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-20T13:36:01.810987Z",
+  "createdAt" : "2022-09-26T11:29:27.665058Z",
   "id" : "t3q2ufnz",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "nNHPpdWbrm"
       ],
+      "title" : "A work with format Audio",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.8.Audio.json
+++ b/common/search/src/test/resources/test_documents/works.formats.8.Audio.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-20T13:36:01.824598Z",
+  "createdAt" : "2022-09-26T11:29:27.675735Z",
   "id" : "elrgwjtd",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "RMKkkMWH2B"
       ],
+      "title" : "A work with format Audio",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.9.Pictures.json
+++ b/common/search/src/test/resources/test_documents/works.formats.9.Pictures.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-20T13:36:01.841319Z",
+  "createdAt" : "2022-09-26T11:29:27.686618Z",
   "id" : "sym6ne7x",
   "document" : {
     "debug" : {
@@ -142,6 +142,13 @@
       "identifiers.value" : [
         "FRzpe3bQyh"
       ],
+      "title" : "A work with format Pictures",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -167,6 +174,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.genres.json
+++ b/common/search/src/test/resources/test_documents/works.genres.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with different concepts in the genre",
-  "createdAt" : "2022-09-20T13:36:02.089717Z",
+  "createdAt" : "2022-09-26T11:29:27.832681Z",
   "id" : "2zo588up",
   "document" : {
     "debug" : {
@@ -201,6 +201,13 @@
       "identifiers.value" : [
         "rVoekomuzt"
       ],
+      "title" : "A work with different concepts in the genre",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -230,6 +237,8 @@
         "Past Prehistory"
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.0.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-20T13:36:01.984192Z",
+  "createdAt" : "2022-09-26T11:29:27.784973Z",
   "id" : "yodfctxx",
   "document" : {
     "debug" : {
@@ -181,6 +181,13 @@
       "identifiers.value" : [
         "HfU454vgiI"
       ],
+      "title" : "title-AIpgBtHAhx",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -208,6 +215,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.1.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-20T13:36:01.985436Z",
+  "createdAt" : "2022-09-26T11:29:27.785908Z",
   "id" : "runiusy8",
   "document" : {
     "debug" : {
@@ -183,6 +183,13 @@
       "identifiers.value" : [
         "ZGWEGMyTaq"
       ],
+      "title" : "title-wjvsf3c3yc",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -210,6 +217,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.2.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-20T13:36:01.986763Z",
+  "createdAt" : "2022-09-26T11:29:27.786906Z",
   "id" : "ougtipki",
   "document" : {
     "debug" : {
@@ -181,6 +181,13 @@
       "identifiers.value" : [
         "fbITZO5oAg"
       ],
+      "title" : "title-pEBp6sf3WU",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -208,6 +215,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.3.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-20T13:36:01.993967Z",
+  "createdAt" : "2022-09-26T11:29:27.788234Z",
   "id" : "rstrzip9",
   "document" : {
     "debug" : {
@@ -232,6 +232,13 @@
       "identifiers.value" : [
         "AbkJTEEoLH"
       ],
+      "title" : "title-7h7G222BsR",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -261,6 +268,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.4.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-20T13:36:01.996144Z",
+  "createdAt" : "2022-09-26T11:29:27.788862Z",
   "id" : "vwg1cj2y",
   "document" : {
     "debug" : {
@@ -134,6 +134,13 @@
       "identifiers.value" : [
         "FIC2DNd6NA"
       ],
+      "title" : "title-YmmH4BoIsw",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -159,6 +166,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.0.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-20T13:36:02.279552Z",
+  "createdAt" : "2022-09-26T11:29:27.941844Z",
   "id" : "qjnwiqbs",
   "document" : {
     "debug" : {
@@ -217,6 +217,13 @@
       "identifiers.value" : [
         "Jj1GugWgka"
       ],
+      "title" : "title-m47LFZN2Zg",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -247,6 +254,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.1.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-20T13:36:02.280654Z",
+  "createdAt" : "2022-09-26T11:29:27.942701Z",
   "id" : "upm4bal7",
   "document" : {
     "debug" : {
@@ -218,6 +218,13 @@
       "identifiers.value" : [
         "wkKE1s2opA"
       ],
+      "title" : "title-lcjNV5vdX9",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -248,6 +255,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.2.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-20T13:36:02.281714Z",
+  "createdAt" : "2022-09-26T11:29:27.943533Z",
   "id" : "zbejhda8",
   "document" : {
     "debug" : {
@@ -218,6 +218,13 @@
       "identifiers.value" : [
         "l7ykrmHfSg"
       ],
+      "title" : "title-yvIxyfRHMd",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -248,6 +255,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.3.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-20T13:36:02.282783Z",
+  "createdAt" : "2022-09-26T11:29:27.944456Z",
   "id" : "pex9vogp",
   "document" : {
     "debug" : {
@@ -219,6 +219,13 @@
       "identifiers.value" : [
         "MEUfT3H8Xn"
       ],
+      "title" : "title-YI3LUHDJYY",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -249,6 +256,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.4.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-20T13:36:02.283781Z",
+  "createdAt" : "2022-09-26T11:29:27.945397Z",
   "id" : "c5xw2xfj",
   "document" : {
     "debug" : {
@@ -219,6 +219,13 @@
       "identifiers.value" : [
         "fREqoThymw"
       ],
+      "title" : "title-jI6EjEMJ47",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -249,6 +256,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.languages.0.eng.json
+++ b/common/search/src/test/resources/test_documents/works.languages.0.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-20T13:36:01.883814Z",
+  "createdAt" : "2022-09-26T11:29:27.721067Z",
   "id" : "i8zcsj78",
   "document" : {
     "debug" : {
@@ -143,6 +143,13 @@
       "identifiers.value" : [
         "ZquhBnzQPW"
       ],
+      "title" : "A work with languages English",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -169,6 +176,9 @@
       ],
       "languages.id" : [
         "eng"
+      ],
+      "languages.label" : [
+        "English"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.languages.1.eng.json
+++ b/common/search/src/test/resources/test_documents/works.languages.1.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-20T13:36:01.895575Z",
+  "createdAt" : "2022-09-26T11:29:27.735690Z",
   "id" : "qn97gvxq",
   "document" : {
     "debug" : {
@@ -143,6 +143,13 @@
       "identifiers.value" : [
         "BbZQhYTTwR"
       ],
+      "title" : "A work with languages English",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -169,6 +176,9 @@
       ],
       "languages.id" : [
         "eng"
+      ],
+      "languages.label" : [
+        "English"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.languages.2.eng.json
+++ b/common/search/src/test/resources/test_documents/works.languages.2.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-20T13:36:01.907086Z",
+  "createdAt" : "2022-09-26T11:29:27.743710Z",
   "id" : "yhrq0rmr",
   "document" : {
     "debug" : {
@@ -143,6 +143,13 @@
       "identifiers.value" : [
         "tXlgR2VtcJ"
       ],
+      "title" : "A work with languages English",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -169,6 +176,9 @@
       ],
       "languages.id" : [
         "eng"
+      ],
+      "languages.label" : [
+        "English"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.languages.3.eng+swe.json
+++ b/common/search/src/test/resources/test_documents/works.languages.3.eng+swe.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-20T13:36:01.923190Z",
+  "createdAt" : "2022-09-26T11:29:27.754654Z",
   "id" : "ioqwetut",
   "document" : {
     "debug" : {
@@ -152,6 +152,13 @@
       "identifiers.value" : [
         "5WuJppwWsm"
       ],
+      "title" : "A work with languages English, Swedish",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -179,6 +186,10 @@
       "languages.id" : [
         "eng",
         "swe"
+      ],
+      "languages.label" : [
+        "English",
+        "Swedish"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.languages.4.eng+swe+tur.json
+++ b/common/search/src/test/resources/test_documents/works.languages.4.eng+swe+tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-20T13:36:01.936389Z",
+  "createdAt" : "2022-09-26T11:29:27.761351Z",
   "id" : "edfiesed",
   "document" : {
     "debug" : {
@@ -161,6 +161,13 @@
       "identifiers.value" : [
         "tQZYPmQieO"
       ],
+      "title" : "A work with languages English, Swedish, Turkish",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -189,6 +196,11 @@
         "eng",
         "swe",
         "tur"
+      ],
+      "languages.label" : [
+        "English",
+        "Swedish",
+        "Turkish"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.languages.5.swe.json
+++ b/common/search/src/test/resources/test_documents/works.languages.5.swe.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-20T13:36:01.948628Z",
+  "createdAt" : "2022-09-26T11:29:27.768678Z",
   "id" : "qfscz1rj",
   "document" : {
     "debug" : {
@@ -143,6 +143,13 @@
       "identifiers.value" : [
         "Gk6juMbOeK"
       ],
+      "title" : "A work with languages Swedish",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -169,6 +176,9 @@
       ],
       "languages.id" : [
         "swe"
+      ],
+      "languages.label" : [
+        "Swedish"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.languages.6.tur.json
+++ b/common/search/src/test/resources/test_documents/works.languages.6.tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-20T13:36:01.962813Z",
+  "createdAt" : "2022-09-26T11:29:27.775151Z",
   "id" : "yblbdpjf",
   "document" : {
     "debug" : {
@@ -143,6 +143,13 @@
       "identifiers.value" : [
         "vcw0LP9LzQ"
       ],
+      "title" : "A work with languages Turkish",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -169,6 +176,9 @@
       ],
       "languages.id" : [
         "tur"
+      ],
+      "languages.label" : [
+        "Turkish"
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.0.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-20T13:36:02.609571Z",
+  "createdAt" : "2022-09-26T11:29:28.147985Z",
   "id" : "31spt9st",
   "document" : {
     "debug" : {
@@ -192,6 +192,13 @@
       "identifiers.value" : [
         "WzsZA7OUAa"
       ],
+      "title" : "title-QoeggPvgjR",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -217,6 +224,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.1.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-20T13:36:02.611296Z",
+  "createdAt" : "2022-09-26T11:29:28.148897Z",
   "id" : "v9is9e3t",
   "document" : {
     "debug" : {
@@ -192,6 +192,13 @@
       "identifiers.value" : [
         "fZVe3xG7r6"
       ],
+      "title" : "title-JGYTcwsJbl",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -217,6 +224,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.2.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-20T13:36:02.612533Z",
+  "createdAt" : "2022-09-26T11:29:28.149815Z",
   "id" : "wg3kq4ux",
   "document" : {
     "debug" : {
@@ -192,6 +192,13 @@
       "identifiers.value" : [
         "lfq9upMxJZ"
       ],
+      "title" : "title-oirzqph7Io",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -217,6 +224,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.3.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-20T13:36:02.613856Z",
+  "createdAt" : "2022-09-26T11:29:28.150549Z",
   "id" : "q4abgj9v",
   "document" : {
     "debug" : {
@@ -192,6 +192,13 @@
       "identifiers.value" : [
         "09dkccFCHG"
       ],
+      "title" : "title-PDvN43mh0p",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -217,6 +224,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.4.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-20T13:36:02.615357Z",
+  "createdAt" : "2022-09-26T11:29:28.151489Z",
   "id" : "cuh8ak2g",
   "document" : {
     "debug" : {
@@ -192,6 +192,13 @@
       "identifiers.value" : [
         "KabHlF2fhJ"
       ],
+      "title" : "title-PdAnZy8IL7",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -217,6 +224,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.5.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-20T13:36:02.616600Z",
+  "createdAt" : "2022-09-26T11:29:28.152645Z",
   "id" : "wmzcsqaf",
   "document" : {
     "debug" : {
@@ -192,6 +192,13 @@
       "identifiers.value" : [
         "Kwytcvu6mF"
       ],
+      "title" : "title-tBeNhpR5aF",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -217,6 +224,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.subjects.0.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-20T13:36:02.103050Z",
+  "createdAt" : "2022-09-26T11:29:27.840975Z",
   "id" : "6uwysojy",
   "document" : {
     "debug" : {
@@ -181,6 +181,13 @@
       "identifiers.value" : [
         "pzLgxSR5EK"
       ],
+      "title" : "title-Dtaaw5YmCW",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -210,6 +217,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.subjects.1.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-20T13:36:02.104565Z",
+  "createdAt" : "2022-09-26T11:29:27.841965Z",
   "id" : "mihwfxry",
   "document" : {
     "debug" : {
@@ -181,6 +181,13 @@
       "identifiers.value" : [
         "HypKD9r1zH"
       ],
+      "title" : "title-miZHgL6jXR",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -210,6 +217,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.subjects.2.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-20T13:36:02.106626Z",
+  "createdAt" : "2022-09-26T11:29:27.842957Z",
   "id" : "evraub2i",
   "document" : {
     "debug" : {
@@ -181,6 +181,13 @@
       "identifiers.value" : [
         "E3Fqby26w1"
       ],
+      "title" : "title-sNTcYSKPkF",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -210,6 +217,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.subjects.3.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-20T13:36:02.109184Z",
+  "createdAt" : "2022-09-26T11:29:27.844207Z",
   "id" : "xcssabt1",
   "document" : {
     "debug" : {
@@ -228,6 +228,13 @@
       "identifiers.value" : [
         "7XE0Jxv45o"
       ],
+      "title" : "title-p2sZlO6WXi",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -261,6 +268,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.subjects.4.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-20T13:36:02.110370Z",
+  "createdAt" : "2022-09-26T11:29:27.844897Z",
   "id" : "t9nj8zse",
   "document" : {
     "debug" : {
@@ -134,6 +134,13 @@
       "identifiers.value" : [
         "8imBUVPHmu"
       ],
+      "title" : "title-9al0iIjgaH",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -159,6 +166,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.title-query-parens.json
+++ b/common/search/src/test/resources/test_documents/works.title-query-parens.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has parens meant to trip up ES",
-  "createdAt" : "2022-09-20T13:36:01.869699Z",
+  "createdAt" : "2022-09-26T11:29:27.707048Z",
   "id" : "omok5a37",
   "document" : {
     "debug" : {
@@ -134,6 +134,13 @@
       "identifiers.value" : [
         "y59nY1Nuok"
       ],
+      "title" : "(a b c d e) h",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -159,6 +166,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.title-query-syntax.json
+++ b/common/search/src/test/resources/test_documents/works.title-query-syntax.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has lots of ES query syntax operators",
-  "createdAt" : "2022-09-20T13:36:01.852565Z",
+  "createdAt" : "2022-09-26T11:29:27.696488Z",
   "id" : "hjjs3mu3",
   "document" : {
     "debug" : {
@@ -134,6 +134,13 @@
       "identifiers.value" : [
         "Z3LIdvnOPk"
       ],
+      "title" : "+a -title | with (all the simple) query~4 syntax operators in it*",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -159,6 +166,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.visible.0.json
+++ b/common/search/src/test/resources/test_documents/works.visible.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-20T13:35:59.600065Z",
+  "createdAt" : "2022-09-26T11:29:26.462829Z",
   "id" : "2twopft1",
   "document" : {
     "debug" : {
@@ -134,6 +134,13 @@
       "identifiers.value" : [
         "Uaequ81tpB"
       ],
+      "title" : "title-vaMzxd8prf",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -159,6 +166,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.visible.1.json
+++ b/common/search/src/test/resources/test_documents/works.visible.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-20T13:35:59.610671Z",
+  "createdAt" : "2022-09-26T11:29:26.469706Z",
   "id" : "dph7sjip",
   "document" : {
     "debug" : {
@@ -134,6 +134,13 @@
       "identifiers.value" : [
         "WpBejTwv1N"
       ],
+      "title" : "title-3hvGdgZfc8",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -159,6 +166,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.visible.2.json
+++ b/common/search/src/test/resources/test_documents/works.visible.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-20T13:35:59.612553Z",
+  "createdAt" : "2022-09-26T11:29:26.471498Z",
   "id" : "fyqts0co",
   "document" : {
     "debug" : {
@@ -134,6 +134,13 @@
       "identifiers.value" : [
         "ZvWebpA5WH"
       ],
+      "title" : "title-XQqPyuxbr5",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -159,6 +166,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.visible.3.json
+++ b/common/search/src/test/resources/test_documents/works.visible.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-20T13:35:59.614513Z",
+  "createdAt" : "2022-09-26T11:29:26.473381Z",
   "id" : "raob2ruv",
   "document" : {
     "debug" : {
@@ -134,6 +134,13 @@
       "identifiers.value" : [
         "wyJzS2SuiH"
       ],
+      "title" : "title-bFbQPNB7Zu",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -159,6 +166,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.visible.4.json
+++ b/common/search/src/test/resources/test_documents/works.visible.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-20T13:35:59.616694Z",
+  "createdAt" : "2022-09-26T11:29:26.475309Z",
   "id" : "vbi1ii19",
   "document" : {
     "debug" : {
@@ -134,6 +134,13 @@
       "identifiers.value" : [
         "CzLNHBFHuR"
       ],
+      "title" : "title-jGGR8UNWut",
+      "description" : null,
+      "physicalDescription" : null,
+      "edition" : null,
+      "notes.contents" : [
+      ],
+      "lettering" : null,
       "images.id" : [
       ],
       "images.identifiers.value" : [
@@ -159,6 +166,8 @@
       "genres.concepts.label" : [
       ],
       "languages.id" : [
+      ],
+      "languages.label" : [
       ],
       "contributors.agent.id" : [
       ],

--- a/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -46,7 +46,7 @@ case object WorksMultiMatcher {
         // See https://github.com/wellcomecollection/catalogue-api/issues/466
         SpanFirstQuery(
           SpanTermQuery(
-            field = "data.title.shingles",
+            field = "query.title.shingles",
             value = q
           ),
           boost = Some(1000),
@@ -117,8 +117,8 @@ case object WorksMultiMatcher {
               `type` = Some(CROSS_FIELDS),
               operator = Some(OR),
               fields = Seq(
-                FieldWithOptionalBoost("data.title", boost = Some(100)),
-                FieldWithOptionalBoost("data.description", boost = Some(10))
+                FieldWithOptionalBoost("query.title", boost = Some(100)),
+                FieldWithOptionalBoost("query.description", boost = Some(10))
               )
             )
           ),
@@ -146,16 +146,16 @@ case object WorksMultiMatcher {
           `type` = Some(CROSS_FIELDS),
           operator = Some(AND),
           fields = Seq(
-            (Some(1000), "data.contributors.agent.label"),
+            (Some(1000), "query.contributors.agent.label"),
             (Some(10), "query.subjects.concepts.label"),
             (Some(10), "query.genres.concepts.label"),
             (Some(10), "data.production.*.label"),
-            (None, "data.description"),
-            (None, "data.physicalDescription"),
-            (None, "data.language.label"),
-            (None, "data.edition"),
-            (None, "data.notes.contents"),
-            (None, "data.lettering")
+            (None, "query.description"),
+            (None, "query.physicalDescription"),
+            (None, "query.languages.label"),
+            (None, "query.edition"),
+            (None, "query.notes.contents"),
+            (None, "query.lettering")
           ).map(f => FieldWithOptionalBoost(f._2, f._1.map(_.toDouble)))
         )
       )

--- a/search/src/test/resources/WorksMultiMatcherQuery.json
+++ b/search/src/test/resources/WorksMultiMatcherQuery.json
@@ -5,7 +5,7 @@
         "span_first": {
           "match": {
             "span_term": {
-              "data.title.shingles": "{{query}}"
+              "query.title.shingles": "{{query}}"
             }
           },
           "end": 1,
@@ -73,7 +73,7 @@
             {
               "multi_match": {
                 "query": "{{query}}",
-                "fields": ["data.title^100.0", "data.description^10.0"],
+                "fields": ["query.title^100.0", "query.description^10.0"],
                 "type": "cross_fields",
                 "operator": "Or",
                 "_name": "relations text"
@@ -101,16 +101,16 @@
         "multi_match": {
           "query": "{{query}}",
           "fields": [
-            "data.contributors.agent.label^1000.0",
+            "query.contributors.agent.label^1000.0",
             "query.subjects.concepts.label^10.0",
             "query.genres.concepts.label^10.0",
             "data.production.*.label^10.0",
-            "data.description",
-            "data.physicalDescription",
-            "data.language.label",
-            "data.edition",
-            "data.notes.contents",
-            "data.lettering"
+            "query.description",
+            "query.physicalDescription",
+            "query.languages.label",
+            "query.edition",
+            "query.notes.contents",
+            "query.lettering"
           ],
           "type": "cross_fields",
           "operator": "And",


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5550; follows https://github.com/wellcomecollection/catalogue-pipeline/pull/2211

~This is waiting on the works ingestor queue to clear, which is currently backfilling all these fields – but once it's done,~ I think the only fields left on works to migrate are:

* `search.identifiers`
* `search.titlesAndContributors`
* `data.referenceNumber`
* `data.collectionPath.path.clean`
* `data.collectionPath.label.cleanPath`
* `data.collectionPath.label`
* `data.collectionPath.path.keyword`
* `data.production.*.label`

Then I think we could drop the `data` field on indexed Works. That feels pretty close!