### PR TITLE
new pipeline

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
@@ -10,7 +10,7 @@ case class ElasticConfig(
 trait ElasticConfigBase {
   // We use this to share config across Scala API applications
   // i.e. The API and the snapshot generator.
-  val pipelineDate = "2022-11-28"
+  val pipelineDate = "2023-01-19"
 }
 
 object PipelineClusterElasticConfig extends ElasticConfigBase {


### PR DESCRIPTION
This pipeline should sort out many (but definitely not all) of the instances of missing Concepts.

Because this is more strict about LoC id formats, there will be 240 missing Sierra documents until they get fixed.