### PR TITLE
Remove an errant log

### DIFF
--- a/search/src/main/scala/weco/api/search/services/SearchService.scala
+++ b/search/src/main/scala/weco/api/search/services/SearchService.scala
@@ -65,7 +65,6 @@ trait SearchService[T, VisibleT, Aggs, S <: SearchOptions[_, _, _]] {
       .request(searchOptions, index)
       .trackTotalHits(true)
     Tracing.currentTransaction.addQueryOptionLabels(searchOptions)
-    println(searchRequest)
     elasticsearchService.executeSearchRequest(searchRequest)
   }
 


### PR DESCRIPTION
Spotted while reading code with Harrison today.

We have other code to log the original request when we get an error from Elastic, which is the only ones we really care about: https://github.com/wellcomecollection/catalogue-api/blob/main/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchService.scala#L88-L90