### PR TITLE
Log the original request when we get Elasticsearch errors

### DIFF
--- a/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala
@@ -86,7 +86,7 @@ class ElasticsearchService(elasticClient: ElasticClient)(
             Right(response)
 
           case Left(err) =>
-            warn(s"Error while making request=${request.show}, error=${err}")
+            warn(s"Error while making request=${request.show}, error=$err")
             Left(ElasticsearchError(err))
         }
     }

--- a/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala
@@ -86,6 +86,7 @@ class ElasticsearchService(elasticClient: ElasticClient)(
             Right(response)
 
           case Left(err) =>
+            warn(s"Error while making request=${request.show}, error=${err}")
             Left(ElasticsearchError(err))
         }
     }


### PR DESCRIPTION
This is one of the actions from the retro -- it's meant to help us debug when something has gone bang in a query.