### PR TITLE
Exclusively use fields on the query object when searching Works

### DIFF
--- a/common/search/src/test/resources/WorksIndexConfig.json
+++ b/common/search/src/test/resources/WorksIndexConfig.json
@@ -1030,6 +1030,17 @@
                   }
                 },
                 "analyzer": "asciifolding_analyzer"
+              },
+              "dates": {
+                "properties": {
+                  "range": {
+                    "properties": {
+                      "from": {
+                        "type": "date"
+                      }
+                    }
+                  }
+                }
               }
             }
           },

--- a/common/search/src/test/resources/WorksIndexConfig.json
+++ b/common/search/src/test/resources/WorksIndexConfig.json
@@ -614,10 +614,96 @@
       },
       "query": {
         "properties": {
+          "allIdentifiers": {
+            "type": "keyword",
+            "normalizer": "lowercase_normalizer"
+          },
+          "alternativeTitles": {
+            "type": "text",
+            "fields": {
+              "arabic": {
+                "type": "text",
+                "analyzer": "arabic_analyzer"
+              },
+              "bengali": {
+                "type": "text",
+                "analyzer": "bengali_analyzer"
+              },
+              "english": {
+                "type": "text",
+                "analyzer": "english_analyzer"
+              },
+              "french": {
+                "type": "text",
+                "analyzer": "french_analyzer"
+              },
+              "german": {
+                "type": "text",
+                "analyzer": "german_analyzer"
+              },
+              "hindi": {
+                "type": "text",
+                "analyzer": "hindi_analyzer"
+              },
+              "italian": {
+                "type": "text",
+                "analyzer": "italian_analyzer"
+              },
+              "keyword": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer"
+              },
+              "shingles": {
+                "type": "text",
+                "analyzer": "shingle_asciifolding_analyzer"
+              }
+            },
+            "copy_to": [
+              "query.titlesAndContributors"
+            ]
+          },
           "availabilities": {
             "properties": {
               "id": {
                 "type": "keyword"
+              }
+            }
+          },
+          "collectionPath": {
+            "properties": {
+              "label": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword"
+                  },
+                  "lowercaseKeyword": {
+                    "type": "keyword",
+                    "normalizer": "lowercase_normalizer"
+                  },
+                  "cleanPath": {
+                    "type": "text",
+                    "analyzer": "clean_path_analyzer"
+                  },
+                  "path": {
+                    "type": "text",
+                    "analyzer": "exact_path_analyzer"
+                  }
+                },
+                "analyzer": "asciifolding_analyzer"
+              },
+              "path": {
+                "type": "text",
+                "fields": {
+                  "clean": {
+                    "type": "text",
+                    "analyzer": "clean_path_analyzer"
+                  },
+                  "keyword": {
+                    "type": "keyword"
+                  }
+                },
+                "analyzer": "exact_path_analyzer"
               }
             }
           },
@@ -636,7 +722,10 @@
                         "normalizer": "lowercase_normalizer"
                       }
                     },
-                    "analyzer": "asciifolding_analyzer"
+                    "analyzer": "asciifolding_analyzer",
+                    "copy_to": [
+                      "query.titlesAndContributors"
+                    ]
                   },
                   "id": {
                     "type": "keyword",
@@ -694,7 +783,10 @@
           },
           "id": {
             "type": "keyword",
-            "normalizer": "lowercase_normalizer"
+            "normalizer": "lowercase_normalizer",
+            "copy_to": [
+              "query.allIdentifiers"
+            ]
           },
           "type": {
             "type": "keyword"
@@ -713,7 +805,10 @@
             "properties": {
               "value": {
                 "type": "keyword",
-                "normalizer": "lowercase_normalizer"
+                "normalizer": "lowercase_normalizer",
+                "copy_to": [
+                  "query.allIdentifiers"
+                ]
               }
             }
           },
@@ -721,13 +816,19 @@
             "properties": {
               "id": {
                 "type": "keyword",
-                "normalizer": "lowercase_normalizer"
+                "normalizer": "lowercase_normalizer",
+                "copy_to": [
+                  "query.allIdentifiers"
+                ]
               },
               "identifiers": {
                 "properties": {
                   "value": {
                     "type": "keyword",
-                    "normalizer": "lowercase_normalizer"
+                    "normalizer": "lowercase_normalizer",
+                    "copy_to": [
+                      "query.allIdentifiers"
+                    ]
                   }
                 }
               }
@@ -737,13 +838,19 @@
             "properties": {
               "id": {
                 "type": "keyword",
-                "normalizer": "lowercase_normalizer"
+                "normalizer": "lowercase_normalizer",
+                "copy_to": [
+                  "query.allIdentifiers"
+                ]
               },
               "identifiers": {
                 "properties": {
                   "value": {
                     "type": "keyword",
-                    "normalizer": "lowercase_normalizer"
+                    "normalizer": "lowercase_normalizer",
+                    "copy_to": [
+                      "query.allIdentifiers"
+                    ]
                   }
                 }
               },
@@ -909,6 +1016,29 @@
               }
             }
           },
