### PR TITLE
add a script to populate a local .env file

### DIFF
--- a/rank/README.md
+++ b/rank/README.md
@@ -6,11 +6,12 @@ It uses [elasticsearch's `rank_eval` API](https://www.elastic.co/guide/en/elasti
 
 ## Getting started
 
-Clone this repo and run:
+Clone this repo, and run:
 
+- `cd rank`
 - `yarn` to install packages
-- `yarn env` to populate a local `.env` file.  
-   This assumes you're part of the Wellcome Collection team on Vercel. You'll be asked to link your local repo to the project in order to fetch the necessary secrets. The project name is `rank`.
+- `yarn env` to populate a local `.env` file. You'll need to be signed into a Wellcome Collection AWS account with access to the `platform-dev` role to do this.
+- `yarn rank` to run the relevance tests
 
 ## Docs 📖
 

--- a/rank/package.json
+++ b/rank/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
     "copyQueries": "ts-node ./scripts/copyQueries",
+    "env": "AWS_PROFILE=platform-dev bash ./scripts/getEnv.sh",
     "test": "jest",
     "rank": "ts-node -r dotenv/config ./scripts/rank",
     "search": "ts-node -r dotenv/config ./scripts/search",

--- a/rank/scripts/getEnv.sh
+++ b/rank/scripts/getEnv.sh
@@ -1,0 +1,45 @@
+#!/usr/local/bin/bash
+
+set -o errexit
+set -o nounset
+
+# Create a .env file if one doesn't already exist. The contents of an existing
+# file will be unchanged
+touch .env
+
+# Read the existing environment variables from the .env file and store them as
+# an associative array
+echo "Reading environment variables from existing .env file"
+declare -A environmentVariables
+while IFS='=' read -r key value; do
+  environmentVariables[$key]="$value"
+done < .env
+
+# Loop through a list of environment variable names, fetch the values from
+# secretsmanager using the AWS CLI, and add them to the associative array
+environmentVariableKeys=(
+    "ES_RANK_CLOUD_ID"
+    "ES_RANK_PASSWORD"
+    "ES_RANK_USER"
+    "ES_REPORTING_CLOUD_ID"
+    "ES_REPORTING_PASSWORD"
+    "ES_REPORTING_USER"
+)
+
+for key in ${environmentVariableKeys[@]}; do
+    echo "Fetching $key from secretsmanager"
+    environmentVariables[$key]=$(aws secretsmanager get-secret-value \
+        --secret-id elasticsearch/rank/$key \
+        --query SecretString \
+        --output text
+    )
+done
+
+# the associative array is then converted to a list of key=value pairs and
+# written to a .env file, sorted by key
+echo "Writing environment variables back to .env"
+rm -f .env
+touch .env
+for key in $(printf '%s\n' "${!environmentVariables[@]}" | sort); do
+    echo "$key=${environmentVariables[$key]}" >> .env
+done


### PR DESCRIPTION
We've deleted the web UI for rank, and the associated vercel project along with it. The vercel project/cli allowed us to populate a local `.env` file for rank with a single command, which made the setup process super smooth.

This PR replaces that functionality with a bash script.