### PR TITLE
assume the catalogue-ci role when running rank tests in deployment pipelines

### DIFF
--- a/.buildkite/pipeline.deploy-prod.yml
+++ b/.buildkite/pipeline.deploy-prod.yml
@@ -19,14 +19,21 @@ steps:
           image: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/weco-deploy:5.7
           workdir: /repo
           mount-ssh-agent: true
-          command: [
-              "--project-id", "catalogue_api",
+          command:
+            [
+              "--project-id",
+              "catalogue_api",
               "--confirm",
               "release-deploy",
-              "--from-label", "ref.$BUILDKITE_COMMIT",
-              "--environment-id", "prod",
-              "--description", $BUILDKITE_BUILD_URL,
-              "--confirmation-wait-for", 3600 ]
+              "--from-label",
+              "ref.$BUILDKITE_COMMIT",
+              "--environment-id",
+              "prod",
+              "--description",
+              $BUILDKITE_BUILD_URL,
+              "--confirmation-wait-for",
+              3600,
+            ]
     agents:
       queue: nano
   - label: "Deploy (requests prod)"
@@ -36,14 +43,21 @@ steps:
           image: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/weco-deploy:5.7
           workdir: /repo
           mount-ssh-agent: true
-          command: [
-              "--project-id", "requests_api",
+          command:
+            [
+              "--project-id",
+              "requests_api",
               "--confirm",
               "release-deploy",
-              "--from-label", "ref.$BUILDKITE_COMMIT",
-              "--environment-id", "prod",
-              "--description", $BUILDKITE_BUILD_URL,
-              "--confirmation-wait-for", 3600 ]
+              "--from-label",
+              "ref.$BUILDKITE_COMMIT",
+              "--environment-id",
+              "prod",
+              "--description",
+              $BUILDKITE_BUILD_URL,
+              "--confirmation-wait-for",
+              3600,
+            ]
     agents:
       queue: nano
 
@@ -56,7 +70,7 @@ steps:
           role: "arn:aws:iam::130871440101:role/experience-ci"
       - docker-compose#v3.5.0:
           run: smoke_test_catalogue_api_stage
-          command: [ "yarn", "run", "smokeTestCatalogueApiProd" ]
+          command: ["yarn", "run", "smokeTestCatalogueApiProd"]
           env:
             - AWS_ACCESS_KEY_ID
             - AWS_SECRET_ACCESS_KEY
@@ -74,3 +88,6 @@ steps:
     command: ./.buildkite/scripts/test_rank.sh
     env:
       QUERY_ENV: "production"
+    plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::756629837203:role/catalogue-ci"

--- a/.buildkite/pipeline.deploy-stage.yml
+++ b/.buildkite/pipeline.deploy-stage.yml
@@ -6,14 +6,21 @@ steps:
           image: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/weco-deploy:5.7
           workdir: /repo
           mount-ssh-agent: true
-          command: [
-              "--project-id", "catalogue_api",
+          command:
+            [
+              "--project-id",
+              "catalogue_api",
               "--confirm",
               "release-deploy",
-              "--from-label", "ref.$BUILDKITE_COMMIT",
-              "--environment-id", "stage",
-              "--description", $BUILDKITE_BUILD_URL,
-              "--confirmation-wait-for", 3600]
+              "--from-label",
+              "ref.$BUILDKITE_COMMIT",
+              "--environment-id",
+              "stage",
+              "--description",
+              $BUILDKITE_BUILD_URL,
+              "--confirmation-wait-for",
+              3600,
+            ]
     agents:
       queue: nano
   - label: "Deploy (requests stage)"
@@ -23,14 +30,21 @@ steps:
           image: 760097843905.dkr.ecr.eu-west-1.amazonaws.com/wellcome/weco-deploy:5.7
           workdir: /repo
           mount-ssh-agent: true
-          command: [
-              "--project-id", "requests_api",
+          command:
+            [
+              "--project-id",
+              "requests_api",
               "--confirm",
               "release-deploy",
-              "--from-label", "ref.$BUILDKITE_COMMIT",
-              "--environment-id", "stage",
-              "--description", $BUILDKITE_BUILD_URL,
-              "--confirmation-wait-for", 3600]
+              "--from-label",
+              "ref.$BUILDKITE_COMMIT",
+              "--environment-id",
+              "stage",
+              "--description",
+              $BUILDKITE_BUILD_URL,
+              "--confirmation-wait-for",
+              3600,
+            ]
     agents:
       queue: nano
 
@@ -43,7 +57,7 @@ steps:
           role: "arn:aws:iam::130871440101:role/experience-ci"
       - docker-compose#v3.5.0:
           run: smoke_test_catalogue_api_stage
-          command: [ "yarn", "run", "smokeTestCatalogueApiStage" ]
+          command: ["yarn", "run", "smokeTestCatalogueApiStage"]
           env:
             - AWS_ACCESS_KEY_ID
             - AWS_SECRET_ACCESS_KEY
@@ -62,6 +76,9 @@ steps:
     command: ./.buildkite/scripts/test_rank.sh
     env:
       QUERY_ENV: "staging"
+    plugins:
+      - wellcomecollection/aws-assume-role#v0.2.2:
+          role: "arn:aws:iam::756629837203:role/catalogue-ci"
 
   - wait
 


### PR DESCRIPTION
In [this PR](https://github.com/wellcomecollection/catalogue-api/pull/557), @jamieparkinson and I tweaked `pipeline.yml` and `pipeline.rank.yml` to get rank running, but we forgot that rank also runs before deployments.

There's a bunch of autoformatting in here, but the real change is at the end of each file, with the addition of 

```
    plugins:
      - wellcomecollection/aws-assume-role#v0.2.2:
          role: "arn:aws:iam::756629837203:role/catalogue-ci"
```

to the rank steps.