### PR TITLE
Run rank tests against the pipeline cluster in CI

### DIFF
--- a/.buildkite/pipeline.rank.yml
+++ b/.buildkite/pipeline.rank.yml
@@ -2,3 +2,6 @@ steps:
   - command: ./.buildkite/scripts/test_rank.sh
     env:
       QUERY_ENV: "production"
+    plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::756629837203:role/catalogue-ci"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,6 +74,9 @@ steps:
     label: "rank"
     env:
       QUERY_ENV: "candidate"
+    plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::756629837203:role/catalogue-ci"
 
   - wait
 

--- a/.buildkite/scripts/test_rank.sh
+++ b/.buildkite/scripts/test_rank.sh
@@ -36,6 +36,9 @@ URL="https://${SUBDOMAIN}.wellcomecollection.org/catalogue/v2/_elasticConfig"
 # run works tests
 WORKS_INDEX=$(curl -s "${URL}" | jq -r .worksIndex)
 docker run \
+    -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+    -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+    -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
     -v $HOME/.aws:/root/.aws \
     -v $(pwd):/catalogue-api \
     --workdir /catalogue-api/rank \
@@ -51,6 +54,9 @@ docker run \
 # run images tests
 IMAGES_INDEX=$(curl -s "${URL}" | jq -r .imagesIndex)
 docker run \
+    -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+    -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+    -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN \
     -v $HOME/.aws:/root/.aws \
     -v $(pwd):/catalogue-api \
     --workdir /catalogue-api/rank \

--- a/.buildkite/scripts/test_rank.sh
+++ b/.buildkite/scripts/test_rank.sh
@@ -42,6 +42,7 @@ docker run \
     public.ecr.aws/docker/library/node:14-slim \
     yarn test \
         --queryEnv=$QUERY_ENV \
+        --cluster=pipeline \
         --index="$WORKS_INDEX" \
         --testId=alternative-spellings \
         --testId=precision \
@@ -56,6 +57,7 @@ docker run \
     public.ecr.aws/docker/library/node:14-slim \
     yarn test \
         --queryEnv=$QUERY_ENV \
+        --cluster=pipeline \
         --index="$IMAGES_INDEX" \
         --testId=alternative-spellings \
         --testId=precision \

--- a/rank/README.md
+++ b/rank/README.md
@@ -28,6 +28,14 @@ docker run -it \
 
 </details>
 
+## Choosing a cluster to run tests against
+
+Running rank locally allows you to test against the `pipeline` or `rank` cluster.
+
+You should almost always choose to run local experiments against the `rank` cluster with indices replicated from the `pipeline` cluster (see more details and instructions [here](../docs/search/rank/cluster.md)). The pipeline cluster is used directly by the API, so experimenting against it can be dangerous.
+
+To minimise the risks associated with automated cross cluster replication, we run rank in CI against the `pipeline` cluster. The tests in CI use known queries, so we're much less likely to affect the performance of the API.
+
 ## Docs 📖
 
 Rank documentation lives alongside the rest of the search docs in gitbook. You can see the markdown docs [here](../docs/search/rank/README.md).