+          "production": {
+            "properties": {
+              "label": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword"
+                  },
+                  "lowercaseKeyword": {
+                    "type": "keyword",
+                    "normalizer": "lowercase_normalizer"
+                  }
+                },
+                "analyzer": "asciifolding_analyzer"
+              }
+            }
+          },
+          "referenceNumber": {
+            "type": "keyword",
+            "copy_to": [
+              "query.allIdentifiers"
+            ]
+          },
           "subjects": {
             "properties": {
               "concepts": {
@@ -981,6 +1111,46 @@
               "keyword": {
                 "type": "keyword",
                 "normalizer": "lowercase_normalizer"
+              },
+              "shingles": {
+                "type": "text",
+                "analyzer": "shingle_asciifolding_analyzer"
+              }
+            },
+            "copy_to": [
+              "query.titlesAndContributors"
+            ]
+          },
+          "titlesAndContributors": {
+            "type": "text",
+            "fields": {
+              "arabic": {
+                "type": "text",
+                "analyzer": "arabic_analyzer"
+              },
+              "bengali": {
+                "type": "text",
+                "analyzer": "bengali_analyzer"
+              },
+              "english": {
+                "type": "text",
+                "analyzer": "english_analyzer"
+              },
+              "french": {
+                "type": "text",
+                "analyzer": "french_analyzer"
+              },
+              "german": {
+                "type": "text",
+                "analyzer": "german_analyzer"
+              },
+              "hindi": {
+                "type": "text",
+                "analyzer": "hindi_analyzer"
+              },
+              "italian": {
+                "type": "text",
+                "analyzer": "italian_analyzer"
               },
               "shingles": {
                 "type": "text",

--- a/common/search/src/test/resources/test_documents/images.contributors.0.json
+++ b/common/search/src/test/resources/test_documents/images.contributors.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different contributors",
-  "createdAt" : "2022-09-13T17:09:39.604641Z",
+  "createdAt" : "2022-09-28T12:18:40.953109Z",
   "id" : "juvasind",
   "document" : {
     "version" : 1,
@@ -4399,6 +4399,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#395B28",
       "source" : {
         "id" : "3sveb2mo",
         "title" : "title-Mpr8zU4ceU",

--- a/common/search/src/test/resources/test_documents/images.contributors.1.json
+++ b/common/search/src/test/resources/test_documents/images.contributors.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different contributors",
-  "createdAt" : "2022-09-13T17:09:39.614879Z",
+  "createdAt" : "2022-09-28T12:18:40.963750Z",
   "id" : "qkusykqo",
   "document" : {
     "version" : 1,
@@ -4412,6 +4412,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#CD9411",
       "source" : {
         "id" : "tplolgti",
         "title" : "title-i8p3faeYPB",

--- a/common/search/src/test/resources/test_documents/images.contributors.2.json
+++ b/common/search/src/test/resources/test_documents/images.contributors.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different contributors",
-  "createdAt" : "2022-09-13T17:09:39.624559Z",
+  "createdAt" : "2022-09-28T12:18:40.975093Z",
   "id" : "de54kq1t",
   "document" : {
     "version" : 1,
@@ -4416,6 +4416,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#28F1BA",
       "source" : {
         "id" : "tnd0gimf",
         "title" : "title-hn12DtgqN5",

--- a/common/search/src/test/resources/test_documents/images.different-licenses.0.json
+++ b/common/search/src/test/resources/test_documents/images.different-licenses.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-09-13T17:09:39.389003Z",
+  "createdAt" : "2022-09-28T12:18:40.664441Z",
   "id" : "0nj3tuzq",
   "document" : {
     "version" : 1,
@@ -4419,6 +4419,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#2F199D",
       "source" : {
         "id" : "yqts0coj",
         "title" : "title-QqPyuxbr58",

--- a/common/search/src/test/resources/test_documents/images.different-licenses.1.json
+++ b/common/search/src/test/resources/test_documents/images.different-licenses.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-09-13T17:09:39.396292Z",
+  "createdAt" : "2022-09-28T12:18:40.667771Z",
   "id" : "frbgwqa9",
   "document" : {
     "version" : 1,
@@ -4423,6 +4423,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#667FB7",
       "source" : {
         "id" : "bs7ocjmn",
         "title" : "title-r9kNroYBux",

--- a/common/search/src/test/resources/test_documents/images.different-licenses.2.json
+++ b/common/search/src/test/resources/test_documents/images.different-licenses.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-09-13T17:09:39.401433Z",
+  "createdAt" : "2022-09-28T12:18:40.670196Z",
   "id" : "b7uakwkz",
   "document" : {
     "version" : 1,
@@ -4423,6 +4423,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#D516E6",
       "source" : {
         "id" : "qysiiyfk",
         "title" : "title-9TJULsTtNl",

--- a/common/search/src/test/resources/test_documents/images.different-licenses.3.json
+++ b/common/search/src/test/resources/test_documents/images.different-licenses.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-09-13T17:09:39.406731Z",
+  "createdAt" : "2022-09-28T12:18:40.672202Z",
   "id" : "igj3cy3f",
   "document" : {
     "version" : 1,
@@ -4419,6 +4419,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#AA1FDA",
       "source" : {
         "id" : "mp7va0c4",
         "title" : "title-EkWOXuggct",

--- a/common/search/src/test/resources/test_documents/images.different-licenses.4.json
+++ b/common/search/src/test/resources/test_documents/images.different-licenses.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-09-13T17:09:39.411656Z",
+  "createdAt" : "2022-09-28T12:18:40.673858Z",
   "id" : "z9e1lnnv",
   "document" : {
     "version" : 1,
@@ -4423,6 +4423,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#979329",
       "source" : {
         "id" : "cbm3ev9e",
         "title" : "title-PbbJQdXrdJ",

--- a/common/search/src/test/resources/test_documents/images.different-licenses.5.json
+++ b/common/search/src/test/resources/test_documents/images.different-licenses.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-09-13T17:09:39.415536Z",
+  "createdAt" : "2022-09-28T12:18:40.675169Z",
   "id" : "i1k4zk7n",
   "document" : {
     "version" : 1,
@@ -4423,6 +4423,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#194D6A",
       "source" : {
         "id" : "d55u8fis",
         "title" : "title-f1XQOTYzAU",

--- a/common/search/src/test/resources/test_documents/images.different-licenses.6.json
+++ b/common/search/src/test/resources/test_documents/images.different-licenses.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different licenses",
-  "createdAt" : "2022-09-13T17:09:39.417981Z",
+  "createdAt" : "2022-09-28T12:18:40.676424Z",
   "id" : "itecyzhr",
   "document" : {
     "version" : 1,
@@ -4423,6 +4423,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#0EBB1F",
       "source" : {
         "id" : "gbjkwtuj",
         "title" : "title-h7pFiQIGYP",

--- a/common/search/src/test/resources/test_documents/images.everything.json
+++ b/common/search/src/test/resources/test_documents/images.everything.json
@@ -1,6 +1,6 @@
 {
   "description" : "an image with every include",
-  "createdAt" : "2022-09-13T17:09:40.055795Z",
+  "createdAt" : "2022-09-28T12:18:41.551957Z",
   "id" : "vihqhhlw",
   "document" : {
     "version" : 1,
@@ -4476,6 +4476,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#62C3E1",
       "source" : {
         "id" : "64m9ngi3",
         "title" : "Apple agitator",

--- a/common/search/src/test/resources/test_documents/images.examples.bread-baguette.json
+++ b/common/search/src/test/resources/test_documents/images.examples.bread-baguette.json
@@ -1,6 +1,6 @@
 {
   "description" : "an example of images with work metadata for the API tests",
-  "createdAt" : "2022-09-13T17:09:40.118504Z",
+  "createdAt" : "2022-09-28T12:18:41.645652Z",
   "id" : "ojdlglxy",
   "document" : {
     "version" : 1,
@@ -4382,6 +4382,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#718CFE",
       "source" : {
         "id" : "ozzeza6t",
         "title" : "Baguette is a French style of bread; it's a long, thin bread; other countries also make this bread",

--- a/common/search/src/test/resources/test_documents/images.examples.bread-focaccia.json
+++ b/common/search/src/test/resources/test_documents/images.examples.bread-focaccia.json
@@ -1,6 +1,6 @@
 {
   "description" : "an example of images with work metadata for the API tests",
-  "createdAt" : "2022-09-13T17:09:40.124419Z",
+  "createdAt" : "2022-09-28T12:18:41.654607Z",
   "id" : "ojy5ccix",
   "document" : {
     "version" : 1,
@@ -4384,6 +4384,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#F3329F",
       "source" : {
         "id" : "heqzy5i2",
         "title" : "A Ligurian style of bread, Focaccia is a flat Italian bread",

--- a/common/search/src/test/resources/test_documents/images.examples.bread-mantou.json
+++ b/common/search/src/test/resources/test_documents/images.examples.bread-mantou.json
@@ -1,6 +1,6 @@
 {
   "description" : "an example of images with work metadata for the API tests",
-  "createdAt" : "2022-09-13T17:09:40.136229Z",
+  "createdAt" : "2022-09-28T12:18:41.672260Z",
   "id" : "mmsz3uax",
   "document" : {
     "version" : 1,
@@ -4384,6 +4384,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#00C688",
       "source" : {
         "id" : "agy0m5ej",
         "title" : "Mantou is a steamed bread associated with Northern China",

--- a/common/search/src/test/resources/test_documents/images.examples.bread-schiacciata.json
+++ b/common/search/src/test/resources/test_documents/images.examples.bread-schiacciata.json
@@ -1,6 +1,6 @@
 {
   "description" : "an example of images with work metadata for the API tests",
-  "createdAt" : "2022-09-13T17:09:40.130890Z",
+  "createdAt" : "2022-09-28T12:18:41.663556Z",
   "id" : "uwywethj",
   "document" : {
     "version" : 1,
@@ -4384,6 +4384,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#79C9A7",
       "source" : {
         "id" : "66snxpnt",
         "title" : "Schiacciata is a Tuscan focaccia",

--- a/common/search/src/test/resources/test_documents/images.examples.color-filter-tests.blue.json
+++ b/common/search/src/test/resources/test_documents/images.examples.color-filter-tests.blue.json
@@ -1,6 +1,6 @@
 {
   "description" : "example for the color filter tests",
-  "createdAt" : "2022-09-13T17:09:40.039480Z",
+  "createdAt" : "2022-09-28T12:18:41.533413Z",
   "id" : "c6elvmdf",
   "document" : {
     "version" : 1,
@@ -4317,6 +4317,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#A0CA96",
       "source" : {
         "id" : "oefvh9tp",
         "title" : "title-iaLchMu2dl",

--- a/common/search/src/test/resources/test_documents/images.examples.color-filter-tests.even-less-red.json
+++ b/common/search/src/test/resources/test_documents/images.examples.color-filter-tests.even-less-red.json
@@ -1,6 +1,6 @@
 {
   "description" : "example for the color filter tests",
-  "createdAt" : "2022-09-13T17:09:40.033031Z",
+  "createdAt" : "2022-09-28T12:18:41.525671Z",
   "id" : "xqjiditc",
   "document" : {
     "version" : 1,
@@ -4302,6 +4302,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#08D449",
       "source" : {
         "id" : "oieolfdo",
         "title" : "title-EcoKBCN1m2",

--- a/common/search/src/test/resources/test_documents/images.examples.color-filter-tests.red.json
+++ b/common/search/src/test/resources/test_documents/images.examples.color-filter-tests.red.json
@@ -1,6 +1,6 @@
 {
   "description" : "example for the color filter tests",
-  "createdAt" : "2022-09-13T17:09:40.020940Z",
+  "createdAt" : "2022-09-28T12:18:41.507741Z",
   "id" : "k3kkv8mz",
   "document" : {
     "version" : 1,
@@ -4308,6 +4308,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#670610",
       "source" : {
         "id" : "6bglpj7w",
         "title" : "title-32Rf4FVVTN",

--- a/common/search/src/test/resources/test_documents/images.examples.color-filter-tests.slightly-less-red.json
+++ b/common/search/src/test/resources/test_documents/images.examples.color-filter-tests.slightly-less-red.json
@@ -1,6 +1,6 @@
 {
   "description" : "example for the color filter tests",
-  "createdAt" : "2022-09-13T17:09:40.026788Z",
+  "createdAt" : "2022-09-28T12:18:41.516371Z",
   "id" : "11c7vzpp",
   "document" : {
     "version" : 1,
@@ -4303,6 +4303,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#1FEA1A",
       "source" : {
         "id" : "fp38b5sn",
         "title" : "title-fTz2vaAgR4",

--- a/common/search/src/test/resources/test_documents/images.examples.contributor-filter-tests.0.json
+++ b/common/search/src/test/resources/test_documents/images.examples.contributor-filter-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-13T17:09:39.940115Z",
+  "createdAt" : "2022-09-28T12:18:41.408927Z",
   "id" : "6lticgpc",
   "document" : {
     "version" : 1,
@@ -4401,6 +4401,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#BD563A",
       "source" : {
         "id" : "sjsjtui2",
         "title" : "title-NpCNtq3nmM",

--- a/common/search/src/test/resources/test_documents/images.examples.contributor-filter-tests.1.json
+++ b/common/search/src/test/resources/test_documents/images.examples.contributor-filter-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-13T17:09:39.942053Z",
+  "createdAt" : "2022-09-28T12:18:41.410252Z",
   "id" : "guv3wimu",
   "document" : {
     "version" : 1,
@@ -4399,6 +4399,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#979643",
       "source" : {
         "id" : "y2dcec1e",
         "title" : "title-PWicCq4pdZ",

--- a/common/search/src/test/resources/test_documents/images.examples.contributor-filter-tests.2.json
+++ b/common/search/src/test/resources/test_documents/images.examples.contributor-filter-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-13T17:09:39.943538Z",
+  "createdAt" : "2022-09-28T12:18:41.411041Z",
   "id" : "zo8rfpqe",
   "document" : {
     "version" : 1,
@@ -4396,6 +4396,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#679838",
       "source" : {
         "id" : "quyddcqo",
         "title" : "title-2sQvo5HzZf",

--- a/common/search/src/test/resources/test_documents/images.examples.genre-filter-tests.0.json
+++ b/common/search/src/test/resources/test_documents/images.examples.genre-filter-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre filter tests",
-  "createdAt" : "2022-09-13T17:09:39.989621Z",
+  "createdAt" : "2022-09-28T12:18:41.469320Z",
   "id" : "pw03noef",
   "document" : {
     "version" : 1,
@@ -4408,6 +4408,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#371301",
       "source" : {
         "id" : "inqoin52",
         "title" : "title-CIrfuDmt9g",

--- a/common/search/src/test/resources/test_documents/images.examples.genre-filter-tests.1.json
+++ b/common/search/src/test/resources/test_documents/images.examples.genre-filter-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre filter tests",
-  "createdAt" : "2022-09-13T17:09:39.990435Z",
+  "createdAt" : "2022-09-28T12:18:41.470636Z",
   "id" : "pdjafbnc",
   "document" : {
     "version" : 1,
@@ -4396,6 +4396,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#944720",
       "source" : {
         "id" : "4ws2ekt5",
         "title" : "title-FgVnMxxUvQ",

--- a/common/search/src/test/resources/test_documents/images.examples.genre-filter-tests.2.json
+++ b/common/search/src/test/resources/test_documents/images.examples.genre-filter-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre filter tests",
-  "createdAt" : "2022-09-13T17:09:39.992448Z",
+  "createdAt" : "2022-09-28T12:18:41.473179Z",
   "id" : "balrhf7c",
   "document" : {
     "version" : 1,
@@ -4436,6 +4436,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#70069A",
       "source" : {
         "id" : "adqtw0zc",
         "title" : "title-mDNHnumOpV",

--- a/common/search/src/test/resources/test_documents/images.examples.linked-with-another-work.json
+++ b/common/search/src/test/resources/test_documents/images.examples.linked-with-another-work.json
@@ -1,6 +1,6 @@
 {
   "description" : "images linked with another work",
-  "createdAt" : "2022-09-13T17:09:40.104103Z",
+  "createdAt" : "2022-09-28T12:18:41.617425Z",
   "id" : "2gthps4g",
   "document" : {
     "version" : 1,
@@ -4398,6 +4398,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#E47FF0",
       "source" : {
         "id" : "0bcf0gp7",
         "title" : "title-bQSp6yhxBw",

--- a/common/search/src/test/resources/test_documents/images.examples.linked-with-the-same-work.0.json
+++ b/common/search/src/test/resources/test_documents/images.examples.linked-with-the-same-work.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images linked with the same work",
-  "createdAt" : "2022-09-13T17:09:40.076860Z",
+  "createdAt" : "2022-09-28T12:18:41.570895Z",
   "id" : "twwihhcj",
   "document" : {
     "version" : 1,
@@ -4400,6 +4400,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#27D6D6",
       "source" : {
         "id" : "osxxkxkl",
         "title" : "title-ZQqHwUEtrG",

--- a/common/search/src/test/resources/test_documents/images.examples.linked-with-the-same-work.1.json
+++ b/common/search/src/test/resources/test_documents/images.examples.linked-with-the-same-work.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images linked with the same work",
-  "createdAt" : "2022-09-13T17:09:40.077796Z",
+  "createdAt" : "2022-09-28T12:18:41.572095Z",
   "id" : "owdqv6d1",
   "document" : {
     "version" : 1,
@@ -4398,6 +4398,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#DFC065",
       "source" : {
         "id" : "osxxkxkl",
         "title" : "title-ZQqHwUEtrG",

--- a/common/search/src/test/resources/test_documents/images.examples.linked-with-the-same-work.2.json
+++ b/common/search/src/test/resources/test_documents/images.examples.linked-with-the-same-work.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images linked with the same work",
-  "createdAt" : "2022-09-13T17:09:40.081804Z",
+  "createdAt" : "2022-09-28T12:18:41.573233Z",
   "id" : "4urwh7h9",
   "document" : {
     "version" : 1,
@@ -4398,6 +4398,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#D96DDA",
       "source" : {
         "id" : "osxxkxkl",
         "title" : "title-ZQqHwUEtrG",

--- a/common/search/src/test/resources/test_documents/images.examples.linked-with-the-same-work.3.json
+++ b/common/search/src/test/resources/test_documents/images.examples.linked-with-the-same-work.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "images linked with the same work",
-  "createdAt" : "2022-09-13T17:09:40.082805Z",
+  "createdAt" : "2022-09-28T12:18:41.574606Z",
   "id" : "iw2nsqro",
   "document" : {
     "version" : 1,
@@ -4398,6 +4398,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#93D550",
       "source" : {
         "id" : "osxxkxkl",
         "title" : "title-ZQqHwUEtrG",

--- a/common/search/src/test/resources/test_documents/images.genres.0.json
+++ b/common/search/src/test/resources/test_documents/images.genres.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different genres",
-  "createdAt" : "2022-09-13T17:09:39.668403Z",
+  "createdAt" : "2022-09-28T12:18:41.034308Z",
   "id" : "h7v2aaet",
   "document" : {
     "version" : 1,
@@ -4391,6 +4391,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#733A7D",
       "source" : {
         "id" : "tosf3v85",
         "title" : "title-cODPVEG5v4",

--- a/common/search/src/test/resources/test_documents/images.genres.1.json
+++ b/common/search/src/test/resources/test_documents/images.genres.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different genres",
-  "createdAt" : "2022-09-13T17:09:39.670009Z",
+  "createdAt" : "2022-09-28T12:18:41.035777Z",
   "id" : "2i4w2t7k",
   "document" : {
     "version" : 1,
@@ -4398,6 +4398,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#A290A2",
       "source" : {
         "id" : "hwdyhya1",
         "title" : "title-MCNPZ7IYeI",

--- a/common/search/src/test/resources/test_documents/images.genres.2.json
+++ b/common/search/src/test/resources/test_documents/images.genres.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different genres",
-  "createdAt" : "2022-09-13T17:09:39.671792Z",
+  "createdAt" : "2022-09-28T12:18:41.037489Z",
   "id" : "vfagreai",
   "document" : {
     "version" : 1,
@@ -4397,6 +4397,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#F559FD",
       "source" : {
         "id" : "uhiqt84a",
         "title" : "title-O3h9IBe9DR",

--- a/common/search/src/test/resources/test_documents/images.inferred-data.none.json
+++ b/common/search/src/test/resources/test_documents/images.inferred-data.none.json
@@ -1,6 +1,6 @@
 {
   "description" : "an image without any inferred data",
-  "createdAt" : "2022-09-13T17:09:39.893907Z",
+  "createdAt" : "2022-09-28T12:18:41.361683Z",
   "id" : "l5gjhkar",
   "document" : {
     "version" : 1,
@@ -140,6 +140,7 @@
         }
       ],
       "aspectRatio" : 1.0,
+      "averageColor" : "#ffffff",
       "source" : {
         "id" : "dh33dnst",
         "title" : "title-xv9hSPqrWp",

--- a/common/search/src/test/resources/test_documents/images.inferred-data.wrong-format.json
+++ b/common/search/src/test/resources/test_documents/images.inferred-data.wrong-format.json
@@ -1,6 +1,6 @@
 {
   "description" : "an image with inferred data in the wrong format",
-  "createdAt" : "2022-09-13T17:09:39.903486Z",
+  "createdAt" : "2022-09-28T12:18:41.369851Z",
   "id" : "j2sapi9z",
   "document" : {
     "version" : 1,
@@ -4384,6 +4384,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#20757D",
       "source" : {
         "id" : "n2pfpikw",
         "title" : "title-ZzFBkq2piz",

--- a/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.0.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-09-13T17:09:39.724930Z",
+  "createdAt" : "2022-09-28T12:18:41.108275Z",
   "id" : "qdgvzuta",
   "document" : {
     "version" : 1,
@@ -4400,6 +4400,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#9BF5AA",
       "source" : {
         "id" : "aplbcmay",
         "title" : "title-aXPBgcVGR3",

--- a/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.1.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-09-13T17:09:39.726901Z",
+  "createdAt" : "2022-09-28T12:18:41.109554Z",
   "id" : "ijx4qclp",
   "document" : {
     "version" : 1,
@@ -4398,6 +4398,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#486BFA",
       "source" : {
         "id" : "gd4zfuet",
         "title" : "title-Wot5CJhaNy",

--- a/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.2.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-09-13T17:09:39.728498Z",
+  "createdAt" : "2022-09-28T12:18:41.110666Z",
   "id" : "nhw33n0p",
   "document" : {
     "version" : 1,
@@ -4396,6 +4396,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#596617",
       "source" : {
         "id" : "ajjumjhp",
         "title" : "title-EFGyJhj4l3",

--- a/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.3.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-09-13T17:09:39.730199Z",
+  "createdAt" : "2022-09-28T12:18:41.111969Z",
   "id" : "fkmdnf7w",
   "document" : {
     "version" : 1,
@@ -4400,6 +4400,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#798BFF",
       "source" : {
         "id" : "hcxr6ueg",
         "title" : "title-nR5nXJ8LU0",

--- a/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.4.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-09-13T17:09:39.731834Z",
+  "createdAt" : "2022-09-28T12:18:41.113508Z",
   "id" : "zgaqbdy7",
   "document" : {
     "version" : 1,
@@ -4396,6 +4396,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#75592E",
       "source" : {
         "id" : "m3fbtups",
         "title" : "title-dP4GGLQ3iR",

--- a/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.5.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features-and-palettes.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features and palettes",
-  "createdAt" : "2022-09-13T17:09:39.733527Z",
+  "createdAt" : "2022-09-28T12:18:41.114803Z",
   "id" : "lxtbdt9c",
   "document" : {
     "version" : 1,
@@ -4398,6 +4398,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#E6B9F6",
       "source" : {
         "id" : "xr3pijbk",
         "title" : "title-Kq8KV3FdO6",

--- a/common/search/src/test/resources/test_documents/images.similar-features.0.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-09-13T17:09:39.792288Z",
+  "createdAt" : "2022-09-28T12:18:41.220493Z",
   "id" : "rlj2t5sp",
   "document" : {
     "version" : 1,
@@ -4400,6 +4400,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#6E7D23",
       "source" : {
         "id" : "wykjnptu",
         "title" : "title-JvwScpYJWp",

--- a/common/search/src/test/resources/test_documents/images.similar-features.1.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-09-13T17:09:39.793347Z",
+  "createdAt" : "2022-09-28T12:18:41.221453Z",
   "id" : "02353bji",
   "document" : {
     "version" : 1,
@@ -4400,6 +4400,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#3CAD73",
       "source" : {
         "id" : "qmeur6q3",
         "title" : "title-JgRUj0E7Py",

--- a/common/search/src/test/resources/test_documents/images.similar-features.2.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-09-13T17:09:39.794286Z",
+  "createdAt" : "2022-09-28T12:18:41.222471Z",
   "id" : "2bsv7wis",
   "document" : {
     "version" : 1,
@@ -4396,6 +4396,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#A0BD83",
       "source" : {
         "id" : "wynb71k7",
         "title" : "title-8rZwWNxllW",

--- a/common/search/src/test/resources/test_documents/images.similar-features.3.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-09-13T17:09:39.795116Z",
+  "createdAt" : "2022-09-28T12:18:41.223325Z",
   "id" : "9f7x4ikz",
   "document" : {
     "version" : 1,
@@ -4396,6 +4396,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#D46E73",
       "source" : {
         "id" : "yegkg6pc",
         "title" : "title-1xThQH1jdZ",

--- a/common/search/src/test/resources/test_documents/images.similar-features.4.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-09-13T17:09:39.795998Z",
+  "createdAt" : "2022-09-28T12:18:41.224495Z",
   "id" : "k6oa7tyq",
   "document" : {
     "version" : 1,
@@ -4398,6 +4398,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#F11267",
       "source" : {
         "id" : "b32rvpj3",
         "title" : "title-kIVOsu3kyj",

--- a/common/search/src/test/resources/test_documents/images.similar-features.5.json
+++ b/common/search/src/test/resources/test_documents/images.similar-features.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar features",
-  "createdAt" : "2022-09-13T17:09:39.796916Z",
+  "createdAt" : "2022-09-28T12:18:41.225719Z",
   "id" : "j99zsdky",
   "document" : {
     "version" : 1,
@@ -4396,6 +4396,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#AA6499",
       "source" : {
         "id" : "gr4r3wn4",
         "title" : "title-CoWyFam6RL",

--- a/common/search/src/test/resources/test_documents/images.similar-palettes.0.json
+++ b/common/search/src/test/resources/test_documents/images.similar-palettes.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-09-13T17:09:39.858411Z",
+  "createdAt" : "2022-09-28T12:18:41.307340Z",
   "id" : "lerxblzo",
   "document" : {
     "version" : 1,
@@ -4398,6 +4398,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#C8FF74",
       "source" : {
         "id" : "xodcfpw1",
         "title" : "title-yEwSRYvGS5",

--- a/common/search/src/test/resources/test_documents/images.similar-palettes.1.json
+++ b/common/search/src/test/resources/test_documents/images.similar-palettes.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-09-13T17:09:39.859328Z",
+  "createdAt" : "2022-09-28T12:18:41.308706Z",
   "id" : "sqjpw8mc",
   "document" : {
     "version" : 1,
@@ -4400,6 +4400,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#6CCEC4",
       "source" : {
         "id" : "chaen4ll",
         "title" : "title-coU2LNDRdV",

--- a/common/search/src/test/resources/test_documents/images.similar-palettes.2.json
+++ b/common/search/src/test/resources/test_documents/images.similar-palettes.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-09-13T17:09:39.860300Z",
+  "createdAt" : "2022-09-28T12:18:41.309844Z",
   "id" : "tivxhktz",
   "document" : {
     "version" : 1,
@@ -4398,6 +4398,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#3AE9B2",
       "source" : {
         "id" : "vodsy58x",
         "title" : "title-NpAwCCxcnw",

--- a/common/search/src/test/resources/test_documents/images.similar-palettes.3.json
+++ b/common/search/src/test/resources/test_documents/images.similar-palettes.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-09-13T17:09:39.861341Z",
+  "createdAt" : "2022-09-28T12:18:41.310628Z",
   "id" : "d8bmz04m",
   "document" : {
     "version" : 1,
@@ -4396,6 +4396,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#11AC3B",
       "source" : {
         "id" : "5rfjogjy",
         "title" : "title-444Kvau8AZ",

--- a/common/search/src/test/resources/test_documents/images.similar-palettes.4.json
+++ b/common/search/src/test/resources/test_documents/images.similar-palettes.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-09-13T17:09:39.862872Z",
+  "createdAt" : "2022-09-28T12:18:41.311620Z",
   "id" : "0klshcez",
   "document" : {
     "version" : 1,
@@ -4398,6 +4398,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#39CD08",
       "source" : {
         "id" : "ea7pddbm",
         "title" : "title-j9LRGuxWJg",

--- a/common/search/src/test/resources/test_documents/images.similar-palettes.5.json
+++ b/common/search/src/test/resources/test_documents/images.similar-palettes.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with similar palettes",
-  "createdAt" : "2022-09-13T17:09:39.863977Z",
+  "createdAt" : "2022-09-28T12:18:41.312660Z",
   "id" : "jeomchl0",
   "document" : {
     "version" : 1,
@@ -4400,6 +4400,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#213CFB",
       "source" : {
         "id" : "vvodj3hj",
         "title" : "title-S2WNFk8kPA",

--- a/common/search/src/test/resources/test_documents/images.subjects.screwdrivers-1.json
+++ b/common/search/src/test/resources/test_documents/images.subjects.screwdrivers-1.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-09-13T17:09:40.161351Z",
+  "createdAt" : "2022-09-28T12:18:41.700432Z",
   "id" : "yvttbbsh",
   "document" : {
     "version" : 1,
@@ -4404,6 +4404,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#52F034",
       "source" : {
         "id" : "v15v47lj",
         "title" : "title-Vurfdp9iCx",

--- a/common/search/src/test/resources/test_documents/images.subjects.screwdrivers-2.json
+++ b/common/search/src/test/resources/test_documents/images.subjects.screwdrivers-2.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-09-13T17:09:40.166300Z",
+  "createdAt" : "2022-09-28T12:18:41.708175Z",
   "id" : "snvcbjf1",
   "document" : {
     "version" : 1,
@@ -4400,6 +4400,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#EE8285",
       "source" : {
         "id" : "sjnnyap0",
         "title" : "title-Ufg7v6vARA",

--- a/common/search/src/test/resources/test_documents/images.subjects.sounds.json
+++ b/common/search/src/test/resources/test_documents/images.subjects.sounds.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-09-13T17:09:40.156200Z",
+  "createdAt" : "2022-09-28T12:18:41.692981Z",
   "id" : "l6hqqw3i",
   "document" : {
     "version" : 1,
@@ -4392,6 +4392,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#FFF94E",
       "source" : {
         "id" : "kxd5hg2c",
         "title" : "title-UXbrIVN9As",

--- a/common/search/src/test/resources/test_documents/images.subjects.squirrel,sample.json
+++ b/common/search/src/test/resources/test_documents/images.subjects.squirrel,sample.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-09-13T17:09:40.171752Z",
+  "createdAt" : "2022-09-28T12:18:41.715992Z",
   "id" : "vy5cbwmu",
   "document" : {
     "version" : 1,
@@ -4408,6 +4408,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#315940",
       "source" : {
         "id" : "rzdy7j30",
         "title" : "title-TtTPX0c4SG",

--- a/common/search/src/test/resources/test_documents/images.subjects.squirrel,screwdriver.json
+++ b/common/search/src/test/resources/test_documents/images.subjects.squirrel,screwdriver.json
@@ -1,6 +1,6 @@
 {
   "description" : "images with different subjects",
-  "createdAt" : "2022-09-13T17:09:40.176965Z",
+  "createdAt" : "2022-09-28T12:18:41.723672Z",
   "id" : "jibj9ykt",
   "document" : {
     "version" : 1,
@@ -4408,6 +4408,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#C6C4B1",
       "source" : {
         "id" : "zhjf0yam",
         "title" : "title-4gQiRZVtJi",

--- a/common/search/src/test/resources/test_documents/work-production.1098.json
+++ b/common/search/src/test/resources/test_documents/work-production.1098.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1098",
-  "createdAt" : "2022-09-26T11:29:27.282394Z",
+  "createdAt" : "2022-09-28T15:53:38.397736Z",
   "id" : "guav7chy",
   "document" : {
     "debug" : {
@@ -170,6 +170,8 @@
         "W9fptfa5Xn"
       ],
       "title" : "Production event in 1098",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -208,12 +210,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "1098"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/work-production.1098.json
+++ b/common/search/src/test/resources/test_documents/work-production.1098.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1098",
-  "createdAt" : "2022-09-28T15:53:38.397736Z",
+  "createdAt" : "2022-09-30T08:11:41.065502Z",
   "id" : "guav7chy",
   "document" : {
     "debug" : {
@@ -212,6 +212,9 @@
       ],
       "production.label" : [
         "1098"
+      ],
+      "production.dates.range.from" : [
+        -27517622400000
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-production.1900.json
+++ b/common/search/src/test/resources/test_documents/work-production.1900.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1900",
-  "createdAt" : "2022-09-26T11:29:27.244442Z",
+  "createdAt" : "2022-09-28T15:53:38.318683Z",
   "id" : "rbnro6wx",
   "document" : {
     "debug" : {
@@ -170,6 +170,8 @@
         "akaUmx5H3i"
       ],
       "title" : "Production event in 1900",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -208,12 +210,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "1900"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/work-production.1900.json
+++ b/common/search/src/test/resources/test_documents/work-production.1900.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1900",
-  "createdAt" : "2022-09-28T15:53:38.318683Z",
+  "createdAt" : "2022-09-30T08:11:41.036959Z",
   "id" : "rbnro6wx",
   "document" : {
     "debug" : {
@@ -212,6 +212,9 @@
       ],
       "production.label" : [
         "1900"
+      ],
+      "production.dates.range.from" : [
+        -2208988800000
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-production.1904.json
+++ b/common/search/src/test/resources/test_documents/work-production.1904.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1904",
-  "createdAt" : "2022-09-28T15:53:38.360189Z",
+  "createdAt" : "2022-09-30T08:11:41.051448Z",
   "id" : "aiv95swj",
   "document" : {
     "debug" : {
@@ -212,6 +212,9 @@
       ],
       "production.label" : [
         "1904"
+      ],
+      "production.dates.range.from" : [
+        -2082844800000
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-production.1904.json
+++ b/common/search/src/test/resources/test_documents/work-production.1904.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1904",
-  "createdAt" : "2022-09-26T11:29:27.266410Z",
+  "createdAt" : "2022-09-28T15:53:38.360189Z",
   "id" : "aiv95swj",
   "document" : {
     "debug" : {
@@ -170,6 +170,8 @@
         "h0QyLvGt20"
       ],
       "title" : "Production event in 1904",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -208,12 +210,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "1904"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/work-production.1976.json
+++ b/common/search/src/test/resources/test_documents/work-production.1976.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1976",
-  "createdAt" : "2022-09-28T15:53:38.340357Z",
+  "createdAt" : "2022-09-30T08:11:41.044433Z",
   "id" : "5vjghupy",
   "document" : {
     "debug" : {
@@ -212,6 +212,9 @@
       ],
       "production.label" : [
         "1976"
+      ],
+      "production.dates.range.from" : [
+        189302400000
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-production.1976.json
+++ b/common/search/src/test/resources/test_documents/work-production.1976.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 1976",
-  "createdAt" : "2022-09-26T11:29:27.257410Z",
+  "createdAt" : "2022-09-28T15:53:38.340357Z",
   "id" : "5vjghupy",
   "document" : {
     "debug" : {
@@ -170,6 +170,8 @@
         "xrdlOL8J49"
       ],
       "title" : "Production event in 1976",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -208,12 +210,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "1976"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/work-production.2020.json
+++ b/common/search/src/test/resources/test_documents/work-production.2020.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 2020",
-  "createdAt" : "2022-09-28T15:53:38.374898Z",
+  "createdAt" : "2022-09-30T08:11:41.058390Z",
   "id" : "0fucriyr",
   "document" : {
     "debug" : {
@@ -212,6 +212,9 @@
       ],
       "production.label" : [
         "2020"
+      ],
+      "production.dates.range.from" : [
+        1577836800000
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-production.2020.json
+++ b/common/search/src/test/resources/test_documents/work-production.2020.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a production event in 2020",
-  "createdAt" : "2022-09-26T11:29:27.274530Z",
+  "createdAt" : "2022-09-28T15:53:38.374898Z",
   "id" : "0fucriyr",
   "document" : {
     "debug" : {
@@ -170,6 +170,8 @@
         "KgSH5dUX0Z"
       ],
       "title" : "Production event in 2020",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -208,12 +210,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "2020"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/work-thumbnail.json
+++ b/common/search/src/test/resources/test_documents/work-thumbnail.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a thumbnail",
-  "createdAt" : "2022-09-28T15:53:38.124862Z",
+  "createdAt" : "2022-09-30T08:11:40.977422Z",
   "id" : "sahqcluh",
   "document" : {
     "debug" : {
@@ -205,6 +205,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-thumbnail.json
+++ b/common/search/src/test/resources/test_documents/work-thumbnail.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a thumbnail",
-  "createdAt" : "2022-09-26T11:29:27.167985Z",
+  "createdAt" : "2022-09-28T15:53:38.124862Z",
   "id" : "sahqcluh",
   "document" : {
     "debug" : {
@@ -164,6 +164,8 @@
         "rRRYGQYiF7"
       ],
       "title" : "title-LSfnjHB2TS",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -202,12 +204,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/work-title-dodo.json
+++ b/common/search/src/test/resources/test_documents/work-title-dodo.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'dodo' in the title",
-  "createdAt" : "2022-09-28T15:53:38.167109Z",
+  "createdAt" : "2022-09-30T08:11:40.986709Z",
   "id" : "ezagik4b",
   "document" : {
     "debug" : {
@@ -177,6 +177,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-title-dodo.json
+++ b/common/search/src/test/resources/test_documents/work-title-dodo.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'dodo' in the title",
-  "createdAt" : "2022-09-26T11:29:27.180235Z",
+  "createdAt" : "2022-09-28T15:53:38.167109Z",
   "id" : "ezagik4b",
   "document" : {
     "debug" : {
@@ -136,6 +136,8 @@
         "xg9OuzGali"
       ],
       "title" : "A drawing of a dodo",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -174,12 +176,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/work-title-mouse.json
+++ b/common/search/src/test/resources/test_documents/work-title-mouse.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'mouse' in the title",
-  "createdAt" : "2022-09-28T15:53:38.190717Z",
+  "createdAt" : "2022-09-30T08:11:40.993274Z",
   "id" : "lnn17cwk",
   "document" : {
     "debug" : {
@@ -177,6 +177,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-title-mouse.json
+++ b/common/search/src/test/resources/test_documents/work-title-mouse.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with 'mouse' in the title",
-  "createdAt" : "2022-09-26T11:29:27.187468Z",
+  "createdAt" : "2022-09-28T15:53:38.190717Z",
   "id" : "lnn17cwk",
   "document" : {
     "debug" : {
@@ -136,6 +136,8 @@
         "EhPpSB8mq7"
       ],
       "title" : "A mezzotint of a mouse",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -174,12 +176,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/work-with-edition-and-duration.json
+++ b/common/search/src/test/resources/test_documents/work-with-edition-and-duration.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with optional top-level fields",
-  "createdAt" : "2022-09-28T15:53:37.928867Z",
+  "createdAt" : "2022-09-30T08:11:40.928940Z",
   "id" : "gsruvqwf",
   "document" : {
     "debug" : {
@@ -178,6 +178,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work-with-edition-and-duration.json
+++ b/common/search/src/test/resources/test_documents/work-with-edition-and-duration.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with optional top-level fields",
-  "createdAt" : "2022-09-26T11:29:27.107456Z",
+  "createdAt" : "2022-09-28T15:53:37.928867Z",
   "id" : "gsruvqwf",
   "document" : {
     "debug" : {
@@ -137,6 +137,8 @@
         "7YNi35xO0f"
       ],
       "title" : "title-4pIj0kgXrt",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : "Special edition",
@@ -175,12 +177,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/work.items-with-location-types.0.json
+++ b/common/search/src/test/resources/test_documents/work.items-with-location-types.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-09-26T11:29:28.189533Z",
+  "createdAt" : "2022-09-28T15:53:40.901800Z",
   "id" : "kdwct2lf",
   "document" : {
     "debug" : {
@@ -202,6 +202,8 @@
         "vUprsjrX3O"
       ],
       "title" : "title-sLaubb73X6",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -244,12 +246,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/work.items-with-location-types.0.json
+++ b/common/search/src/test/resources/test_documents/work.items-with-location-types.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-09-28T15:53:40.901800Z",
+  "createdAt" : "2022-09-30T08:11:41.942541Z",
   "id" : "kdwct2lf",
   "document" : {
     "debug" : {
@@ -247,6 +247,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work.items-with-location-types.1.json
+++ b/common/search/src/test/resources/test_documents/work.items-with-location-types.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-09-26T11:29:28.190576Z",
+  "createdAt" : "2022-09-28T15:53:40.907824Z",
   "id" : "sgatphra",
   "document" : {
     "debug" : {
@@ -234,6 +234,8 @@
         "GsIdzZyGYB"
       ],
       "title" : "title-GkJTZWwn4A",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -278,12 +280,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/work.items-with-location-types.1.json
+++ b/common/search/src/test/resources/test_documents/work.items-with-location-types.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-09-28T15:53:40.907824Z",
+  "createdAt" : "2022-09-30T08:11:41.943466Z",
   "id" : "sgatphra",
   "document" : {
     "debug" : {
@@ -281,6 +281,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work.items-with-location-types.2.json
+++ b/common/search/src/test/resources/test_documents/work.items-with-location-types.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-09-26T11:29:28.191463Z",
+  "createdAt" : "2022-09-28T15:53:40.909295Z",
   "id" : "wt6pclbs",
   "document" : {
     "debug" : {
@@ -210,6 +210,8 @@
         "D31AdK5EfQ"
       ],
       "title" : "title-e4jqB3DBkI",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -252,13 +254,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
         "closed-stores"
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/work.items-with-location-types.2.json
+++ b/common/search/src/test/resources/test_documents/work.items-with-location-types.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "items with different location types",
-  "createdAt" : "2022-09-28T15:53:40.909295Z",
+  "createdAt" : "2022-09-30T08:11:41.944409Z",
   "id" : "wt6pclbs",
   "document" : {
     "debug" : {
@@ -255,6 +255,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/work.visible.everything.0.json
+++ b/common/search/src/test/resources/test_documents/work.visible.everything.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-09-28T15:53:39.109041Z",
+  "createdAt" : "2022-09-30T08:11:41.258175Z",
   "id" : "tmdfbk5k",
   "document" : {
     "debug" : {
@@ -1091,6 +1091,8 @@
         "zvroF4g2k9",
         "frr0xAeKZI",
         "7aEhJ"
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
         "0cs6cerb",

--- a/common/search/src/test/resources/test_documents/work.visible.everything.0.json
+++ b/common/search/src/test/resources/test_documents/work.visible.everything.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-09-26T11:29:27.526306Z",
+  "createdAt" : "2022-09-28T15:53:39.109041Z",
   "id" : "tmdfbk5k",
   "document" : {
     "debug" : {
@@ -1002,6 +1002,8 @@
         "UfcQYSxE7g"
       ],
       "title" : "A work with all the include-able fields",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -1082,6 +1084,14 @@
         "person-W9SVIX0fEg",
         "person-IWtB2H6"
       ],
+      "production.label" : [
+        "Nr11C9xxYE",
+        "dUXSLHjmev",
+        "8ssuR",
+        "zvroF4g2k9",
+        "frr0xAeKZI",
+        "7aEhJ"
+      ],
       "partOf.id" : [
         "0cs6cerb",
         "nrvdy0jg"
@@ -1091,7 +1101,10 @@
         "title-MS5Hy6x38N"
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/work.visible.everything.1.json
+++ b/common/search/src/test/resources/test_documents/work.visible.everything.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-09-28T15:53:39.245671Z",
+  "createdAt" : "2022-09-30T08:11:41.303444Z",
   "id" : "nlqnlwch",
   "document" : {
     "debug" : {
@@ -1160,6 +1160,8 @@
         "iRibBOUDMp",
         "ITHk4Fal6y",
         "LEuJL"
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
         "jlsj0le6",

--- a/common/search/src/test/resources/test_documents/work.visible.everything.1.json
+++ b/common/search/src/test/resources/test_documents/work.visible.everything.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-09-26T11:29:27.571095Z",
+  "createdAt" : "2022-09-28T15:53:39.245671Z",
   "id" : "nlqnlwch",
   "document" : {
     "debug" : {
@@ -1071,6 +1071,8 @@
         "aGKxAEeG0H"
       ],
       "title" : "A work with all the include-able fields",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -1151,6 +1153,14 @@
         "person-kGPDWLL",
         "person-2Xsatm0"
       ],
+      "production.label" : [
+        "RL51HaiqMv",
+        "Pe7X4srn7y",
+        "dL6XA",
+        "iRibBOUDMp",
+        "ITHk4Fal6y",
+        "LEuJL"
+      ],
       "partOf.id" : [
         "jlsj0le6",
         "qfoju3if"
@@ -1161,7 +1171,10 @@
       ],
       "availabilities.id" : [
         "closed-stores"
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/work.visible.everything.2.json
+++ b/common/search/src/test/resources/test_documents/work.visible.everything.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-09-26T11:29:27.577852Z",
+  "createdAt" : "2022-09-28T15:53:39.330982Z",
   "id" : "jfzz4ou9",
   "document" : {
     "debug" : {
@@ -1080,6 +1080,8 @@
         "FhqVjVef8B"
       ],
       "title" : "A work with all the include-able fields",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -1160,6 +1162,14 @@
         "person-UFES8H2",
         "person-LQeClX"
       ],
+      "production.label" : [
+        "Vibco3T5a2",
+        "CtekEl0aPD",
+        "tepg6",
+        "ba2c8ykXyK",
+        "H9vtTXh5eC",
+        "S91lO"
+      ],
       "partOf.id" : [
         "k4gltrjv",
         "0le4q0ih"
@@ -1171,7 +1181,10 @@
       "availabilities.id" : [
         "open-shelves",
         "closed-stores"
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/work.visible.everything.2.json
+++ b/common/search/src/test/resources/test_documents/work.visible.everything.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a list of work with all the include-able fields",
-  "createdAt" : "2022-09-28T15:53:39.330982Z",
+  "createdAt" : "2022-09-30T08:11:41.314006Z",
   "id" : "jfzz4ou9",
   "document" : {
     "debug" : {
@@ -1169,6 +1169,8 @@
         "ba2c8ykXyK",
         "H9vtTXh5eC",
         "S91lO"
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
         "k4gltrjv",

--- a/common/search/src/test/resources/test_documents/works.collection-path.NUFFINK.json
+++ b/common/search/src/test/resources/test_documents/works.collection-path.NUFFINK.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a collection path",
-  "createdAt" : "2022-09-28T15:53:40.461661Z",
+  "createdAt" : "2022-09-30T08:11:41.752638Z",
   "id" : "dtqmc0yn",
   "document" : {
     "debug" : {
@@ -179,6 +179,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.collection-path.NUFFINK.json
+++ b/common/search/src/test/resources/test_documents/works.collection-path.NUFFINK.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a collection path",
-  "createdAt" : "2022-09-26T11:29:27.997100Z",
+  "createdAt" : "2022-09-28T15:53:40.461661Z",
   "id" : "dtqmc0yn",
   "document" : {
     "debug" : {
@@ -138,6 +138,8 @@
         "Lq95TrUx7A"
       ],
       "title" : "title-boqbXNAi3a",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -176,12 +178,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : "NUF/FINK",
+      "collectionPath.path" : "NUFFINK",
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.collection-path.PPCRI.json
+++ b/common/search/src/test/resources/test_documents/works.collection-path.PPCRI.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a collection path",
-  "createdAt" : "2022-09-26T11:29:27.985572Z",
+  "createdAt" : "2022-09-28T15:53:40.443537Z",
   "id" : "mlqs2qbd",
   "document" : {
     "debug" : {
@@ -138,6 +138,8 @@
         "yQb1GgWKF4"
       ],
       "title" : "title-X1EiWSsi1c",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -176,12 +178,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : "PP/CRI",
+      "collectionPath.path" : "PPCRI",
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.collection-path.PPCRI.json
+++ b/common/search/src/test/resources/test_documents/works.collection-path.PPCRI.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with a collection path",
-  "createdAt" : "2022-09-28T15:53:40.443537Z",
+  "createdAt" : "2022-09-30T08:11:41.746543Z",
   "id" : "mlqs2qbd",
   "document" : {
     "debug" : {
@@ -179,6 +179,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.contributor.0.json
+++ b/common/search/src/test/resources/test_documents/works.contributor.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-09-26T11:29:27.909515Z",
+  "createdAt" : "2022-09-28T15:53:40.217422Z",
   "id" : "gvkz3vff",
   "document" : {
     "debug" : {
@@ -160,6 +160,8 @@
         "5CJlp05MGl"
       ],
       "title" : "title-Wh4OVfDtEV",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -199,12 +201,17 @@
       "contributors.agent.label" : [
         "47"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.contributor.0.json
+++ b/common/search/src/test/resources/test_documents/works.contributor.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-09-28T15:53:40.217422Z",
+  "createdAt" : "2022-09-30T08:11:41.661960Z",
   "id" : "gvkz3vff",
   "document" : {
     "debug" : {
@@ -202,6 +202,8 @@
         "47"
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.contributor.1.json
+++ b/common/search/src/test/resources/test_documents/works.contributor.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-09-28T15:53:40.220593Z",
+  "createdAt" : "2022-09-30T08:11:41.663295Z",
   "id" : "bj9evx0c",
   "document" : {
     "debug" : {
@@ -202,6 +202,8 @@
         "47"
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.contributor.1.json
+++ b/common/search/src/test/resources/test_documents/works.contributor.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-09-26T11:29:27.910624Z",
+  "createdAt" : "2022-09-28T15:53:40.220593Z",
   "id" : "bj9evx0c",
   "document" : {
     "debug" : {
@@ -160,6 +160,8 @@
         "TjLML0MOH1"
       ],
       "title" : "title-h70mKj49k3",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -199,12 +201,17 @@
       "contributors.agent.label" : [
         "47"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.contributor.2.json
+++ b/common/search/src/test/resources/test_documents/works.contributor.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-09-26T11:29:27.916077Z",
+  "createdAt" : "2022-09-28T15:53:40.236628Z",
   "id" : "z08k6cnn",
   "document" : {
     "debug" : {
@@ -185,6 +185,8 @@
         "juTufKU2Ye"
       ],
       "title" : "title-UVMdWdPx74",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -225,12 +227,17 @@
         "007",
         "MI5"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.contributor.2.json
+++ b/common/search/src/test/resources/test_documents/works.contributor.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-09-28T15:53:40.236628Z",
+  "createdAt" : "2022-09-30T08:11:41.670122Z",
   "id" : "z08k6cnn",
   "document" : {
     "debug" : {
@@ -228,6 +228,8 @@
         "MI5"
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.contributor.3.json
+++ b/common/search/src/test/resources/test_documents/works.contributor.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-09-26T11:29:27.917335Z",
+  "createdAt" : "2022-09-28T15:53:40.242525Z",
   "id" : "gtfjchvo",
   "document" : {
     "debug" : {
@@ -185,6 +185,8 @@
         "xKXAvquihJ"
       ],
       "title" : "title-AJeGRUgE73",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -225,12 +227,17 @@
         "MI5",
         "GCHQ"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.contributor.3.json
+++ b/common/search/src/test/resources/test_documents/works.contributor.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different contributor",
-  "createdAt" : "2022-09-28T15:53:40.242525Z",
+  "createdAt" : "2022-09-30T08:11:41.671594Z",
   "id" : "gtfjchvo",
   "document" : {
     "debug" : {
@@ -228,6 +228,8 @@
         "GCHQ"
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.0.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.013931Z",
+  "createdAt" : "2022-09-28T15:53:40.489516Z",
   "id" : "4njkixz6",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "BApNW5yJ4Q"
       ],
       "title" : "title-6YygLZHy7Z",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.0.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.489516Z",
+  "createdAt" : "2022-09-30T08:11:41.761499Z",
   "id" : "4njkixz6",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.1.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.014484Z",
+  "createdAt" : "2022-09-28T15:53:40.492107Z",
   "id" : "jugcpduf",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "YysYTJPbhB"
       ],
       "title" : "title-DhzFoUvfxn",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.1.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.492107Z",
+  "createdAt" : "2022-09-30T08:11:41.762174Z",
   "id" : "jugcpduf",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.10.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.531034Z",
+  "createdAt" : "2022-09-30T08:11:41.769825Z",
   "id" : "4wwgkp4h",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.10.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.019907Z",
+  "createdAt" : "2022-09-28T15:53:40.531034Z",
   "id" : "4wwgkp4h",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "miNkeZ17CI"
       ],
       "title" : "title-uALANM5eCQ",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.11.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.533332Z",
+  "createdAt" : "2022-09-30T08:11:41.770344Z",
   "id" : "kkcl3dhq",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.11.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.023792Z",
+  "createdAt" : "2022-09-28T15:53:40.533332Z",
   "id" : "kkcl3dhq",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "INEpZD4veL"
       ],
       "title" : "title-ooZVNybADY",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.12.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.539395Z",
+  "createdAt" : "2022-09-30T08:11:41.770881Z",
   "id" : "ilrp0gol",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.12.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.024679Z",
+  "createdAt" : "2022-09-28T15:53:40.539395Z",
   "id" : "ilrp0gol",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "TRLxjc4Dv7"
       ],
       "title" : "title-5MZkkqME2t",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.13.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.544320Z",
+  "createdAt" : "2022-09-30T08:11:41.771435Z",
   "id" : "rdqs25hn",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.13.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.025349Z",
+  "createdAt" : "2022-09-28T15:53:40.544320Z",
   "id" : "rdqs25hn",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "fZ9zaDFnzp"
       ],
       "title" : "title-uQBSkLFL8C",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.14.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.026102Z",
+  "createdAt" : "2022-09-28T15:53:40.548040Z",
   "id" : "124qx5km",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "LCpWDX84If"
       ],
       "title" : "title-WpmMJGY9dh",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.14.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.548040Z",
+  "createdAt" : "2022-09-30T08:11:41.771939Z",
   "id" : "124qx5km",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.15.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.026845Z",
+  "createdAt" : "2022-09-28T15:53:40.549521Z",
   "id" : "tlc5rq9a",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "mz25207khU"
       ],
       "title" : "title-jNr737MdPw",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.15.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.549521Z",
+  "createdAt" : "2022-09-30T08:11:41.772449Z",
   "id" : "tlc5rq9a",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.16.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.550645Z",
+  "createdAt" : "2022-09-30T08:11:41.773015Z",
   "id" : "sdb22mdv",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.16.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.027416Z",
+  "createdAt" : "2022-09-28T15:53:40.550645Z",
   "id" : "sdb22mdv",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "qjgnqBCXUR"
       ],
       "title" : "title-8D1YQhdjF0",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.17.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.552036Z",
+  "createdAt" : "2022-09-30T08:11:41.773909Z",
   "id" : "9tar4kg6",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.17.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.028074Z",
+  "createdAt" : "2022-09-28T15:53:40.552036Z",
   "id" : "9tar4kg6",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "WpfpIxjlf3"
       ],
       "title" : "title-zifN5hzpvx",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.18.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.028774Z",
+  "createdAt" : "2022-09-28T15:53:40.553084Z",
   "id" : "au6tjof0",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "vISRu7MtEo"
       ],
       "title" : "title-GajAY87vuu",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.18.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.553084Z",
+  "createdAt" : "2022-09-30T08:11:41.774557Z",
   "id" : "au6tjof0",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.19.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.554206Z",
+  "createdAt" : "2022-09-30T08:11:41.775108Z",
   "id" : "ogdq417u",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.19.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.029343Z",
+  "createdAt" : "2022-09-28T15:53:40.554206Z",
   "id" : "ogdq417u",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "lq8kfIsxyr"
       ],
       "title" : "title-7J1fupAzsf",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.2.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.015175Z",
+  "createdAt" : "2022-09-28T15:53:40.494494Z",
   "id" : "fuwvinln",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "40wEIb4rPR"
       ],
       "title" : "title-8ljlZQFqGf",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.2.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.494494Z",
+  "createdAt" : "2022-09-30T08:11:41.763579Z",
   "id" : "fuwvinln",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.20.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.555668Z",
+  "createdAt" : "2022-09-30T08:11:41.775712Z",
   "id" : "jyum0yf1",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.20.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.030073Z",
+  "createdAt" : "2022-09-28T15:53:40.555668Z",
   "id" : "jyum0yf1",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "KzDNfalpwO"
       ],
       "title" : "title-ImZeIhkjzt",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.21.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.557545Z",
+  "createdAt" : "2022-09-30T08:11:41.776321Z",
   "id" : "cwippax3",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.21.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.030680Z",
+  "createdAt" : "2022-09-28T15:53:40.557545Z",
   "id" : "cwippax3",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "2PauY4Py8G"
       ],
       "title" : "title-5qt38YgNxO",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.22.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.031194Z",
+  "createdAt" : "2022-09-28T15:53:40.559505Z",
   "id" : "9rgmu63i",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "3tyy1ghzsQ"
       ],
       "title" : "title-sDHZ5kGsC2",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.22.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.559505Z",
+  "createdAt" : "2022-09-30T08:11:41.776931Z",
   "id" : "9rgmu63i",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.3.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.500311Z",
+  "createdAt" : "2022-09-30T08:11:41.764808Z",
   "id" : "i77xk8vj",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.3.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.015808Z",
+  "createdAt" : "2022-09-28T15:53:40.500311Z",
   "id" : "i77xk8vj",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "SZKltFZVRN"
       ],
       "title" : "title-3TPxT5oi8C",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.4.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.016379Z",
+  "createdAt" : "2022-09-28T15:53:40.506343Z",
   "id" : "xgsosrhr",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "L5s2axrzcV"
       ],
       "title" : "title-K7J5071Cwm",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.4.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.506343Z",
+  "createdAt" : "2022-09-30T08:11:41.765494Z",
   "id" : "xgsosrhr",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.5.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.017149Z",
+  "createdAt" : "2022-09-28T15:53:40.516509Z",
   "id" : "cvdyxyqr",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "LIOVK6f1ni"
       ],
       "title" : "title-eWPnruNlWw",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.5.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.516509Z",
+  "createdAt" : "2022-09-30T08:11:41.766420Z",
   "id" : "cvdyxyqr",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.6.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.520648Z",
+  "createdAt" : "2022-09-30T08:11:41.767104Z",
   "id" : "aftvp1wz",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.6.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.017781Z",
+  "createdAt" : "2022-09-28T15:53:40.520648Z",
   "id" : "aftvp1wz",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "rMq0Chsgjm"
       ],
       "title" : "title-K883LiigJ4",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.7.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.018332Z",
+  "createdAt" : "2022-09-28T15:53:40.524495Z",
   "id" : "y8glbwdh",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "NrhJtvfJrH"
       ],
       "title" : "title-PcZctCb44q",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.7.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.524495Z",
+  "createdAt" : "2022-09-30T08:11:41.767861Z",
   "id" : "y8glbwdh",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.8.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.526074Z",
+  "createdAt" : "2022-09-30T08:11:41.768579Z",
   "id" : "4fkr6m6l",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.8.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.018867Z",
+  "createdAt" : "2022-09-28T15:53:40.526074Z",
   "id" : "4fkr6m6l",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "Ngls6zS4b2"
       ],
       "title" : "title-uUZlr85jkf",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.every-format.9.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-28T15:53:40.527494Z",
+  "createdAt" : "2022-09-30T08:11:41.769174Z",
   "id" : "e2zva5mj",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.every-format.9.json
+++ b/common/search/src/test/resources/test_documents/works.every-format.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with every format",
-  "createdAt" : "2022-09-26T11:29:28.019371Z",
+  "createdAt" : "2022-09-28T15:53:40.527494Z",
   "id" : "e2zva5mj",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "2Ap82csHfk"
       ],
       "title" : "title-AcxE29kiXI",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-28T15:53:42.194247Z",
+  "createdAt" : "2022-09-30T08:11:42.424059Z",
   "id" : "stsp385v",
   "document" : {
     "debug" : {
@@ -273,6 +273,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-26T11:29:28.642707Z",
+  "createdAt" : "2022-09-28T15:53:42.194247Z",
   "id" : "stsp385v",
   "document" : {
     "debug" : {
@@ -227,6 +227,8 @@
         "PD8H80xrR5"
       ],
       "title" : "title-GLuYXYlnwW",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -270,12 +272,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-26T11:29:28.643552Z",
+  "createdAt" : "2022-09-28T15:53:42.195931Z",
   "id" : "jwvfegzn",
   "document" : {
     "debug" : {
@@ -225,6 +225,8 @@
         "FvAY3kDPeO"
       ],
       "title" : "title-8X1iQV3o0G",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -268,12 +270,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-28T15:53:42.195931Z",
+  "createdAt" : "2022-09-30T08:11:42.424939Z",
   "id" : "jwvfegzn",
   "document" : {
     "debug" : {
@@ -271,6 +271,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-28T15:53:42.197834Z",
+  "createdAt" : "2022-09-30T08:11:42.425517Z",
   "id" : "glagakd2",
   "document" : {
     "debug" : {
@@ -271,6 +271,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-26T11:29:28.644286Z",
+  "createdAt" : "2022-09-28T15:53:42.197834Z",
   "id" : "glagakd2",
   "document" : {
     "debug" : {
@@ -225,6 +225,8 @@
         "aCHuXzrv8P"
       ],
       "title" : "title-zPZAnMiJNW",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -268,12 +270,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-28T15:53:42.200053Z",
+  "createdAt" : "2022-09-30T08:11:42.426192Z",
   "id" : "wys5lz5r",
   "document" : {
     "debug" : {
@@ -280,6 +280,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-26T11:29:28.644983Z",
+  "createdAt" : "2022-09-28T15:53:42.200053Z",
   "id" : "wys5lz5r",
   "document" : {
     "debug" : {
@@ -234,6 +234,8 @@
         "GWT6gTiZ6K"
       ],
       "title" : "title-MofTOW5bCv",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -277,13 +279,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
         "online"
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-28T15:53:42.201474Z",
+  "createdAt" : "2022-09-30T08:11:42.426853Z",
   "id" : "iqani2su",
   "document" : {
     "debug" : {
@@ -279,6 +279,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-26T11:29:28.645621Z",
+  "createdAt" : "2022-09-28T15:53:42.201474Z",
   "id" : "iqani2su",
   "document" : {
     "debug" : {
@@ -233,6 +233,8 @@
         "jYpuBxuni2"
       ],
       "title" : "title-7p7NJFW4Dx",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -276,13 +278,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
         "online"
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-26T11:29:28.660671Z",
+  "createdAt" : "2022-09-28T15:53:42.221076Z",
   "id" : "yh6sk7pv",
   "document" : {
     "debug" : {
@@ -237,6 +237,8 @@
         "5tbPGXaLqw"
       ],
       "title" : "title-r7VLiwfab6",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -280,13 +282,18 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
         "online"
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-28T15:53:42.221076Z",
+  "createdAt" : "2022-09-30T08:11:42.439095Z",
   "id" : "yh6sk7pv",
   "document" : {
     "debug" : {
@@ -283,6 +283,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.6.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-26T11:29:28.661843Z",
+  "createdAt" : "2022-09-28T15:53:42.222910Z",
   "id" : "uqhxoxvf",
   "document" : {
     "debug" : {
@@ -229,6 +229,8 @@
         "Ey1hoMJJvc"
       ],
       "title" : "title-tU496lvqxD",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -272,12 +274,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.6.json
+++ b/common/search/src/test/resources/test_documents/works.examples.access-status-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the access status tests",
-  "createdAt" : "2022-09-28T15:53:42.222910Z",
+  "createdAt" : "2022-09-30T08:11:42.440125Z",
   "id" : "uqhxoxvf",
   "document" : {
     "debug" : {
@@ -275,6 +275,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.215713Z",
+  "createdAt" : "2022-09-28T15:53:40.999773Z",
   "id" : "vqys4hio",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "ESZHkohLBq"
       ],
       "title" : "title-vwQleJkqVb",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:40.999773Z",
+  "createdAt" : "2022-09-30T08:11:41.965686Z",
   "id" : "vqys4hio",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.001772Z",
+  "createdAt" : "2022-09-30T08:11:41.966859Z",
   "id" : "scernate",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.216895Z",
+  "createdAt" : "2022-09-28T15:53:41.001772Z",
   "id" : "scernate",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "mxTT1Dnad9"
       ],
       "title" : "title-ZtfG4qEc4M",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.10.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.056386Z",
+  "createdAt" : "2022-09-30T08:11:41.974642Z",
   "id" : "sw2fzgit",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.10.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.10.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.226315Z",
+  "createdAt" : "2022-09-28T15:53:41.056386Z",
   "id" : "sw2fzgit",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "6gzFFn0MzM"
       ],
       "title" : "title-5K9RmsgKYJ",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.11.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.227296Z",
+  "createdAt" : "2022-09-28T15:53:41.067660Z",
   "id" : "4elqjncu",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "WyiVFCEDYI"
       ],
       "title" : "title-pZH75AXbZo",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.11.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.11.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.067660Z",
+  "createdAt" : "2022-09-30T08:11:41.975453Z",
   "id" : "4elqjncu",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.12.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.069398Z",
+  "createdAt" : "2022-09-30T08:11:41.976244Z",
   "id" : "8yitytyw",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.12.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.12.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.228148Z",
+  "createdAt" : "2022-09-28T15:53:41.069398Z",
   "id" : "8yitytyw",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "a33KTr4gSW"
       ],
       "title" : "title-3z92KVUKZD",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.13.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.228924Z",
+  "createdAt" : "2022-09-28T15:53:41.086516Z",
   "id" : "66bwuadw",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "t9Z95L7cLo"
       ],
       "title" : "title-2M9CVkukQI",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.13.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.13.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.086516Z",
+  "createdAt" : "2022-09-30T08:11:41.977015Z",
   "id" : "66bwuadw",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.14.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.115665Z",
+  "createdAt" : "2022-09-30T08:11:41.978044Z",
   "id" : "dborzqld",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.14.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.14.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.229866Z",
+  "createdAt" : "2022-09-28T15:53:41.115665Z",
   "id" : "dborzqld",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "xZlpWaXi4Y"
       ],
       "title" : "title-LN4dq7YPgQ",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.15.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.125965Z",
+  "createdAt" : "2022-09-30T08:11:41.978865Z",
   "id" : "fu0kybma",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.15.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.15.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.230867Z",
+  "createdAt" : "2022-09-28T15:53:41.125965Z",
   "id" : "fu0kybma",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "SlRRldG9e4"
       ],
       "title" : "title-54cIcDQPXI",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.16.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.231835Z",
+  "createdAt" : "2022-09-28T15:53:41.135003Z",
   "id" : "pyub9jxo",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "qajt54m4dW"
       ],
       "title" : "title-bp7ZbfAOv6",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.16.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.16.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.135003Z",
+  "createdAt" : "2022-09-30T08:11:41.979648Z",
   "id" : "pyub9jxo",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.17.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.232808Z",
+  "createdAt" : "2022-09-28T15:53:41.144258Z",
   "id" : "izlcv3sm",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "x0zgHgbzqM"
       ],
       "title" : "title-aNuUq84cRg",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.17.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.17.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.144258Z",
+  "createdAt" : "2022-09-30T08:11:41.980431Z",
   "id" : "izlcv3sm",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.18.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.149321Z",
+  "createdAt" : "2022-09-30T08:11:41.981358Z",
   "id" : "s4ry14qu",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.18.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.18.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.234053Z",
+  "createdAt" : "2022-09-28T15:53:41.149321Z",
   "id" : "s4ry14qu",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "Ue8m3HVuer"
       ],
       "title" : "title-XX1muoI8Tp",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.19.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.154931Z",
+  "createdAt" : "2022-09-30T08:11:41.982177Z",
   "id" : "svr3x3ca",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.19.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.19.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.235237Z",
+  "createdAt" : "2022-09-28T15:53:41.154931Z",
   "id" : "svr3x3ca",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "FRfKD3vr5o"
       ],
       "title" : "title-lluSXGQIID",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.010613Z",
+  "createdAt" : "2022-09-30T08:11:41.967836Z",
   "id" : "vpkqafpg",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.218197Z",
+  "createdAt" : "2022-09-28T15:53:41.010613Z",
   "id" : "vpkqafpg",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "dPAcgpfIbf"
       ],
       "title" : "title-z7am59I9Cw",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.20.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.157898Z",
+  "createdAt" : "2022-09-30T08:11:41.983005Z",
   "id" : "w4lfjuza",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.20.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.20.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.236280Z",
+  "createdAt" : "2022-09-28T15:53:41.157898Z",
   "id" : "w4lfjuza",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "P7HD59gW9t"
       ],
       "title" : "title-quWoTqEmJ6",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.21.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.159403Z",
+  "createdAt" : "2022-09-30T08:11:41.983832Z",
   "id" : "5hlmpzzh",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.21.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.21.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.237197Z",
+  "createdAt" : "2022-09-28T15:53:41.159403Z",
   "id" : "5hlmpzzh",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "PyW5z3uVBA"
       ],
       "title" : "title-JtbkBsxzfE",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.22.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.238070Z",
+  "createdAt" : "2022-09-28T15:53:41.161071Z",
   "id" : "b5lylqvq",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "DIlUXQf0x4"
       ],
       "title" : "title-SQr2rDSofx",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.22.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.22.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.161071Z",
+  "createdAt" : "2022-09-30T08:11:41.984660Z",
   "id" : "b5lylqvq",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.219698Z",
+  "createdAt" : "2022-09-28T15:53:41.015786Z",
   "id" : "ivw1mq40",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "zoIhNdLDgG"
       ],
       "title" : "title-gbiIgGzgYB",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.015786Z",
+  "createdAt" : "2022-09-30T08:11:41.968904Z",
   "id" : "ivw1mq40",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.025428Z",
+  "createdAt" : "2022-09-30T08:11:41.969813Z",
   "id" : "mxssba8u",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.220962Z",
+  "createdAt" : "2022-09-28T15:53:41.025428Z",
   "id" : "mxssba8u",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "QnFei9OwDH"
       ],
       "title" : "title-TG3GuW07LA",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.032442Z",
+  "createdAt" : "2022-09-30T08:11:41.970627Z",
   "id" : "pi8hxmce",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.221884Z",
+  "createdAt" : "2022-09-28T15:53:41.032442Z",
   "id" : "pi8hxmce",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "tXxMtg7dko"
       ],
       "title" : "title-jABF1suXYC",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.6.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.034188Z",
+  "createdAt" : "2022-09-30T08:11:41.971464Z",
   "id" : "lwt2ohte",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.6.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.222760Z",
+  "createdAt" : "2022-09-28T15:53:41.034188Z",
   "id" : "lwt2ohte",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "zOTvHYjPJX"
       ],
       "title" : "title-5AXQEaJ1be",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.7.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.223627Z",
+  "createdAt" : "2022-09-28T15:53:41.036170Z",
   "id" : "a62ffqxh",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "dUrbgrWtto"
       ],
       "title" : "title-ojQsszds7w",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.7.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.036170Z",
+  "createdAt" : "2022-09-30T08:11:41.972267Z",
   "id" : "a62ffqxh",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.8.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.047350Z",
+  "createdAt" : "2022-09-30T08:11:41.973006Z",
   "id" : "atgvzcvy",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.8.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.224443Z",
+  "createdAt" : "2022-09-28T15:53:41.047350Z",
   "id" : "atgvzcvy",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "za69e7zAIP"
       ],
       "title" : "title-WMl0kbMOTy",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.9.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-26T11:29:28.225321Z",
+  "createdAt" : "2022-09-28T15:53:41.053322Z",
   "id" : "mopzrqzu",
   "document" : {
     "debug" : {
@@ -190,6 +190,8 @@
         "DIXUuyd8hW"
       ],
       "title" : "title-pVU0ULWN0n",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -232,12 +234,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.9.json
+++ b/common/search/src/test/resources/test_documents/works.examples.aggregation-with-filters-tests.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the aggregation-with-filters tests",
-  "createdAt" : "2022-09-28T15:53:41.053322Z",
+  "createdAt" : "2022-09-30T08:11:41.973878Z",
   "id" : "mopzrqzu",
   "document" : {
     "debug" : {
@@ -235,6 +235,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-26T11:29:28.474688Z",
+  "createdAt" : "2022-09-28T15:53:41.907335Z",
   "id" : "h5zn9bqm",
   "document" : {
     "debug" : {
@@ -162,6 +162,8 @@
         "OQ6G6Rkv6Q"
       ],
       "title" : "title-6Obq6lxZzG",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -201,12 +203,17 @@
       "contributors.agent.label" : [
         "Bath, Patricia"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-28T15:53:41.907335Z",
+  "createdAt" : "2022-09-30T08:11:42.273823Z",
   "id" : "h5zn9bqm",
   "document" : {
     "debug" : {
@@ -204,6 +204,8 @@
         "Bath, Patricia"
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-26T11:29:28.475482Z",
+  "createdAt" : "2022-09-28T15:53:41.908904Z",
   "id" : "gnuj1it3",
   "document" : {
     "debug" : {
@@ -162,6 +162,8 @@
         "Og3KGy7Mz5"
       ],
       "title" : "title-c4OR9LzJV7",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -201,12 +203,17 @@
       "contributors.agent.label" : [
         "Karl Marx"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-28T15:53:41.908904Z",
+  "createdAt" : "2022-09-30T08:11:42.274605Z",
   "id" : "gnuj1it3",
   "document" : {
     "debug" : {
@@ -204,6 +204,8 @@
         "Karl Marx"
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-26T11:29:28.476364Z",
+  "createdAt" : "2022-09-28T15:53:41.910214Z",
   "id" : "e1k1l8xu",
   "document" : {
     "debug" : {
@@ -162,6 +162,8 @@
         "Kvqw9fGol7"
       ],
       "title" : "title-cLZhc35m9C",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -201,12 +203,17 @@
       "contributors.agent.label" : [
         "Jake Paul"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-28T15:53:41.910214Z",
+  "createdAt" : "2022-09-30T08:11:42.275565Z",
   "id" : "e1k1l8xu",
   "document" : {
     "debug" : {
@@ -204,6 +204,8 @@
         "Jake Paul"
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-26T11:29:28.477016Z",
+  "createdAt" : "2022-09-28T15:53:41.911232Z",
   "id" : "6q7wkowr",
   "document" : {
     "debug" : {
@@ -162,6 +162,8 @@
         "AgxJAjEybh"
       ],
       "title" : "title-NOoLbpS5jR",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -201,12 +203,17 @@
       "contributors.agent.label" : [
         "Darwin \"Jones\", Charles"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-28T15:53:41.911232Z",
+  "createdAt" : "2022-09-30T08:11:42.276268Z",
   "id" : "6q7wkowr",
   "document" : {
     "debug" : {
@@ -204,6 +204,8 @@
         "Darwin \"Jones\", Charles"
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-28T15:53:41.912074Z",
+  "createdAt" : "2022-09-30T08:11:42.277314Z",
   "id" : "cpwnrkdo",
   "document" : {
     "debug" : {
@@ -232,6 +232,8 @@
         "Darwin \"Jones\", Charles"
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-26T11:29:28.477659Z",
+  "createdAt" : "2022-09-28T15:53:41.912074Z",
   "id" : "cpwnrkdo",
   "document" : {
     "debug" : {
@@ -189,6 +189,8 @@
         "FqozNGJ9Pf"
       ],
       "title" : "title-Vp3bULWghZ",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -229,12 +231,17 @@
         "Bath, Patricia",
         "Darwin \"Jones\", Charles"
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-26T11:29:28.478039Z",
+  "createdAt" : "2022-09-28T15:53:41.913091Z",
   "id" : "bexh6kx6",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "5q2ktKEnxz"
       ],
       "title" : "title-ERuJHArEMd",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.contributor-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the contributor filter tests",
-  "createdAt" : "2022-09-28T15:53:41.913091Z",
+  "createdAt" : "2022-09-30T08:11:42.277974Z",
   "id" : "bexh6kx6",
   "document" : {
     "debug" : {
@@ -176,6 +176,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.different-work-types.Collection.json
+++ b/common/search/src/test/resources/test_documents/works.examples.different-work-types.Collection.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-09-26T11:29:28.376725Z",
+  "createdAt" : "2022-09-28T15:53:41.700435Z",
   "id" : "2tqcclh1",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "ZiS5MlN0hQ"
       ],
       "title" : "rats",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.different-work-types.Collection.json
+++ b/common/search/src/test/resources/test_documents/works.examples.different-work-types.Collection.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-09-28T15:53:41.700435Z",
+  "createdAt" : "2022-09-30T08:11:42.160265Z",
   "id" : "2tqcclh1",
   "document" : {
     "debug" : {
@@ -176,6 +176,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.different-work-types.Section.json
+++ b/common/search/src/test/resources/test_documents/works.examples.different-work-types.Section.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-09-28T15:53:41.680150Z",
+  "createdAt" : "2022-09-30T08:11:42.151825Z",
   "id" : "iw5fnuyy",
   "document" : {
     "debug" : {
@@ -176,6 +176,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.different-work-types.Section.json
+++ b/common/search/src/test/resources/test_documents/works.examples.different-work-types.Section.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-09-26T11:29:28.370171Z",
+  "createdAt" : "2022-09-28T15:53:41.680150Z",
   "id" : "iw5fnuyy",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "Xo35aec2Io"
       ],
       "title" : "rats",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.different-work-types.Series.json
+++ b/common/search/src/test/resources/test_documents/works.examples.different-work-types.Series.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-09-26T11:29:28.382399Z",
+  "createdAt" : "2022-09-28T15:53:41.718547Z",
   "id" : "fndkxmxs",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "yW6CgVzwIJ"
       ],
       "title" : "rats",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.different-work-types.Series.json
+++ b/common/search/src/test/resources/test_documents/works.examples.different-work-types.Series.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples of works with different types",
-  "createdAt" : "2022-09-28T15:53:41.718547Z",
+  "createdAt" : "2022-09-30T08:11:42.169604Z",
   "id" : "fndkxmxs",
   "document" : {
     "debug" : {
@@ -176,6 +176,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-28T15:53:42.313786Z",
+  "createdAt" : "2022-09-30T08:11:42.480294Z",
   "id" : "phodmv5g",
   "document" : {
     "debug" : {
@@ -195,6 +195,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.697765Z",
+  "createdAt" : "2022-09-28T15:53:42.313786Z",
   "id" : "phodmv5g",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "kSl7z2IaIy"
       ],
       "title" : "rats",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-28T15:53:42.315824Z",
+  "createdAt" : "2022-09-30T08:11:42.480789Z",
   "id" : "580nnpfa",
   "document" : {
     "debug" : {
@@ -195,6 +195,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.698291Z",
+  "createdAt" : "2022-09-28T15:53:42.315824Z",
   "id" : "580nnpfa",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "wz2OkOJHcs"
       ],
       "title" : "capybara",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.698779Z",
+  "createdAt" : "2022-09-28T15:53:42.318028Z",
   "id" : "jfnymrg2",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "zrSaF1p8IU"
       ],
       "title" : "tapirs",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-28T15:53:42.318028Z",
+  "createdAt" : "2022-09-30T08:11:42.481236Z",
   "id" : "jfnymrg2",
   "document" : {
     "debug" : {
@@ -195,6 +195,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-28T15:53:42.319583Z",
+  "createdAt" : "2022-09-30T08:11:42.481661Z",
   "id" : "lpoz1fy9",
   "document" : {
     "debug" : {
@@ -195,6 +195,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.699339Z",
+  "createdAt" : "2022-09-28T15:53:42.319583Z",
   "id" : "lpoz1fy9",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "FGpPdnmb6i"
       ],
       "title" : "rats",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.699870Z",
+  "createdAt" : "2022-09-28T15:53:42.320922Z",
   "id" : "in2u7aru",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "OHrklHuS07"
       ],
       "title" : "capybara",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-28T15:53:42.320922Z",
+  "createdAt" : "2022-09-30T08:11:42.482143Z",
   "id" : "in2u7aru",
   "document" : {
     "debug" : {
@@ -195,6 +195,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-28T15:53:42.322068Z",
+  "createdAt" : "2022-09-30T08:11:42.482544Z",
   "id" : "wkzjlx5a",
   "document" : {
     "debug" : {
@@ -195,6 +195,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.700313Z",
+  "createdAt" : "2022-09-28T15:53:42.322068Z",
   "id" : "wkzjlx5a",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "SKphDnojLC"
       ],
       "title" : "tapirs",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.6.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-28T15:53:42.328301Z",
+  "createdAt" : "2022-09-30T08:11:42.483026Z",
   "id" : "iykrudzs",
   "document" : {
     "debug" : {
@@ -195,6 +195,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.6.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.6.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.700810Z",
+  "createdAt" : "2022-09-28T15:53:42.328301Z",
   "id" : "iykrudzs",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "QnjXRANbEF"
       ],
       "title" : "rats",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.7.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-28T15:53:42.333284Z",
+  "createdAt" : "2022-09-30T08:11:42.484101Z",
   "id" : "pskvh87t",
   "document" : {
     "debug" : {
@@ -195,6 +195,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.7.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.7.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.701369Z",
+  "createdAt" : "2022-09-28T15:53:42.333284Z",
   "id" : "pskvh87t",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "lBGTOMLJUB"
       ],
       "title" : "capybara",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.8.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-28T15:53:42.334770Z",
+  "createdAt" : "2022-09-30T08:11:42.485431Z",
   "id" : "k57syong",
   "document" : {
     "debug" : {
@@ -195,6 +195,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.8.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.8.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.701927Z",
+  "createdAt" : "2022-09-28T15:53:42.334770Z",
   "id" : "k57syong",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "czKSHpT0IR"
       ],
       "title" : "tapirs",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.9.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-26T11:29:28.702525Z",
+  "createdAt" : "2022-09-28T15:53:42.337374Z",
   "id" : "lkq8nygj",
   "document" : {
     "debug" : {
@@ -152,6 +152,8 @@
         "UBhh45MMdu"
       ],
       "title" : "rats",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -192,12 +194,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.9.json
+++ b/common/search/src/test/resources/test_documents/works.examples.filtered-aggregations-tests.9.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the works filtered aggregations tests",
-  "createdAt" : "2022-09-28T15:53:42.337374Z",
+  "createdAt" : "2022-09-30T08:11:42.486946Z",
   "id" : "lkq8nygj",
   "document" : {
     "debug" : {
@@ -195,6 +195,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-26T11:29:28.390646Z",
+  "createdAt" : "2022-09-28T15:53:41.740845Z",
   "id" : "jywtq4xg",
   "document" : {
     "debug" : {
@@ -179,6 +179,8 @@
         "LgGFRAV0Zs"
       ],
       "title" : "title-ZEnp6i2y6i",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -221,12 +223,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-28T15:53:41.740845Z",
+  "createdAt" : "2022-09-30T08:11:42.181156Z",
   "id" : "jywtq4xg",
   "document" : {
     "debug" : {
@@ -224,6 +224,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-26T11:29:28.391574Z",
+  "createdAt" : "2022-09-28T15:53:41.749659Z",
   "id" : "ahr8n4ei",
   "document" : {
     "debug" : {
@@ -179,6 +179,8 @@
         "g4JnCRDZnk"
       ],
       "title" : "title-Rew3RmJ48v",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -221,12 +223,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-28T15:53:41.749659Z",
+  "createdAt" : "2022-09-30T08:11:42.182825Z",
   "id" : "ahr8n4ei",
   "document" : {
     "debug" : {
@@ -224,6 +224,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-28T15:53:41.753164Z",
+  "createdAt" : "2022-09-30T08:11:42.184626Z",
   "id" : "yhjhxcof",
   "document" : {
     "debug" : {
@@ -224,6 +224,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-26T11:29:28.392276Z",
+  "createdAt" : "2022-09-28T15:53:41.753164Z",
   "id" : "yhjhxcof",
   "document" : {
     "debug" : {
@@ -179,6 +179,8 @@
         "lydjDVoexx"
       ],
       "title" : "title-wsvmZKLOsI",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -221,12 +223,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-26T11:29:28.393018Z",
+  "createdAt" : "2022-09-28T15:53:41.763522Z",
   "id" : "1mqutqzm",
   "document" : {
     "debug" : {
@@ -179,6 +179,8 @@
         "EmqhmRoJyr"
       ],
       "title" : "title-bPJWDqmpbe",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -221,12 +223,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-28T15:53:41.763522Z",
+  "createdAt" : "2022-09-30T08:11:42.186652Z",
   "id" : "1mqutqzm",
   "document" : {
     "debug" : {
@@ -224,6 +224,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-28T15:53:41.769527Z",
+  "createdAt" : "2022-09-30T08:11:42.189933Z",
   "id" : "4btprmwn",
   "document" : {
     "debug" : {
@@ -320,6 +320,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-26T11:29:28.394343Z",
+  "createdAt" : "2022-09-28T15:53:41.769527Z",
   "id" : "4btprmwn",
   "document" : {
     "debug" : {
@@ -267,6 +267,8 @@
         "C7XCeymDdf"
       ],
       "title" : "title-iLGpm85YYF",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -317,12 +319,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-28T15:53:41.772396Z",
+  "createdAt" : "2022-09-30T08:11:42.191071Z",
   "id" : "oo0o5odf",
   "document" : {
     "debug" : {
@@ -176,6 +176,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.genre-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the genre tests",
-  "createdAt" : "2022-09-26T11:29:28.394959Z",
+  "createdAt" : "2022-09-28T15:53:41.772396Z",
   "id" : "oo0o5odf",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "T9fhswtSuP"
       ],
       "title" : "title-odercwIWKJ",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-26T11:29:28.430885Z",
+  "createdAt" : "2022-09-28T15:53:41.837932Z",
   "id" : "tayys6jp",
   "document" : {
     "debug" : {
@@ -220,6 +220,8 @@
         "3OfWNE6m5y"
       ],
       "title" : "title-JiYzJ9DWDL",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -263,12 +265,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.0.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-28T15:53:41.837932Z",
+  "createdAt" : "2022-10-01T19:21:01.779185Z",
   "id" : "tayys6jp",
   "document" : {
     "debug" : {
@@ -161,7 +161,7 @@
             {
               "identifierType" : {
                 "id" : "nlm-mesh",
-                "label" : "Medical Subject Headings (MESH) identifier",
+                "label" : "Medical Subject Headings (MeSH) identifier",
                 "type" : "IdentifierType"
               },
               "value" : "mesh-sanitation",
@@ -266,6 +266,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-28T15:53:41.840248Z",
+  "createdAt" : "2022-09-30T08:11:42.235006Z",
   "id" : "zwggainv",
   "document" : {
     "debug" : {
@@ -227,6 +227,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.1.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-26T11:29:28.431846Z",
+  "createdAt" : "2022-09-28T15:53:41.840248Z",
   "id" : "zwggainv",
   "document" : {
     "debug" : {
@@ -182,6 +182,8 @@
         "RdbNpFC2P5"
       ],
       "title" : "title-k5aVuGQD3S",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -224,12 +226,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-28T15:53:41.842446Z",
+  "createdAt" : "2022-09-30T08:11:42.235748Z",
   "id" : "mazaizfa",
   "document" : {
     "debug" : {
@@ -227,6 +227,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.2.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-26T11:29:28.432760Z",
+  "createdAt" : "2022-09-28T15:53:41.842446Z",
   "id" : "mazaizfa",
   "document" : {
     "debug" : {
@@ -182,6 +182,8 @@
         "QFJOR9VqAE"
       ],
       "title" : "title-vTVR490Vab",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -224,12 +226,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-26T11:29:28.433704Z",
+  "createdAt" : "2022-09-28T15:53:41.845504Z",
   "id" : "b1r485o0",
   "document" : {
     "debug" : {
@@ -204,6 +204,8 @@
         "4zh18D0cbF"
       ],
       "title" : "title-DxPLXKke6N",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -247,12 +249,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.3.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-28T15:53:41.845504Z",
+  "createdAt" : "2022-09-30T08:11:42.236572Z",
   "id" : "b1r485o0",
   "document" : {
     "debug" : {
@@ -250,6 +250,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-28T15:53:41.849256Z",
+  "createdAt" : "2022-09-30T08:11:42.238356Z",
   "id" : "gmzc1icz",
   "document" : {
     "debug" : {
@@ -352,6 +352,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.4.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-26T11:29:28.435096Z",
+  "createdAt" : "2022-09-28T15:53:41.849256Z",
   "id" : "gmzc1icz",
   "document" : {
     "debug" : {
@@ -298,6 +298,8 @@
         "Q8QOPJdAXF"
       ],
       "title" : "title-vNWbRfsAZ5",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -349,12 +351,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-26T11:29:28.436784Z",
+  "createdAt" : "2022-09-28T15:53:41.851230Z",
   "id" : "rbao66qq",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "5hoUH5ZhFq"
       ],
       "title" : "title-bcmHn7act9",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.5.json
+++ b/common/search/src/test/resources/test_documents/works.examples.subject-filters-tests.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "examples for the subject filter tests",
-  "createdAt" : "2022-09-28T15:53:41.851230Z",
+  "createdAt" : "2022-09-30T08:11:42.240469Z",
   "id" : "rbao66qq",
   "document" : {
     "debug" : {
@@ -176,6 +176,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.0.Books.json
+++ b/common/search/src/test/resources/test_documents/works.formats.0.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.616384Z",
+  "createdAt" : "2022-09-28T15:53:39.524543Z",
   "id" : "gfw8fs9l",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "wayOhJ3Mha"
       ],
       "title" : "A work with format Books",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.formats.0.Books.json
+++ b/common/search/src/test/resources/test_documents/works.formats.0.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-28T15:53:39.524543Z",
+  "createdAt" : "2022-09-30T08:11:41.355594Z",
   "id" : "gfw8fs9l",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.1.Books.json
+++ b/common/search/src/test/resources/test_documents/works.formats.1.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-28T15:53:39.553432Z",
+  "createdAt" : "2022-09-30T08:11:41.364805Z",
   "id" : "ciweswu5",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.1.Books.json
+++ b/common/search/src/test/resources/test_documents/works.formats.1.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.623345Z",
+  "createdAt" : "2022-09-28T15:53:39.553432Z",
   "id" : "ciweswu5",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "ESu6j0cajz"
       ],
       "title" : "A work with format Books",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.formats.2.Books.json
+++ b/common/search/src/test/resources/test_documents/works.formats.2.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.630005Z",
+  "createdAt" : "2022-09-28T15:53:39.571734Z",
   "id" : "j27g6hhl",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "vyeItSna2X"
       ],
       "title" : "A work with format Books",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.formats.2.Books.json
+++ b/common/search/src/test/resources/test_documents/works.formats.2.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-28T15:53:39.571734Z",
+  "createdAt" : "2022-09-30T08:11:41.372122Z",
   "id" : "j27g6hhl",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.3.Books.json
+++ b/common/search/src/test/resources/test_documents/works.formats.3.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.635967Z",
+  "createdAt" : "2022-09-28T15:53:39.594817Z",
   "id" : "bujceq4p",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "HuLHN83UU0"
       ],
       "title" : "A work with format Books",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.formats.3.Books.json
+++ b/common/search/src/test/resources/test_documents/works.formats.3.Books.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-28T15:53:39.594817Z",
+  "createdAt" : "2022-09-30T08:11:41.379547Z",
   "id" : "bujceq4p",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.4.Journals.json
+++ b/common/search/src/test/resources/test_documents/works.formats.4.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-28T15:53:39.623686Z",
+  "createdAt" : "2022-09-30T08:11:41.386386Z",
   "id" : "wqcumcet",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.4.Journals.json
+++ b/common/search/src/test/resources/test_documents/works.formats.4.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.641905Z",
+  "createdAt" : "2022-09-28T15:53:39.623686Z",
   "id" : "wqcumcet",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "vc628Sgu9f"
       ],
       "title" : "A work with format Journals",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.formats.5.Journals.json
+++ b/common/search/src/test/resources/test_documents/works.formats.5.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.648234Z",
+  "createdAt" : "2022-09-28T15:53:39.643198Z",
   "id" : "plmmmkup",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "X7kBc19InD"
       ],
       "title" : "A work with format Journals",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.formats.5.Journals.json
+++ b/common/search/src/test/resources/test_documents/works.formats.5.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-28T15:53:39.643198Z",
+  "createdAt" : "2022-09-30T08:11:41.395324Z",
   "id" : "plmmmkup",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.6.Journals.json
+++ b/common/search/src/test/resources/test_documents/works.formats.6.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.655877Z",
+  "createdAt" : "2022-09-28T15:53:39.665389Z",
   "id" : "xc5d7pc4",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "HXsUYY6dN4"
       ],
       "title" : "A work with format Journals",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.formats.6.Journals.json
+++ b/common/search/src/test/resources/test_documents/works.formats.6.Journals.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-28T15:53:39.665389Z",
+  "createdAt" : "2022-09-30T08:11:41.403746Z",
   "id" : "xc5d7pc4",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.7.Audio.json
+++ b/common/search/src/test/resources/test_documents/works.formats.7.Audio.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.665058Z",
+  "createdAt" : "2022-09-28T15:53:39.681956Z",
   "id" : "t3q2ufnz",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "nNHPpdWbrm"
       ],
       "title" : "A work with format Audio",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.formats.7.Audio.json
+++ b/common/search/src/test/resources/test_documents/works.formats.7.Audio.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-28T15:53:39.681956Z",
+  "createdAt" : "2022-09-30T08:11:41.410200Z",
   "id" : "t3q2ufnz",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.8.Audio.json
+++ b/common/search/src/test/resources/test_documents/works.formats.8.Audio.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-28T15:53:39.701423Z",
+  "createdAt" : "2022-09-30T08:11:41.416366Z",
   "id" : "elrgwjtd",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.formats.8.Audio.json
+++ b/common/search/src/test/resources/test_documents/works.formats.8.Audio.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.675735Z",
+  "createdAt" : "2022-09-28T15:53:39.701423Z",
   "id" : "elrgwjtd",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "RMKkkMWH2B"
       ],
       "title" : "A work with format Audio",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.formats.9.Pictures.json
+++ b/common/search/src/test/resources/test_documents/works.formats.9.Pictures.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-26T11:29:27.686618Z",
+  "createdAt" : "2022-09-28T15:53:39.718631Z",
   "id" : "sym6ne7x",
   "document" : {
     "debug" : {
@@ -143,6 +143,8 @@
         "FRzpe3bQyh"
       ],
       "title" : "A work with format Pictures",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -181,12 +183,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.formats.9.Pictures.json
+++ b/common/search/src/test/resources/test_documents/works.formats.9.Pictures.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of formats",
-  "createdAt" : "2022-09-28T15:53:39.718631Z",
+  "createdAt" : "2022-09-30T08:11:41.423156Z",
   "id" : "sym6ne7x",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.genres.json
+++ b/common/search/src/test/resources/test_documents/works.genres.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with different concepts in the genre",
-  "createdAt" : "2022-09-28T15:53:40.005116Z",
+  "createdAt" : "2022-09-30T08:11:41.557882Z",
   "id" : "2zo588up",
   "document" : {
     "debug" : {
@@ -247,6 +247,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.genres.json
+++ b/common/search/src/test/resources/test_documents/works.genres.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with different concepts in the genre",
-  "createdAt" : "2022-09-26T11:29:27.832681Z",
+  "createdAt" : "2022-09-28T15:53:40.005116Z",
   "id" : "2zo588up",
   "document" : {
     "debug" : {
@@ -202,6 +202,8 @@
         "rVoekomuzt"
       ],
       "title" : "A work with different concepts in the genre",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -244,12 +246,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.0.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-26T11:29:27.784973Z",
+  "createdAt" : "2022-09-28T15:53:39.880995Z",
   "id" : "yodfctxx",
   "document" : {
     "debug" : {
@@ -182,6 +182,8 @@
         "HfU454vgiI"
       ],
       "title" : "title-AIpgBtHAhx",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -222,12 +224,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.0.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-28T15:53:39.880995Z",
+  "createdAt" : "2022-09-30T08:11:41.498839Z",
   "id" : "yodfctxx",
   "document" : {
     "debug" : {
@@ -225,6 +225,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.1.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-28T15:53:39.884477Z",
+  "createdAt" : "2022-09-30T08:11:41.499838Z",
   "id" : "runiusy8",
   "document" : {
     "debug" : {
@@ -227,6 +227,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.1.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-26T11:29:27.785908Z",
+  "createdAt" : "2022-09-28T15:53:39.884477Z",
   "id" : "runiusy8",
   "document" : {
     "debug" : {
@@ -184,6 +184,8 @@
         "ZGWEGMyTaq"
       ],
       "title" : "title-wjvsf3c3yc",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -224,12 +226,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.2.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-28T15:53:39.888761Z",
+  "createdAt" : "2022-09-30T08:11:41.500876Z",
   "id" : "ougtipki",
   "document" : {
     "debug" : {
@@ -225,6 +225,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.2.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-26T11:29:27.786906Z",
+  "createdAt" : "2022-09-28T15:53:39.888761Z",
   "id" : "ougtipki",
   "document" : {
     "debug" : {
@@ -182,6 +182,8 @@
         "fbITZO5oAg"
       ],
       "title" : "title-pEBp6sf3WU",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -222,12 +224,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.3.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-26T11:29:27.788234Z",
+  "createdAt" : "2022-09-28T15:53:39.894047Z",
   "id" : "rstrzip9",
   "document" : {
     "debug" : {
@@ -233,6 +233,8 @@
         "AbkJTEEoLH"
       ],
       "title" : "title-7h7G222BsR",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -275,12 +277,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.3.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-28T15:53:39.894047Z",
+  "createdAt" : "2022-09-30T08:11:41.502074Z",
   "id" : "rstrzip9",
   "document" : {
     "debug" : {
@@ -278,6 +278,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.4.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-28T15:53:39.895662Z",
+  "createdAt" : "2022-09-30T08:11:41.502632Z",
   "id" : "vwg1cj2y",
   "document" : {
     "debug" : {
@@ -176,6 +176,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-licenses.4.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-licenses.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work with licensed digital items",
-  "createdAt" : "2022-09-26T11:29:27.788862Z",
+  "createdAt" : "2022-09-28T15:53:39.895662Z",
   "id" : "vwg1cj2y",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "FIC2DNd6NA"
       ],
       "title" : "title-YmmH4BoIsw",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.0.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-26T11:29:27.941844Z",
+  "createdAt" : "2022-09-28T15:53:40.323642Z",
   "id" : "qjnwiqbs",
   "document" : {
     "debug" : {
@@ -218,6 +218,8 @@
         "Jj1GugWgka"
       ],
       "title" : "title-m47LFZN2Zg",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -261,12 +263,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.0.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-28T15:53:40.323642Z",
+  "createdAt" : "2022-09-30T08:11:41.706587Z",
   "id" : "qjnwiqbs",
   "document" : {
     "debug" : {
@@ -264,6 +264,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.1.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-28T15:53:40.333398Z",
+  "createdAt" : "2022-09-30T08:11:41.709806Z",
   "id" : "upm4bal7",
   "document" : {
     "debug" : {
@@ -265,6 +265,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.1.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-26T11:29:27.942701Z",
+  "createdAt" : "2022-09-28T15:53:40.333398Z",
   "id" : "upm4bal7",
   "document" : {
     "debug" : {
@@ -219,6 +219,8 @@
         "wkKE1s2opA"
       ],
       "title" : "title-lcjNV5vdX9",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -262,12 +264,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.2.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-28T15:53:40.339453Z",
+  "createdAt" : "2022-09-30T08:11:41.710908Z",
   "id" : "zbejhda8",
   "document" : {
     "debug" : {
@@ -265,6 +265,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.2.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-26T11:29:27.943533Z",
+  "createdAt" : "2022-09-28T15:53:40.339453Z",
   "id" : "zbejhda8",
   "document" : {
     "debug" : {
@@ -219,6 +219,8 @@
         "l7ykrmHfSg"
       ],
       "title" : "title-yvIxyfRHMd",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -262,12 +264,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.3.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-28T15:53:40.346511Z",
+  "createdAt" : "2022-09-30T08:11:41.712015Z",
   "id" : "pex9vogp",
   "document" : {
     "debug" : {
@@ -266,6 +266,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.3.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-26T11:29:27.944456Z",
+  "createdAt" : "2022-09-28T15:53:40.346511Z",
   "id" : "pex9vogp",
   "document" : {
     "debug" : {
@@ -220,6 +220,8 @@
         "MEUfT3H8Xn"
       ],
       "title" : "title-YI3LUHDJYY",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -263,12 +265,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.4.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-26T11:29:27.945397Z",
+  "createdAt" : "2022-09-28T15:53:40.349899Z",
   "id" : "c5xw2xfj",
   "document" : {
     "debug" : {
@@ -220,6 +220,8 @@
         "fREqoThymw"
       ],
       "title" : "title-jI6EjEMJ47",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -263,12 +265,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.4.json
+++ b/common/search/src/test/resources/test_documents/works.items-with-other-identifiers.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with items with other identifiers",
-  "createdAt" : "2022-09-28T15:53:40.349899Z",
+  "createdAt" : "2022-09-30T08:11:41.712991Z",
   "id" : "c5xw2xfj",
   "document" : {
     "debug" : {
@@ -266,6 +266,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.languages.0.eng.json
+++ b/common/search/src/test/resources/test_documents/works.languages.0.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-28T15:53:39.764288Z",
+  "createdAt" : "2022-09-30T08:11:41.449268Z",
   "id" : "i8zcsj78",
   "document" : {
     "debug" : {
@@ -187,6 +187,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.languages.0.eng.json
+++ b/common/search/src/test/resources/test_documents/works.languages.0.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-26T11:29:27.721067Z",
+  "createdAt" : "2022-09-28T15:53:39.764288Z",
   "id" : "i8zcsj78",
   "document" : {
     "debug" : {
@@ -144,6 +144,8 @@
         "ZquhBnzQPW"
       ],
       "title" : "A work with languages English",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -184,12 +186,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.languages.1.eng.json
+++ b/common/search/src/test/resources/test_documents/works.languages.1.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-28T15:53:39.779191Z",
+  "createdAt" : "2022-09-30T08:11:41.456696Z",
   "id" : "qn97gvxq",
   "document" : {
     "debug" : {
@@ -187,6 +187,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.languages.1.eng.json
+++ b/common/search/src/test/resources/test_documents/works.languages.1.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-26T11:29:27.735690Z",
+  "createdAt" : "2022-09-28T15:53:39.779191Z",
   "id" : "qn97gvxq",
   "document" : {
     "debug" : {
@@ -144,6 +144,8 @@
         "BbZQhYTTwR"
       ],
       "title" : "A work with languages English",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -184,12 +186,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.languages.2.eng.json
+++ b/common/search/src/test/resources/test_documents/works.languages.2.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-26T11:29:27.743710Z",
+  "createdAt" : "2022-09-28T15:53:39.795282Z",
   "id" : "yhrq0rmr",
   "document" : {
     "debug" : {
@@ -144,6 +144,8 @@
         "tXlgR2VtcJ"
       ],
       "title" : "A work with languages English",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -184,12 +186,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.languages.2.eng.json
+++ b/common/search/src/test/resources/test_documents/works.languages.2.eng.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-28T15:53:39.795282Z",
+  "createdAt" : "2022-09-30T08:11:41.462649Z",
   "id" : "yhrq0rmr",
   "document" : {
     "debug" : {
@@ -187,6 +187,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.languages.3.eng+swe.json
+++ b/common/search/src/test/resources/test_documents/works.languages.3.eng+swe.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-26T11:29:27.754654Z",
+  "createdAt" : "2022-09-28T15:53:39.809811Z",
   "id" : "ioqwetut",
   "document" : {
     "debug" : {
@@ -153,6 +153,8 @@
         "5WuJppwWsm"
       ],
       "title" : "A work with languages English, Swedish",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -195,12 +197,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.languages.3.eng+swe.json
+++ b/common/search/src/test/resources/test_documents/works.languages.3.eng+swe.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-28T15:53:39.809811Z",
+  "createdAt" : "2022-09-30T08:11:41.468505Z",
   "id" : "ioqwetut",
   "document" : {
     "debug" : {
@@ -198,6 +198,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.languages.4.eng+swe+tur.json
+++ b/common/search/src/test/resources/test_documents/works.languages.4.eng+swe+tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-26T11:29:27.761351Z",
+  "createdAt" : "2022-09-28T15:53:39.824813Z",
   "id" : "edfiesed",
   "document" : {
     "debug" : {
@@ -162,6 +162,8 @@
         "tQZYPmQieO"
       ],
       "title" : "A work with languages English, Swedish, Turkish",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -206,12 +208,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.languages.4.eng+swe+tur.json
+++ b/common/search/src/test/resources/test_documents/works.languages.4.eng+swe+tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-28T15:53:39.824813Z",
+  "createdAt" : "2022-09-30T08:11:41.474522Z",
   "id" : "edfiesed",
   "document" : {
     "debug" : {
@@ -209,6 +209,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.languages.5.swe.json
+++ b/common/search/src/test/resources/test_documents/works.languages.5.swe.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-26T11:29:27.768678Z",
+  "createdAt" : "2022-09-28T15:53:39.844267Z",
   "id" : "qfscz1rj",
   "document" : {
     "debug" : {
@@ -144,6 +144,8 @@
         "Gk6juMbOeK"
       ],
       "title" : "A work with languages Swedish",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -184,12 +186,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.languages.5.swe.json
+++ b/common/search/src/test/resources/test_documents/works.languages.5.swe.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-28T15:53:39.844267Z",
+  "createdAt" : "2022-09-30T08:11:41.482442Z",
   "id" : "qfscz1rj",
   "document" : {
     "debug" : {
@@ -187,6 +187,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.languages.6.tur.json
+++ b/common/search/src/test/resources/test_documents/works.languages.6.tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-28T15:53:39.859517Z",
+  "createdAt" : "2022-09-30T08:11:41.490189Z",
   "id" : "yblbdpjf",
   "document" : {
     "debug" : {
@@ -187,6 +187,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.languages.6.tur.json
+++ b/common/search/src/test/resources/test_documents/works.languages.6.tur.json
@@ -1,6 +1,6 @@
 {
   "description" : "one of a list of works with a variety of languages",
-  "createdAt" : "2022-09-26T11:29:27.775151Z",
+  "createdAt" : "2022-09-28T15:53:39.859517Z",
   "id" : "yblbdpjf",
   "document" : {
     "debug" : {
@@ -144,6 +144,8 @@
         "vcw0LP9LzQ"
       ],
       "title" : "A work with languages Turkish",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -184,12 +186,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.0.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-26T11:29:28.147985Z",
+  "createdAt" : "2022-09-28T15:53:40.806288Z",
   "id" : "31spt9st",
   "document" : {
     "debug" : {
@@ -193,6 +193,8 @@
         "WzsZA7OUAa"
       ],
       "title" : "title-QoeggPvgjR",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -231,12 +233,20 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "54blSY3iyd",
+        "rQHICakdbo",
+        "1850"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.0.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-28T15:53:40.806288Z",
+  "createdAt" : "2022-09-30T08:11:41.906128Z",
   "id" : "31spt9st",
   "document" : {
     "debug" : {
@@ -237,6 +237,9 @@
         "54blSY3iyd",
         "rQHICakdbo",
         "1850"
+      ],
+      "production.dates.range.from" : [
+        -3786825600000
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.1.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-28T15:53:40.809016Z",
+  "createdAt" : "2022-09-30T08:11:41.906941Z",
   "id" : "v9is9e3t",
   "document" : {
     "debug" : {
@@ -237,6 +237,9 @@
         "Qjq4EFefGh",
         "SS8PUjTA45",
         "1850-2000"
+      ],
+      "production.dates.range.from" : [
+        -3786825600000
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.1.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-26T11:29:28.148897Z",
+  "createdAt" : "2022-09-28T15:53:40.809016Z",
   "id" : "v9is9e3t",
   "document" : {
     "debug" : {
@@ -193,6 +193,8 @@
         "fZVe3xG7r6"
       ],
       "title" : "title-JGYTcwsJbl",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -231,12 +233,20 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "Qjq4EFefGh",
+        "SS8PUjTA45",
+        "1850-2000"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.2.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-28T15:53:40.811628Z",
+  "createdAt" : "2022-09-30T08:11:41.907875Z",
   "id" : "wg3kq4ux",
   "document" : {
     "debug" : {
@@ -237,6 +237,9 @@
         "YdIXqL6hBi",
         "4EVx0a62zj",
         "1860-1960"
+      ],
+      "production.dates.range.from" : [
+        -3471292800000
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.2.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-26T11:29:28.149815Z",
+  "createdAt" : "2022-09-28T15:53:40.811628Z",
   "id" : "wg3kq4ux",
   "document" : {
     "debug" : {
@@ -193,6 +193,8 @@
         "lfq9upMxJZ"
       ],
       "title" : "title-oirzqph7Io",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -231,12 +233,20 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "YdIXqL6hBi",
+        "4EVx0a62zj",
+        "1860-1960"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.3.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-26T11:29:28.150549Z",
+  "createdAt" : "2022-09-28T15:53:40.813629Z",
   "id" : "q4abgj9v",
   "document" : {
     "debug" : {
@@ -193,6 +193,8 @@
         "09dkccFCHG"
       ],
       "title" : "title-PDvN43mh0p",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -231,12 +233,20 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "aIg4BPWRHb",
+        "uSqTDzUOjO",
+        "1960"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.3.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-28T15:53:40.813629Z",
+  "createdAt" : "2022-09-30T08:11:41.908786Z",
   "id" : "q4abgj9v",
   "document" : {
     "debug" : {
@@ -237,6 +237,9 @@
         "aIg4BPWRHb",
         "uSqTDzUOjO",
         "1960"
+      ],
+      "production.dates.range.from" : [
+        -315619200000
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.4.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-26T11:29:28.151489Z",
+  "createdAt" : "2022-09-28T15:53:40.815999Z",
   "id" : "cuh8ak2g",
   "document" : {
     "debug" : {
@@ -193,6 +193,8 @@
         "KabHlF2fhJ"
       ],
       "title" : "title-PdAnZy8IL7",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -231,12 +233,20 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "QHgcJPyjdm",
+        "hcczXNV4U4",
+        "1960-1964"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.4.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-28T15:53:40.815999Z",
+  "createdAt" : "2022-09-30T08:11:41.909525Z",
   "id" : "cuh8ak2g",
   "document" : {
     "debug" : {
@@ -237,6 +237,9 @@
         "QHgcJPyjdm",
         "hcczXNV4U4",
         "1960-1964"
+      ],
+      "production.dates.range.from" : [
+        -315619200000
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.5.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-26T11:29:28.152645Z",
+  "createdAt" : "2022-09-28T15:53:40.817464Z",
   "id" : "wmzcsqaf",
   "document" : {
     "debug" : {
@@ -193,6 +193,8 @@
         "Kwytcvu6mF"
       ],
       "title" : "title-tBeNhpR5aF",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -231,12 +233,20 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+        "QMh6zvv2Jj",
+        "5pKO9kAlfI",
+        "1962"
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.production.multi-year.5.json
+++ b/common/search/src/test/resources/test_documents/works.production.multi-year.5.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with multi-year production ranges",
-  "createdAt" : "2022-09-28T15:53:40.817464Z",
+  "createdAt" : "2022-09-30T08:11:41.910262Z",
   "id" : "wmzcsqaf",
   "document" : {
     "debug" : {
@@ -237,6 +237,9 @@
         "QMh6zvv2Jj",
         "5pKO9kAlfI",
         "1962"
+      ],
+      "production.dates.range.from" : [
+        -252460800000
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.subjects.0.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-26T11:29:27.840975Z",
+  "createdAt" : "2022-09-28T15:53:40.041971Z",
   "id" : "6uwysojy",
   "document" : {
     "debug" : {
@@ -182,6 +182,8 @@
         "pzLgxSR5EK"
       ],
       "title" : "title-Dtaaw5YmCW",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -224,12 +226,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.subjects.0.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-28T15:53:40.041971Z",
+  "createdAt" : "2022-09-30T08:11:41.572902Z",
   "id" : "6uwysojy",
   "document" : {
     "debug" : {
@@ -227,6 +227,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.subjects.1.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-26T11:29:27.841965Z",
+  "createdAt" : "2022-09-28T15:53:40.046136Z",
   "id" : "mihwfxry",
   "document" : {
     "debug" : {
@@ -182,6 +182,8 @@
         "HypKD9r1zH"
       ],
       "title" : "title-miZHgL6jXR",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -224,12 +226,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.subjects.1.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-28T15:53:40.046136Z",
+  "createdAt" : "2022-09-30T08:11:41.574610Z",
   "id" : "mihwfxry",
   "document" : {
     "debug" : {
@@ -227,6 +227,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.subjects.2.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-28T15:53:40.054330Z",
+  "createdAt" : "2022-09-30T08:11:41.576091Z",
   "id" : "evraub2i",
   "document" : {
     "debug" : {
@@ -227,6 +227,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.subjects.2.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-26T11:29:27.842957Z",
+  "createdAt" : "2022-09-28T15:53:40.054330Z",
   "id" : "evraub2i",
   "document" : {
     "debug" : {
@@ -182,6 +182,8 @@
         "E3Fqby26w1"
       ],
       "title" : "title-sNTcYSKPkF",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -224,12 +226,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.subjects.3.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-26T11:29:27.844207Z",
+  "createdAt" : "2022-09-28T15:53:40.063807Z",
   "id" : "xcssabt1",
   "document" : {
     "debug" : {
@@ -229,6 +229,8 @@
         "7XE0Jxv45o"
       ],
       "title" : "title-p2sZlO6WXi",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -275,12 +277,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.subjects.3.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-28T15:53:40.063807Z",
+  "createdAt" : "2022-09-30T08:11:41.577764Z",
   "id" : "xcssabt1",
   "document" : {
     "debug" : {
@@ -278,6 +278,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.subjects.4.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-28T15:53:40.066015Z",
+  "createdAt" : "2022-09-30T08:11:41.578430Z",
   "id" : "t9nj8zse",
   "document" : {
     "debug" : {
@@ -176,6 +176,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.subjects.4.json
+++ b/common/search/src/test/resources/test_documents/works.subjects.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "works with different subjects",
-  "createdAt" : "2022-09-26T11:29:27.844897Z",
+  "createdAt" : "2022-09-28T15:53:40.066015Z",
   "id" : "t9nj8zse",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "8imBUVPHmu"
       ],
       "title" : "title-9al0iIjgaH",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.title-query-parens.json
+++ b/common/search/src/test/resources/test_documents/works.title-query-parens.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has parens meant to trip up ES",
-  "createdAt" : "2022-09-26T11:29:27.707048Z",
+  "createdAt" : "2022-09-28T15:53:39.746995Z",
   "id" : "omok5a37",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "y59nY1Nuok"
       ],
       "title" : "(a b c d e) h",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.title-query-parens.json
+++ b/common/search/src/test/resources/test_documents/works.title-query-parens.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has parens meant to trip up ES",
-  "createdAt" : "2022-09-28T15:53:39.746995Z",
+  "createdAt" : "2022-09-30T08:11:41.437146Z",
   "id" : "omok5a37",
   "document" : {
     "debug" : {
@@ -176,6 +176,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.title-query-syntax.json
+++ b/common/search/src/test/resources/test_documents/works.title-query-syntax.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has lots of ES query syntax operators",
-  "createdAt" : "2022-09-28T15:53:39.732141Z",
+  "createdAt" : "2022-09-30T08:11:41.430928Z",
   "id" : "hjjs3mu3",
   "document" : {
     "debug" : {
@@ -176,6 +176,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.title-query-syntax.json
+++ b/common/search/src/test/resources/test_documents/works.title-query-syntax.json
@@ -1,6 +1,6 @@
 {
   "description" : "a work whose title has lots of ES query syntax operators",
-  "createdAt" : "2022-09-26T11:29:27.696488Z",
+  "createdAt" : "2022-09-28T15:53:39.732141Z",
   "id" : "hjjs3mu3",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "Z3LIdvnOPk"
       ],
       "title" : "+a -title | with (all the simple) query~4 syntax operators in it*",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.visible.0.json
+++ b/common/search/src/test/resources/test_documents/works.visible.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-28T15:53:36.426844Z",
+  "createdAt" : "2022-09-30T08:11:40.323992Z",
   "id" : "2twopft1",
   "document" : {
     "debug" : {
@@ -176,6 +176,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.visible.0.json
+++ b/common/search/src/test/resources/test_documents/works.visible.0.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-26T11:29:26.462829Z",
+  "createdAt" : "2022-09-28T15:53:36.426844Z",
   "id" : "2twopft1",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "Uaequ81tpB"
       ],
       "title" : "title-vaMzxd8prf",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.visible.1.json
+++ b/common/search/src/test/resources/test_documents/works.visible.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-26T11:29:26.469706Z",
+  "createdAt" : "2022-09-28T15:53:36.443941Z",
   "id" : "dph7sjip",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "WpBejTwv1N"
       ],
       "title" : "title-3hvGdgZfc8",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.visible.1.json
+++ b/common/search/src/test/resources/test_documents/works.visible.1.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-28T15:53:36.443941Z",
+  "createdAt" : "2022-09-30T08:11:40.332534Z",
   "id" : "dph7sjip",
   "document" : {
     "debug" : {
@@ -176,6 +176,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.visible.2.json
+++ b/common/search/src/test/resources/test_documents/works.visible.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-28T15:53:36.447259Z",
+  "createdAt" : "2022-09-30T08:11:40.334343Z",
   "id" : "fyqts0co",
   "document" : {
     "debug" : {
@@ -176,6 +176,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.visible.2.json
+++ b/common/search/src/test/resources/test_documents/works.visible.2.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-26T11:29:26.471498Z",
+  "createdAt" : "2022-09-28T15:53:36.447259Z",
   "id" : "fyqts0co",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "ZvWebpA5WH"
       ],
       "title" : "title-XQqPyuxbr5",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.visible.3.json
+++ b/common/search/src/test/resources/test_documents/works.visible.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-26T11:29:26.473381Z",
+  "createdAt" : "2022-09-28T15:53:36.450910Z",
   "id" : "raob2ruv",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "wyJzS2SuiH"
       ],
       "title" : "title-bFbQPNB7Zu",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/common/search/src/test/resources/test_documents/works.visible.3.json
+++ b/common/search/src/test/resources/test_documents/works.visible.3.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-28T15:53:36.450910Z",
+  "createdAt" : "2022-09-30T08:11:40.335975Z",
   "id" : "raob2ruv",
   "document" : {
     "debug" : {
@@ -176,6 +176,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.visible.4.json
+++ b/common/search/src/test/resources/test_documents/works.visible.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-28T15:53:36.453821Z",
+  "createdAt" : "2022-09-30T08:11:40.337387Z",
   "id" : "vbi1ii19",
   "document" : {
     "debug" : {
@@ -176,6 +176,8 @@
       "contributors.agent.label" : [
       ],
       "production.label" : [
+      ],
+      "production.dates.range.from" : [
       ],
       "partOf.id" : [
       ],

--- a/common/search/src/test/resources/test_documents/works.visible.4.json
+++ b/common/search/src/test/resources/test_documents/works.visible.4.json
@@ -1,6 +1,6 @@
 {
   "description" : "an arbitrary list of visible works",
-  "createdAt" : "2022-09-26T11:29:26.475309Z",
+  "createdAt" : "2022-09-28T15:53:36.453821Z",
   "id" : "vbi1ii19",
   "document" : {
     "debug" : {
@@ -135,6 +135,8 @@
         "CzLNHBFHuR"
       ],
       "title" : "title-jGGR8UNWut",
+      "alternativeTitles" : [
+      ],
       "description" : null,
       "physicalDescription" : null,
       "edition" : null,
@@ -173,12 +175,17 @@
       ],
       "contributors.agent.label" : [
       ],
+      "production.label" : [
+      ],
       "partOf.id" : [
       ],
       "partOf.title" : [
       ],
       "availabilities.id" : [
-      ]
+      ],
+      "collectionPath.label" : null,
+      "collectionPath.path" : null,
+      "referenceNumber" : null
     },
     "aggregatableValues" : {
       "workType" : [

--- a/copy_test_documents.py
+++ b/copy_test_documents.py
@@ -27,3 +27,12 @@ for prefix in prefixes:
                 os.path.basename(path),
             ),
         )
+
+os.rename(
+    "./common/search/src/test/resources/test_documents/WorksIndexConfig.json",
+    "./common/search/src/test/resources/WorksIndexConfig.json",
+)
+os.rename(
+    "./common/search/src/test/resources/test_documents/ImagesIndexConfig.json",
+    "./common/search/src/test/resources/ImagesIndexConfig.json",
+)

--- a/search/src/main/scala/weco/api/search/elasticsearch/FieldWithoutBoost.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/FieldWithoutBoost.scala
@@ -1,0 +1,13 @@
+package weco.api.search.elasticsearch
+
+import com.sksamuel.elastic4s.requests.searches.queries.matches.FieldWithOptionalBoost
+
+object FieldWithBoost {
+  def apply(field: String, boost: Int): FieldWithOptionalBoost =
+    FieldWithOptionalBoost(field, boost = Some(boost.toDouble))
+}
+
+object FieldWithoutBoost {
+  def apply(field: String): FieldWithOptionalBoost =
+    FieldWithOptionalBoost(field, boost = None)
+}

--- a/search/src/main/scala/weco/api/search/elasticsearch/ImagesQuery.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/ImagesQuery.scala
@@ -42,10 +42,13 @@ case object ImageSimilarity {
 case object ImagesMultiMatcher {
 
   private def boostedWorkFields(
-    boost: Option[Double] = None,
+    boost: Int,
     fields: Seq[String]
   ): Seq[FieldWithOptionalBoost] =
-    fields.map(f => FieldWithOptionalBoost(s"source.$f", boost))
+    fields.map(f => FieldWithBoost(s"source.$f", boost))
+
+  private def workFields(fields: Seq[String]): Seq[FieldWithOptionalBoost] =
+    fields.map(f => FieldWithoutBoost(s"source.$f"))
 
   private val titleFields = Seq(
     "data.alternativeTitles",
@@ -54,30 +57,29 @@ case object ImagesMultiMatcher {
     "data.title"
   )
 
-  private val idFields: Seq[FieldWithOptionalBoost] = boostedWorkFields(
+  private val idFields: Seq[FieldWithOptionalBoost] = workFields(
     fields = Seq(
       "id.canonicalId",
       "id.sourceIdentifier.value",
-      "data.otherIdentifiers.value"
+      "data.otherIdentifiers.value",
+      "state.canonicalId",
+      "state.sourceIdentifier.value"
     )
-  ) ++ Seq(
-    "state.canonicalId",
-    "state.sourceIdentifier.value"
-  ).map(FieldWithOptionalBoost(_, None))
+  )
 
   private val dataFields: Seq[FieldWithOptionalBoost] = boostedWorkFields(
-    boost = Some(1000.0),
+    boost = 1000,
     fields = Seq("data.contributors.agent.label")
   ) ++
     boostedWorkFields(
-      boost = Some(10.0),
+      boost = 10,
       fields = Seq(
         "data.subjects.concepts.label",
         "data.genres.concepts.label",
         "data.production.*.label"
       )
     ) ++
-    boostedWorkFields(
+    workFields(
       fields = Seq(
         "data.description",
         "data.physicalDescription",
@@ -123,7 +125,7 @@ case object ImagesMultiMatcher {
               q,
               queryName = Some("title exact spellings"),
               fields = boostedWorkFields(
-                boost = Some(100.0),
+                boost = 100,
                 fields = titleFields
               ),
               `type` = Some(BEST_FIELDS),
@@ -135,7 +137,7 @@ case object ImagesMultiMatcher {
               `type` = Some(BEST_FIELDS),
               operator = Some(AND),
               fields = boostedWorkFields(
-                boost = Some(100.0),
+                boost = 100,
                 fields = languages
                   .flatMap(
                     language =>

--- a/search/src/main/scala/weco/api/search/elasticsearch/ImagesQuery.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/ImagesQuery.scala
@@ -62,10 +62,11 @@ case object ImagesMultiMatcher {
       "id.canonicalId",
       "id.sourceIdentifier.value",
       "data.otherIdentifiers.value",
-      "state.canonicalId",
-      "state.sourceIdentifier.value"
     )
-  )
+  ) ++ Seq(
+    "state.canonicalId",
+    "state.sourceIdentifier.value"
+  ).map(FieldWithoutBoost(_))
 
   private val dataFields: Seq[FieldWithOptionalBoost] = boostedWorkFields(
     boost = 1000,

--- a/search/src/main/scala/weco/api/search/elasticsearch/ImagesQuery.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/ImagesQuery.scala
@@ -61,7 +61,7 @@ case object ImagesMultiMatcher {
     fields = Seq(
       "id.canonicalId",
       "id.sourceIdentifier.value",
-      "data.otherIdentifiers.value",
+      "data.otherIdentifiers.value"
     )
   ) ++ Seq(
     "state.canonicalId",

--- a/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -36,7 +36,7 @@ case object WorksMultiMatcher {
     boost: Int,
     fields: Seq[String]
   ): Seq[FieldWithOptionalBoost] =
-    fields.map(FieldWithOptionalBoost(_, Some(boost.toDouble)))
+    fields.map(FieldWithBoost(_, boost))
 
   def apply(q: String): BoolQuery =
     boolQuery()
@@ -110,10 +110,7 @@ case object WorksMultiMatcher {
               fields =
                 titleAndContributorFields.flatMap(field =>
                   nonEnglishLanguages.map(language =>
-                    FieldWithOptionalBoost(
-                      field = s"$field.$language",
-                      boost = None
-                    )
+                    FieldWithoutBoost(s"$field.$language")
                   )
                 ),
               `type` = Some(BEST_FIELDS),
@@ -129,8 +126,8 @@ case object WorksMultiMatcher {
               `type` = Some(CROSS_FIELDS),
               operator = Some(OR),
               fields = Seq(
-                FieldWithOptionalBoost("query.title", boost = Some(100)),
-                FieldWithOptionalBoost("query.description", boost = Some(10))
+                FieldWithBoost("query.title", boost = 100),
+                FieldWithBoost("query.description", boost = 10)
               )
             )
           ),
@@ -140,13 +137,10 @@ case object WorksMultiMatcher {
               queryName = Some("relations paths"),
               operator = Some(OR),
               fields = Seq(
-                FieldWithOptionalBoost("query.collectionPath.path.clean", None),
-                FieldWithOptionalBoost(
-                  "query.collectionPath.label.cleanPath",
-                  None
-                ),
-                FieldWithOptionalBoost("query.collectionPath.label", None),
-                FieldWithOptionalBoost("query.collectionPath.path.keyword", None)
+                FieldWithoutBoost("query.collectionPath.path.clean"),
+                FieldWithoutBoost("query.collectionPath.label.cleanPath"),
+                FieldWithoutBoost("query.collectionPath.label"),
+                FieldWithoutBoost("query.collectionPath.path.keyword")
               )
             )
           ),

--- a/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -102,8 +102,10 @@ case object WorksMultiMatcher {
                 "german",
                 "hindi",
                 "italian"
-              ).map(language =>
-                FieldWithoutBoost(s"query.titlesAndContributors.$language")),
+              ).map(
+                language =>
+                  FieldWithoutBoost(s"query.titlesAndContributors.$language")
+              ),
               `type` = Some(BEST_FIELDS),
               operator = Some(AND)
             )
@@ -153,7 +155,10 @@ case object WorksMultiMatcher {
             (None, "query.edition"),
             (None, "query.notes.contents"),
             (None, "query.lettering")
-          ).map { case (boost, field) => FieldWithOptionalBoost(field, boost.map(_.toDouble)) }
+          ).map {
+            case (boost, field) =>
+              FieldWithOptionalBoost(field, boost.map(_.toDouble))
+          }
         )
       )
       .minimumShouldMatch(1)

--- a/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -68,8 +68,7 @@ case object WorksMultiMatcher {
               "query.items.identifiers.value",
               "query.images.id",
               "query.images.identifiers.value",
-              "data.referenceNumber",
-              "search.identifiers"
+              "query.referenceNumber",
             )
           )
         ),

--- a/search/src/main/scala/weco/api/search/services/WorksRequestBuilder.scala
+++ b/search/src/main/scala/weco/api/search/services/WorksRequestBuilder.scala
@@ -113,7 +113,7 @@ object WorksRequestBuilder
   private def sort(implicit searchOptions: WorkSearchOptions) =
     searchOptions.sortBy
       .map {
-        case ProductionDateSortRequest => "data.production.dates.range.from"
+        case ProductionDateSortRequest => "query.production.dates.range.from"
       }
       .map { FieldSort(_).order(sortOrder) }
 
@@ -153,7 +153,7 @@ object WorksRequestBuilder
       case DateRangeFilter(fromDate, toDate) =>
         val (gte, lte) =
           (fromDate map ElasticDate.apply, toDate map ElasticDate.apply)
-        RangeQuery("data.production.dates.range.from", lte = lte, gte = gte)
+        RangeQuery("query.production.dates.range.from", lte = lte, gte = gte)
       case LanguagesFilter(languageIds) =>
         termsQuery("query.languages.id", languageIds)
       case GenreFilter(genreQueries) =>

--- a/search/src/test/resources/WorksMultiMatcherQuery.json
+++ b/search/src/test/resources/WorksMultiMatcherQuery.json
@@ -24,7 +24,6 @@
             "query.images.id^1000.0",
             "query.images.identifiers.value^1000.0",
             "data.referenceNumber^1000.0",
-            "search.identifiers^1000.0"
           ],
           "type": "best_fields",
           "analyzer": "whitespace_analyzer",

--- a/search/src/test/resources/WorksMultiMatcherQuery.json
+++ b/search/src/test/resources/WorksMultiMatcherQuery.json
@@ -23,7 +23,8 @@
             "query.items.identifiers.value^1000.0",
             "query.images.id^1000.0",
             "query.images.identifiers.value^1000.0",
-            "query.referenceNumber^1000.0"
+            "query.referenceNumber^1000.0",
+            "query.allIdentifiers^1000.0"
           ],
           "type": "best_fields",
           "analyzer": "whitespace_analyzer",
@@ -38,15 +39,9 @@
               "multi_match": {
                 "query": "{{query}}",
                 "fields": [
-                  "query.title^100.0",
-                  "query.title.english^100.0",
-                  "query.title.shingles^100.0",
-                  "query.alternativeTitles^100.0",
-                  "query.alternativeTitles.english^100.0",
-                  "query.alternativeTitles.shingles^100.0",
-                  "query.contributors.agent.label^100.0",
-                  "query.contributors.agent.label.english^100.0",
-                  "query.contributors.agent.label.shingles^100.0"
+                  "query.titlesAndContributors^100.0",
+                  "query.titlesAndContributors.english^100.0",
+                  "query.titlesAndContributors.shingles^100.0"
                 ],
                 "type": "best_fields",
                 "operator": "And",
@@ -57,24 +52,12 @@
               "multi_match": {
                 "query": "{{query}}",
                 "fields": [
-                  "search.title.arabic",
-                  "search.title.bengali",
-                  "search.title.french",
-                  "search.title.german",
-                  "search.title.hindi",
-                  "search.title.italian",
-                  "search.alternativeTitles.arabic",
-                  "search.alternativeTitles.bengali",
-                  "search.alternativeTitles.french",
-                  "search.alternativeTitles.german",
-                  "search.alternativeTitles.hindi",
-                  "search.alternativeTitles.italian",
-                  "search.contributors.agent.label.arabic",
-                  "search.contributors.agent.label.bengali",
-                  "search.contributors.agent.label.french",
-                  "search.contributors.agent.label.german",
-                  "search.contributors.agent.label.hindi",
-                  "search.contributors.agent.label.italian"
+                  "query.titlesAndContributors.arabic",
+                  "query.titlesAndContributors.bengali",
+                  "query.titlesAndContributors.french",
+                  "query.titlesAndContributors.german",
+                  "query.titlesAndContributors.hindi",
+                  "query.titlesAndContributors.italian"
                 ],
                 "type": "best_fields",
                 "operator": "And",

--- a/search/src/test/resources/WorksMultiMatcherQuery.json
+++ b/search/src/test/resources/WorksMultiMatcherQuery.json
@@ -23,7 +23,7 @@
             "query.items.identifiers.value^1000.0",
             "query.images.id^1000.0",
             "query.images.identifiers.value^1000.0",
-            "data.referenceNumber^1000.0",
+            "query.referenceNumber^1000.0"
           ],
           "type": "best_fields",
           "analyzer": "whitespace_analyzer",
@@ -38,9 +38,15 @@
               "multi_match": {
                 "query": "{{query}}",
                 "fields": [
-                  "search.titlesAndContributors^100.0",
-                  "search.titlesAndContributors.english^100.0",
-                  "search.titlesAndContributors.shingles^100.0"
+                  "query.title^100.0",
+                  "query.title.english^100.0",
+                  "query.title.shingles^100.0",
+                  "query.alternativeTitles^100.0",
+                  "query.alternativeTitles.english^100.0",
+                  "query.alternativeTitles.shingles^100.0",
+                  "query.contributors.agent.label^100.0",
+                  "query.contributors.agent.label.english^100.0",
+                  "query.contributors.agent.label.shingles^100.0"
                 ],
                 "type": "best_fields",
                 "operator": "And",
@@ -51,12 +57,24 @@
               "multi_match": {
                 "query": "{{query}}",
                 "fields": [
-                  "search.titlesAndContributors.arabic",
-                  "search.titlesAndContributors.bengali",
-                  "search.titlesAndContributors.french",
-                  "search.titlesAndContributors.german",
-                  "search.titlesAndContributors.hindi",
-                  "search.titlesAndContributors.italian"
+                  "search.title.arabic",
+                  "search.title.bengali",
+                  "search.title.french",
+                  "search.title.german",
+                  "search.title.hindi",
+                  "search.title.italian",
+                  "search.alternativeTitles.arabic",
+                  "search.alternativeTitles.bengali",
+                  "search.alternativeTitles.french",
+                  "search.alternativeTitles.german",
+                  "search.alternativeTitles.hindi",
+                  "search.alternativeTitles.italian",
+                  "search.contributors.agent.label.arabic",
+                  "search.contributors.agent.label.bengali",
+                  "search.contributors.agent.label.french",
+                  "search.contributors.agent.label.german",
+                  "search.contributors.agent.label.hindi",
+                  "search.contributors.agent.label.italian"
                 ],
                 "type": "best_fields",
                 "operator": "And",
@@ -83,10 +101,10 @@
             {
               "multi_match": {
                 "fields": [
-                  "data.collectionPath.path.clean",
-                  "data.collectionPath.label.cleanPath",
-                  "data.collectionPath.label",
-                  "data.collectionPath.path.keyword"
+                  "query.collectionPath.path.clean",
+                  "query.collectionPath.label.cleanPath",
+                  "query.collectionPath.label",
+                  "query.collectionPath.path.keyword"
                 ],
                 "query": "{{query}}",
                 "operator": "Or",
@@ -103,7 +121,7 @@
             "query.contributors.agent.label^1000.0",
             "query.subjects.concepts.label^10.0",
             "query.genres.concepts.label^10.0",
-            "data.production.*.label^10.0",
+            "query.production.label^10.0",
             "query.description",
             "query.physicalDescription",
             "query.languages.label",

--- a/search/src/test/resources/expected_responses/include-image-contributors.json
+++ b/search/src/test/resources/expected_responses/include-image-contributors.json
@@ -37,6 +37,7 @@
     }
   ],
   "aspectRatio" : 0.022521317,
+  "averageColor": "#62C3E1",
   "source" : {
     "id" : "64m9ngi3",
     "title" : "Apple agitator",

--- a/search/src/test/resources/expected_responses/include-image-genres.json
+++ b/search/src/test/resources/expected_responses/include-image-genres.json
@@ -37,6 +37,7 @@
     }
   ],
   "aspectRatio" : 0.022521317,
+  "averageColor" : "#62C3E1",
   "source" : {
     "id" : "64m9ngi3",
     "title" : "Apple agitator",

--- a/search/src/test/resources/expected_responses/include-image-languages.json
+++ b/search/src/test/resources/expected_responses/include-image-languages.json
@@ -37,6 +37,7 @@
     }
   ],
   "aspectRatio" : 0.022521317,
+  "averageColor" : "#62C3E1",
   "source" : {
     "id" : "64m9ngi3",
     "title" : "Apple agitator",

--- a/search/src/test/resources/expected_responses/include-list-contributors.json
+++ b/search/src/test/resources/expected_responses/include-list-contributors.json
@@ -40,6 +40,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#62C3E1",
       "source" : {
         "id" : "64m9ngi3",
         "title" : "Apple agitator",

--- a/search/src/test/resources/expected_responses/include-list-genres.json
+++ b/search/src/test/resources/expected_responses/include-list-genres.json
@@ -40,6 +40,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#62C3E1",
       "source" : {
         "id" : "64m9ngi3",
         "title" : "Apple agitator",

--- a/search/src/test/resources/expected_responses/include-list-languages.json
+++ b/search/src/test/resources/expected_responses/include-list-languages.json
@@ -40,6 +40,7 @@
         }
       ],
       "aspectRatio" : 0.022521317,
+      "averageColor" : "#62C3E1",
       "source" : {
         "id" : "64m9ngi3",
         "title" : "Apple agitator",

--- a/search/src/test/resources/expected_responses/visually-similar-features-and-palettes.json
+++ b/search/src/test/resources/expected_responses/visually-similar-features-and-palettes.json
@@ -1,5 +1,6 @@
 {
   "aspectRatio" : 0.022521317,
+  "averageColor" : "#9BF5AA",
   "id" : "qdgvzuta",
   "locations" : [
     {

--- a/search/src/test/resources/expected_responses/visually-similar-features.json
+++ b/search/src/test/resources/expected_responses/visually-similar-features.json
@@ -1,5 +1,6 @@
 {
   "aspectRatio" : 0.022521317,
+  "averageColor" : "#6E7D23",
   "id" : "rlj2t5sp",
   "locations" : [
     {

--- a/search/src/test/resources/expected_responses/visually-similar-palettes.json
+++ b/search/src/test/resources/expected_responses/visually-similar-palettes.json
@@ -1,5 +1,6 @@
 {
   "aspectRatio" : 0.022521317,
+  "averageColor" : "#C8FF74",
   "id" : "lerxblzo",
   "locations" : [
     {

--- a/search/src/test/scala/weco/api/search/images/ImagesIncludesTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesIncludesTest.scala
@@ -112,6 +112,7 @@ class ImagesIncludesTest extends ApiImagesTestBase {
                         }
                       ],
                       "aspectRatio" : 0.022521317,
+                      "averageColor" : "#FFF94E",
                       "source" : {
                         "id" : "kxd5hg2c",
                         "title" : "title-UXbrIVN9As",
@@ -243,6 +244,7 @@ class ImagesIncludesTest extends ApiImagesTestBase {
                     }
                   ],
                   "aspectRatio" : 0.022521317,
+                  "averageColor" : "#FFF94E",
                   "source" : {
                     "id" : "kxd5hg2c",
                     "title" : "title-UXbrIVN9As",


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5550; follows https://github.com/wellcomecollection/catalogue-pipeline/pull/2214 and https://github.com/wellcomecollection/catalogue-pipeline/pull/2216.

After this patch, everything work-related is being fetched from the `display`, `query`, or `type` fields.

There's a non-trivial change here: I've stopped using the copyTo fields:

* `search.identifiers` – this was completely redundant after the query restructuring. The clause in the WorksMultiMatcher query that used it was also searching all the fields that get copied into this field.
* `search.titlesAndContributors` – once I'd ditched `search.identifiers`, this felt like a weird standout, so I replaced it with searching the individual fields. IMO this will allow us to simplify the index mapping.

This may have implications for query performance/behaviour, so I’d like @harrisonpim to look at this when he’s back on Monday. I think it's fine, but I don't know why we do it this way and there might be a good reason to keep the old behaviour. (If we do, should we lean into it more and _only_ search `search.identifiers`/`query.allIdentifiers`?)