### PR TITLE
Make rank respect different environments

### DIFF
--- a/rank/scripts/utils.ts
+++ b/rank/scripts/utils.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 import path from 'path'
 import prompts from 'prompts'
-import yargs from 'yargs'
+import yargs, { Options } from 'yargs'
 
 const info = (message: string) => {
   console.log(chalk.blue(message))

--- a/rank/services/elasticsearch.ts
+++ b/rank/services/elasticsearch.ts
@@ -33,7 +33,7 @@ export async function getReportingClient(): Promise<Client> {
   return reportingClient
 }
 
-let pipelineClient
+const pipelineClients = {} as Record<QueryEnv, Client>
 export async function getPipelineClient(env: QueryEnv): Promise<Client> {
   const pipelineDate = await fetch(`${apiUrl(env)}/catalogue/v2/_elasticConfig`)
     .then((res) => res.json())
@@ -46,13 +46,11 @@ export async function getPipelineClient(env: QueryEnv): Promise<Client> {
   const username = await getSecret(secretPrefix + 'es_username')
   const password = await getSecret(secretPrefix + 'es_password')
 
-  if (!pipelineClient) {
-    pipelineClient = new Client({
+  if (!pipelineClients[env]) {
+    pipelineClients[env] = new Client({
       node: `${protocol}://${host}:${port}`,
       auth: { username, password },
     })
   }
-  return pipelineClient
+  return pipelineClients[env]
 }
-
-export { rankClient, reportingClient, pipelineClient }

--- a/rank/services/elasticsearch.ts
+++ b/rank/services/elasticsearch.ts
@@ -1,5 +1,7 @@
 import { Client } from '@elastic/elasticsearch'
 import { getSecret } from './secrets'
+import { QueryEnv } from '../types/searchTemplate'
+import { apiUrl } from './search-templates'
 
 let rankClient
 export async function getRankClient(): Promise<Client> {
@@ -32,10 +34,8 @@ export async function getReportingClient(): Promise<Client> {
 }
 
 let pipelineClient
-export async function getPipelineClient(): Promise<Client> {
-  const pipelineDate = await fetch(
-    'https://api.wellcomecollection.org/catalogue/v2/_elasticConfig'
-  )
+export async function getPipelineClient(env: QueryEnv): Promise<Client> {
+  const pipelineDate = await fetch(`${apiUrl(env)}/_elasticConfig`)
     .then((res) => res.json())
     .then((res) => res.worksIndex.split('-').slice(-3).join('-'))
 

--- a/rank/services/elasticsearch.ts
+++ b/rank/services/elasticsearch.ts
@@ -35,7 +35,7 @@ export async function getReportingClient(): Promise<Client> {
 
 let pipelineClient
 export async function getPipelineClient(env: QueryEnv): Promise<Client> {
-  const pipelineDate = await fetch(`${apiUrl(env)}/_elasticConfig`)
+  const pipelineDate = await fetch(`${apiUrl(env)}/catalogue/v2/_elasticConfig`)
     .then((res) => res.json())
     .then((res) => res.worksIndex.split('-').slice(-3).join('-'))
 

--- a/rank/services/search-templates.ts
+++ b/rank/services/search-templates.ts
@@ -9,7 +9,7 @@ import {
 import { Client } from '@elastic/elasticsearch'
 
 export const apiUrl = (queryEnv: QueryEnv): string => {
-  if (queryEnv === 'production') {
+  if (queryEnv === 'production' || queryEnv === 'candidate') {
     return 'https://api.wellcomecollection.org'
   }
   if (queryEnv === 'staging') {

--- a/rank/services/search-templates.ts
+++ b/rank/services/search-templates.ts
@@ -9,7 +9,7 @@ import {
 import { Client } from '@elastic/elasticsearch'
 
 export const apiUrl = (queryEnv: QueryEnv): string => {
-  if (queryEnv === 'production' || queryEnv === 'candidate') {
+  if (queryEnv === 'production') {
     return 'https://api.wellcomecollection.org'
   }
   if (queryEnv === 'staging') {

--- a/rank/services/test.ts
+++ b/rank/services/test.ts
@@ -76,7 +76,9 @@ async function service({
     } else if (await indexExists(stageClient, template.index)) {
       client = stageClient
     } else {
-      throw new Error(`${index} does not exist in the ${cluster} cluster!`)
+      throw new Error(
+        `${index} does not exist in any currently used ${cluster} cluster!`
+      )
     }
   } else if (cluster === 'pipeline') {
     client = await getPipelineClient(queryEnv)

--- a/rank/services/test.ts
+++ b/rank/services/test.ts
@@ -68,7 +68,7 @@ async function service({
   })
 
   let client: Client
-  if (queryEnv === 'candidate') {
+  if (queryEnv === 'candidate' && cluster === 'pipeline') {
     const prodClient = await getPipelineClient('production')
     const stageClient = await getPipelineClient('staging')
     if (await indexExists(prodClient, template.index)) {
@@ -78,8 +78,7 @@ async function service({
     } else {
       throw new Error(`${index} does not exist in the ${cluster} cluster!`)
     }
-  }
-  if (cluster === 'pipeline') {
+  } else if (cluster === 'pipeline') {
     client = await getPipelineClient(queryEnv)
   } else if (cluster === 'rank') {
     client = await getRankClient()

--- a/rank/services/test.ts
+++ b/rank/services/test.ts
@@ -60,7 +60,7 @@ async function service({
 
   let client: Client
   if (cluster === 'pipeline') {
-    client = await getPipelineClient()
+    client = await getPipelineClient(queryEnv)
   } else if (cluster === 'rank') {
     client = await getRankClient()
   } else {


### PR DESCRIPTION
This makes rank think about which cluster it wants to look at. There are quite a few redundant fetches re environments, tangled concerns, and no-longer-useful abstractions here: I tried for a bit to refactor, but it wasn't easy at all.

I would be _strongly_ in favour of a couple of us doing a rank rewrite, given that that it's now doing a very different job to what it was originally intended to do.