--- a/rank/README.md
+++ b/rank/README.md
@@ -19,7 +19,7 @@ The following command will match the environment used in CI exactly, explicitly 
 ```sh
 docker run -it \
   -v $HOME/.aws:/root/.aws \
-  -v $(pwd):/catalogue-api \
+  -v $(git rev-parse --show-toplevel):/catalogue-api \
   --workdir /catalogue-api/rank \
   --env AWS_PROFILE=platform-dev \
   public.ecr.aws/docker/library/node:14-slim \

--- a/rank/__tests__/eval.test.ts
+++ b/rank/__tests__/eval.test.ts
@@ -1,4 +1,4 @@
-import { Index, QueryEnv } from '../types/searchTemplate'
+import { Cluster, Index, QueryEnv } from '../types/searchTemplate'
 
 import { TestResult } from '../types/test'
 import service from '../services/test'
@@ -9,6 +9,7 @@ global.fetch = require('node-fetch')
 const args = yargs(process.argv)
   .options({
     queryEnv: { type: 'string', demandOption: true },
+    cluster: { type: 'string', demandOption: true },
     index: { type: 'string', demandOption: true },
     testId: { type: 'array', demandOption: true },
   })
@@ -16,6 +17,7 @@ const args = yargs(process.argv)
   .parseSync()
 
 const queryEnv = args.queryEnv as QueryEnv
+const cluster = args.cluster as Cluster
 const index = args.index as Index
 const testIds = args.testId as string[]
 
@@ -50,7 +52,7 @@ expect.extend({
 })
 
 test.each(testIds)(`${index} ${queryEnv} %s`, async (testId) => {
-  const result = await service({ queryEnv, index, testId })
+  const result = await service({ queryEnv, index, testId, cluster })
   result.results.forEach((result) => {
     expect(result).toPass()
   })

--- a/rank/scripts/compareQuerySpeed.ts
+++ b/rank/scripts/compareQuerySpeed.ts
@@ -16,7 +16,8 @@ global.fetch = require('node-fetch')
 
 async function go() {
   const queries = await getQueries()
-  const indices = await listIndices()
+  const client = await getRankClient()
+  const indices = await listIndices(client)
 
   const namespace: string = await prompts({
     type: 'select',

--- a/rank/scripts/createIndex.ts
+++ b/rank/scripts/createIndex.ts
@@ -15,7 +15,8 @@ async function go() {
   const configFiles = readdirSync('./mappings/')
     .filter((fileName) => fileName.includes('.json'))
     .map((fileName) => parse(fileName).name)
-  const sourceIndices = await listIndices()
+  const client = await getRankClient()
+  const sourceIndices = await listIndices(client)
   const validIndices = sourceIndices.filter((value) =>
     configFiles.includes(value)
   )
@@ -38,7 +39,6 @@ async function go() {
     initial: `${getNamespaceFromIndexName(localIndex)}-candidate`,
   }).then(({ value }) => value)
 
-  const client = await getRankClient()
   const putIndexRes = await client.indices.create({
     index: remoteIndex,
     body: {

--- a/rank/scripts/getIndexConfig.ts
+++ b/rank/scripts/getIndexConfig.ts
@@ -8,7 +8,8 @@ import prompts from 'prompts'
 global.fetch = require('node-fetch')
 
 async function go() {
-  const remoteIndices = await listIndices()
+  const client = await getRankClient()
+  const remoteIndices = await listIndices(client)
   const indices: string[] = await prompts({
     type: 'multiselect',
     name: 'value',

--- a/rank/scripts/search.ts
+++ b/rank/scripts/search.ts
@@ -2,6 +2,7 @@ import { Index, QueryEnv, queryEnvs } from '../types/searchTemplate'
 
 import chalk from 'chalk'
 import { gatherArgs } from './utils'
+import { getRankClient } from '../services/elasticsearch'
 import { listIndices } from '../services/search-templates'
 import prompts from 'prompts'
 import search from '../services/search'
@@ -9,7 +10,8 @@ import search from '../services/search'
 global.fetch = require('node-fetch')
 
 async function go() {
-  const indices: Index[] = await listIndices()
+  const client = await getRankClient()
+  const indices: Index[] = await listIndices(client)
 
   const args = await gatherArgs({
     index: { type: 'string', choices: indices },

--- a/rank/scripts/updateIndex.ts
+++ b/rank/scripts/updateIndex.ts
@@ -10,7 +10,8 @@ import { readdirSync } from 'fs'
 async function go() {
   // Users should be able to update indices by modifying mappings they've
   // fetched from the rank cluster, where those source indices still exist.
-  const sourceIndices = await listIndices()
+  const client = await getRankClient()
+  const sourceIndices = await listIndices(client)
 
   const indexName = await prompts({
     type: 'select',

--- a/rank/services/decoder.ts
+++ b/rank/services/decoder.ts
@@ -1,9 +1,0 @@
-import { ParsedUrlQuery } from 'querystring'
-
-export type Decoder<Props> = (q: ParsedUrlQuery) => Props
-
-export function decodeString(q: ParsedUrlQuery, key: string): string {
-  const val = q[key]
-  if (!val) throw Error(`Missing value for ${key}`)
-  return val.toString()
-}

--- a/rank/services/elasticsearch.ts
+++ b/rank/services/elasticsearch.ts
@@ -31,4 +31,28 @@ export async function getReportingClient(): Promise<Client> {
   return reportingClient
 }
 
-export { rankClient, reportingClient }
+let pipelineClient
+export async function getPipelineClient(): Promise<Client> {
+  const pipelineDate = await fetch(
+    'https://api.wellcomecollection.org/catalogue/v2/_elasticConfig'
+  )
+    .then((res) => res.json())
+    .then((res) => res.worksIndex.split('-').slice(-3).join('-'))
+
+  const secretPrefix = `elasticsearch/pipeline_storage_${pipelineDate}/`
+  const protocol = await getSecret(secretPrefix + 'protocol')
+  const host = await getSecret(secretPrefix + 'public_host')
+  const port = await getSecret(secretPrefix + 'port')
+  const username = await getSecret(secretPrefix + 'es_username')
+  const password = await getSecret(secretPrefix + 'es_password')
+
+  if (!pipelineClient) {
+    pipelineClient = new Client({
+      node: `${protocol}://${host}:${port}`,
+      auth: { username, password },
+    })
+  }
+  return pipelineClient
+}
+
+export { rankClient, reportingClient, pipelineClient }

--- a/rank/services/search.ts
+++ b/rank/services/search.ts
@@ -1,7 +1,5 @@
-import { Decoder, decodeString } from './decoder'
 import { Index, QueryEnv } from '../types/searchTemplate'
 
-import { ParsedUrlQuery } from 'querystring'
 import { estypes } from '@elastic/elasticsearch'
 import { getRankClient } from './elasticsearch'
 import { getTemplate } from './search-templates'
@@ -11,12 +9,6 @@ type Props = {
   queryEnv: QueryEnv
   index: Index
 }
-
-export const decoder: Decoder<Props> = (q: ParsedUrlQuery) => ({
-  searchTerms: decodeString(q, 'query'),
-  queryEnv: decodeString(q, 'queryEnv') as QueryEnv,
-  index: decodeString(q, 'index') as Index,
-})
 
 async function service({
   queryEnv,

--- a/rank/services/test.ts
+++ b/rank/services/test.ts
@@ -1,10 +1,7 @@
 import { Index, QueryEnv, SearchTemplate } from '../types/searchTemplate'
 import { TestCase, TestResult } from '../types/test'
 
-import { Decoder } from './decoder'
-import { ParsedUrlQuery } from 'querystring'
-import { decodeString } from './decoder'
-import { getRankClient } from './elasticsearch'
+import { Client } from '@elastic/elasticsearch'
 import { getTemplate } from './search-templates'
 import { tests } from '../tests'
 
@@ -90,12 +87,6 @@ async function service({
     results,
   }
 }
-
-export const decoder: Decoder<Props> = (q: ParsedUrlQuery) => ({
-  testId: decodeString(q, 'testId'),
-  queryEnv: decodeString(q, 'queryEnv') as QueryEnv,
-  index: decodeString(q, 'index') as Index,
-})
 
 export default service
 export type { Props }

--- a/rank/services/test.ts
+++ b/rank/services/test.ts
@@ -67,6 +67,13 @@ async function service({
     throw new Error(`Unknown cluster ${cluster}`)
   }
 
+  // fail if the index doesn't exist
+  try {
+    await client.indices.get({ index: template.index })
+  } catch (e) {
+    throw new Error(`${index} does not exist in the ${cluster} cluster!`)
+  }
+
   const res = await client.rankEval({
     index: template.index,
     body: {

--- a/rank/types/searchTemplate.ts
+++ b/rank/types/searchTemplate.ts
@@ -1,6 +1,9 @@
 export const queryEnvs = ['production', 'staging', 'candidate'] as const
 export type QueryEnv = typeof queryEnvs[number]
 
+export const clusters = ['pipeline', 'rank'] as const
+export type Cluster = typeof clusters[number]
+
 export const namespaces = ['works', 'images'] as const
 export type Namespace = typeof namespaces[number]
 


### PR DESCRIPTION
Previously, the `test_rank.sh` script fetched index names from the API [_elasticConfig](https://api.wellcomecollection.org/catalogue/v2/_elasticConfig) endpoint, and then ran the rank tests using that index name against the `rank` cluster.  
Unless it's been manually replicated from pipeline to rank cluster, that index won't exist, and the tests should fail.  
However, a bug in the passing/failing of tests meant that rank still passed against missing indices. We're unlikely to run the replication manually for every new pipeline, but automating CCR has caused all sorts of problems in the past. 

This PR:
- allows the user to specify whether tests should be run against the `rank` or `pipeline` cluster
- checks whether the specified index exists in that cluster, and fails the tests if it doesn't
- runs rank in CI against the `pipeline` cluster
- Closes #552 

NB I'd like to come back to this soon and simplify the pass/fail logic for individual tests as part of a larger piece of work on rank metrics