### PR TITLE
Query with minimum should match

### DIFF
--- a/rank/data/tests/works.json
+++ b/rank/data/tests/works.json
@@ -131,6 +131,14 @@
                     "gdfhp4gw"
                 ],
                 "description": "Searching without punctuation should match a document with punctuation"
+            },
+            {
+                "searchTerms": "sophie's shell",
+                "ratings": [
+                    "gdfhp4gw"
+                ],
+                "knownFailure": true,
+                "description": "Searching for a term including an apostrophe should match the same term"
             }
         ],
         "metric": {

--- a/rank/data/tests/works.json
+++ b/rank/data/tests/works.json
@@ -330,6 +330,21 @@
         "description": "Check that the order of results is correct",
         "cases": [
             {
+                "searchTerms": "Crète",
+                "before": [
+                    "yyz378xr",
+                    "d6aezcvw",
+                    "z4yefjez"
+                ],
+                "after": [
+                    "gsehqy4k",
+                    "zq2yf7uz",
+                    "d2c3k3d3"
+                ],
+                "description": "Term with diacritics is scored higher than the asciifolded equivalent, or versions with different diacritics",
+                "knownFailure": true
+            },
+            {
                 "searchTerms": "horse furniture",
                 "description": "Matches ordered terms ahead of unordered terms",
                 "before": [

--- a/rank/data/tests/works.json
+++ b/rank/data/tests/works.json
@@ -88,8 +88,7 @@
                 "ratings": [
                     "xwtcsk93"
                 ],
-                "description": "Example of a known title's prefix, but not the full thing",
-                "knownFailure": true
+                "description": "Example of a known title's prefix, but not the full thing"
             },
             {
                 "searchTerms": "L0033046",
@@ -117,8 +116,21 @@
                 "ratings": [
                     "ruedafcw"
                 ],
-                "description": "Example of a known title's prefix, but not the full thing",
-                "knownFailure": true
+                "description": "Example of a known title's prefix, but not the full thing"
+            },
+            {
+                "searchTerms": "mammas favorites",
+                "ratings": [
+                    "dbqsn5gk"
+                ],
+                "description": "Searching without punctuation should match a document with punctuation"
+            },
+            {
+                "searchTerms": "sophies shell",
+                "ratings": [
+                    "gdfhp4gw"
+                ],
+                "description": "Searching without punctuation should match a document with punctuation"
             }
         ],
         "metric": {
@@ -133,6 +145,14 @@
         "description": "Ensure that the query brings back the results we expect somewhere in the list",
         "eval": "equalTo1",
         "cases": [
+            {
+                "searchTerms": "indian journal of medical research 1930-1931",
+                "ratings": [
+                    "p444t8rp",
+                    "kccp8d5t"
+                ],
+                "description": "Query where most search terms (but not all) are in the title"
+            },
             {
                 "searchTerms": "Atherosclerosis: an introduction to atherosclerosis",
                 "ratings": [
@@ -347,7 +367,6 @@
             {
                 "searchTerms": "crip",
                 "description": "Exact singular match appears before pluralised match",
-                "knownFailure": true,
                 "before": [
                     "ptvgbenh",
                     "r3eue8kw"
@@ -382,8 +401,7 @@
                     "gvem6rts",
                     "tdwgsdsh",
                     "vfwczwr7"
-                ],
-                "knownFailure": true
+                ]
             },
             {
                 "searchTerms": "aid",
@@ -424,11 +442,11 @@
             {
                 "searchTerms": "x-ray",
                 "description": "tokens joined by hyphens are matched above tokens which are joined by whitespace",
-                "knownFailure": true,
                 "before": [
                     "maxctjgf",
-                    "pbaethns",
-                    "tt2mxtff"
+                    "c3jatdq5",
+                    "dmcchav2",
+                    "gfp86e2b"
                 ],
                 "after": [
                     "thgzs6pd"

--- a/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -1,7 +1,7 @@
 package weco.api.search.elasticsearch
 
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.requests.common.Operator.{AND, OR}
+import com.sksamuel.elastic4s.requests.common.Operator.OR
 import com.sksamuel.elastic4s.requests.searches.queries.compound.BoolQuery
 import com.sksamuel.elastic4s.requests.searches.queries.matches.MultiMatchQueryBuilderType.{
   BEST_FIELDS,
@@ -91,8 +91,9 @@ case object WorksMultiMatcher {
                 fields = titleFields
               ),
               `type` = Some(BEST_FIELDS),
-              operator = Some(AND)
-            ),
+              operator = Some(OR)
+            )        .minimumShouldMatch("80%")
+          ,
             MultiMatchQuery(
               q,
               queryName = Some("non-english titles and contributors"),
@@ -108,9 +109,8 @@ case object WorksMultiMatcher {
                   FieldWithoutBoost(s"query.titlesAndContributors.$language")
               ),
               `type` = Some(BEST_FIELDS),
-              operator = Some(AND)
-            )
-          )
+              operator = Some(OR)
+            ).minimumShouldMatch("80%"))
         ),
         bool(
           shouldQueries = List(
@@ -144,7 +144,7 @@ case object WorksMultiMatcher {
           q,
           queryName = Some("data"),
           `type` = Some(CROSS_FIELDS),
-          operator = Some(AND),
+          operator = Some(OR),
           fields = Seq(
             (Some(1000), "query.contributors.agent.label"),
             (Some(10), "query.subjects.concepts.label"),
@@ -160,12 +160,12 @@ case object WorksMultiMatcher {
             case (boost, field) =>
               FieldWithOptionalBoost(field, boost.map(_.toDouble))
           }
-        ),
+        ).minimumShouldMatch("80%"),
         MultiMatchQuery(
           q,
           queryName = Some("shingles cased"),
           `type` = Some(MOST_FIELDS),
-          operator = Some(AND),
+          operator = Some(OR),
           fields = Seq(
             (Some(1000), "query.title.shingles_cased"),
             (Some(100), "query.alternativeTitles.shingles_cased"),
@@ -174,7 +174,8 @@ case object WorksMultiMatcher {
             case (boost, field) =>
               FieldWithOptionalBoost(field, boost.map(_.toDouble))
           }
-        )
+        ).minimumShouldMatch("80%")
+
       )
       .minimumShouldMatch(1)
 }

--- a/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -92,8 +92,7 @@ case object WorksMultiMatcher {
               ),
               `type` = Some(BEST_FIELDS),
               operator = Some(OR)
-            )        .minimumShouldMatch("80%")
-          ,
+            ).minimumShouldMatch("80%"),
             MultiMatchQuery(
               q,
               queryName = Some("non-english titles and contributors"),
@@ -110,7 +109,8 @@ case object WorksMultiMatcher {
               ),
               `type` = Some(BEST_FIELDS),
               operator = Some(OR)
-            ).minimumShouldMatch("80%"))
+            ).minimumShouldMatch("80%")
+          )
         ),
         bool(
           shouldQueries = List(
@@ -175,7 +175,6 @@ case object WorksMultiMatcher {
               FieldWithOptionalBoost(field, boost.map(_.toDouble))
           }
         ).minimumShouldMatch("80%")
-
       )
       .minimumShouldMatch(1)
 }

--- a/search/src/test/resources/WorksMultiMatcherQuery.json
+++ b/search/src/test/resources/WorksMultiMatcherQuery.json
@@ -44,7 +44,8 @@
                   "query.titlesAndContributors.shingles^100.0"
                 ],
                 "type": "best_fields",
-                "operator": "And",
+                "minimum_should_match": "80%",
+                "operator": "Or",
                 "_name": "title and contributor exact spellings"
               }
             },
@@ -60,7 +61,8 @@
                   "query.titlesAndContributors.italian"
                 ],
                 "type": "best_fields",
-                "operator": "And",
+                "minimum_should_match": "80%",
+                "operator": "Or",
                 "_name": "non-english titles and contributors"
               }
             }
@@ -69,6 +71,21 @@
       },
       {
         "bool": {
+          "must": [
+            {
+              "multi_match": {
+                "query": "{{query}}",
+                "fields": [
+                  "query.collectionPath.path.clean",
+                  "query.collectionPath.label.cleanPath",
+                  "query.collectionPath.label",
+                  "query.collectionPath.path.keyword"
+                ],
+                "operator": "Or",
+                "_name": "relations paths"
+              }
+            }
+          ],
           "should": [
             {
               "multi_match": {
@@ -80,21 +97,6 @@
                 "type": "cross_fields",
                 "operator": "Or",
                 "_name": "relations text"
-              }
-            }
-          ],
-          "must": [
-            {
-              "multi_match": {
-                "fields": [
-                  "query.collectionPath.path.clean",
-                  "query.collectionPath.label.cleanPath",
-                  "query.collectionPath.label",
-                  "query.collectionPath.path.keyword"
-                ],
-                "query": "{{query}}",
-                "operator": "Or",
-                "_name": "relations paths"
               }
             }
           ]
@@ -116,7 +118,8 @@
             "query.lettering"
           ],
           "type": "cross_fields",
-          "operator": "And",
+          "minimum_should_match": "80%",
+          "operator": "Or",
           "_name": "data"
         }
       },
@@ -129,7 +132,8 @@
             "query.partOf.title.shingles_cased^10.0"
           ],
           "type": "most_fields",
-          "operator": "And",
+          "minimum_should_match": "80%",
+          "operator": "Or",
           "_name": "shingles cased"
         }
       }

--- a/search/src/test/scala/weco/api/search/elasticsearch/WorksQueryTest.scala
+++ b/search/src/test/scala/weco/api/search/elasticsearch/WorksQueryTest.scala
@@ -3,11 +3,13 @@ package weco.api.search.elasticsearch
 import com.sksamuel.elastic4s.Index
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.{Assertion, EitherValues}
+import org.scalatest.EitherValues
 import weco.api.search.fixtures.{IndexFixtures, TestDocumentFixtures}
 import weco.api.search.generators.SearchOptionsGenerators
+import weco.api.search.models.index.IndexedWork
 import weco.api.search.models.{SearchQuery, SearchQueryType}
 import weco.api.search.services.WorksService
+import weco.fixtures.TestWith
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -24,11 +26,10 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, works: _*)
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "2twopft1",
-          expectedMatches = List("works.visible.0")
-        )
+        assertForQueryResults(index, query = "2twopft1") { results =>
+          results.size shouldBe 1
+          results.head shouldBe getVisibleWork("works.visible.0")
+        }
       }
     }
 
@@ -36,11 +37,10 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, works: _*)
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "Uaequ81tpB",
-          expectedMatches = List("works.visible.0")
-        )
+        assertForQueryResults(index, query = "Uaequ81tpB") { results =>
+          results.size shouldBe 1
+          results.head shouldBe getVisibleWork("works.visible.0")
+        }
       }
     }
 
@@ -48,11 +48,10 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, worksEverything: _*)
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "UfcQYSxE7g",
-          expectedMatches = List("work.visible.everything.0")
-        )
+        assertForQueryResults(index, query = "UfcQYSxE7g") { results =>
+          results.size shouldBe 1
+          results.head shouldBe getVisibleWork("work.visible.everything.0")
+        }
       }
     }
 
@@ -60,11 +59,10 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, worksEverything: _*)
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "ca3anii6",
-          expectedMatches = List("work.visible.everything.0")
-        )
+        assertForQueryResults(index, query = "ca3anii6") { results =>
+          results.size shouldBe 1
+          results.head shouldBe getVisibleWork("work.visible.everything.0")
+        }
       }
     }
 
@@ -72,11 +70,10 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, worksEverything: _*)
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "hKyStbKjx1",
-          expectedMatches = List("work.visible.everything.0")
-        )
+        assertForQueryResults(index, query = "hKyStbKjx1") { results =>
+          results.size shouldBe 1
+          results.head shouldBe getVisibleWork("work.visible.everything.0")
+        }
       }
     }
 
@@ -87,11 +84,12 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, worksWithItemIdentifiers: _*)
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "xJJHLpGvU7",
-          expectedMatches = List("works.items-with-other-identifiers.0")
-        )
+        assertForQueryResults(index, query = "xJJHLpGvU7") { results =>
+          results.size shouldBe 1
+          results.head shouldBe getVisibleWork(
+            "works.items-with-other-identifiers.0"
+          )
+        }
       }
     }
 
@@ -99,11 +97,10 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, worksEverything: _*)
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "eoedbdmz",
-          expectedMatches = List("work.visible.everything.0")
-        )
+        assertForQueryResults(index, query = "eoedbdmz") { results =>
+          results.size shouldBe 1
+          results.head shouldBe getVisibleWork("work.visible.everything.0")
+        }
       }
     }
 
@@ -111,11 +108,10 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, worksEverything: _*)
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "auL5Gzybrl",
-          expectedMatches = List("work.visible.everything.0")
-        )
+        assertForQueryResults(index, query = "auL5Gzybrl") { results =>
+          results.size shouldBe 1
+          results.head shouldBe getVisibleWork("work.visible.everything.0")
+        }
       }
     }
 
@@ -123,11 +119,10 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, visibleWorks: _*)
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "2twopft1",
-          expectedMatches = List("works.visible.0")
-        )
+        assertForQueryResults(index, query = "2twopft1") { results =>
+          results.size shouldBe 1
+          results.head shouldBe getVisibleWork("works.visible.0")
+        }
       }
     }
 
@@ -135,17 +130,9 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, works: _*)
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "2twopft1",
-          expectedMatches = List("works.visible.0")
-        )
-
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "7sji",
-          expectedMatches = List()
-        )
+        assertForQueryResults(index, query = "7sji") { results =>
+          results shouldBe empty
+        }
       }
     }
 
@@ -153,11 +140,10 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, works: _*)
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "2TWOPFT1",
-          expectedMatches = List("works.visible.0")
-        )
+        assertForQueryResults(index, query = "2TWOPFT1") { results =>
+          results.size shouldBe 1
+          results.head shouldBe getVisibleWork("works.visible.0")
+        }
       }
     }
 
@@ -165,11 +151,13 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, works: _*)
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "2TWOPFT1 dph7sjip",
-          expectedMatches = List("works.visible.0", "works.visible.1")
-        )
+        assertForQueryResults(index, query = "2TWOPFT1 dph7sjip") { results =>
+          results.size shouldBe 2
+          results should contain theSameElementsAs List(
+            "works.visible.0",
+            "works.visible.1"
+          ).map(getVisibleWork)
+        }
       }
     }
 
@@ -177,17 +165,9 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, works: _*)
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "2twopft1",
-          expectedMatches = List("works.visible.0")
-        )
-
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "2two",
-          expectedMatches = List()
-        )
+        assertForQueryResults(index, query = "2two") { results =>
+          results shouldBe empty
+        }
       }
     }
 
@@ -195,11 +175,10 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, worksEverything: _*)
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "person-W9SVIX0fEg",
-          expectedMatches = List("work.visible.everything.0")
-        )
+        assertForQueryResults(index, query = "person-W9SVIX0fEg") { results =>
+          // We don't mind about number of results for a label search
+          results.head shouldBe getVisibleWork("work.visible.everything.0")
+        }
       }
     }
 
@@ -207,11 +186,10 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, worksEverything: _*)
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "IHQR23GK9tQdPt3",
-          expectedMatches = List("work.visible.everything.0")
-        )
+        assertForQueryResults(index, query = "IHQR23GK9tQdPt3") { results =>
+          // We don't mind about number of results for a label search
+          results.head shouldBe getVisibleWork("work.visible.everything.0")
+        }
       }
     }
 
@@ -219,11 +197,10 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, worksEverything: _*)
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "goKOwWLrIbnrzZj",
-          expectedMatches = List("work.visible.everything.0")
-        )
+        assertForQueryResults(index, query = "goKOwWLrIbnrzZj") { results =>
+          // We don't mind about number of results for a label search
+          results.head shouldBe getVisibleWork("work.visible.everything.0")
+        }
       }
     }
 
@@ -231,11 +208,10 @@ class WorksQueryTest
       withLocalWorksIndex { index =>
         indexTestDocuments(index, "work-title-dodo", "work-title-mouse")
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "A line of legible ligatures",
-          expectedMatches = List("work-title-dodo")
-        )
+        assertForQueryResults(index, query = "A line of legible ligatures") {
+          results =>
+            results.head shouldBe getVisibleWork("work-title-dodo")
+        }
       }
     }
 
@@ -247,11 +223,9 @@ class WorksQueryTest
           "works.collection-path.PPCRI"
         )
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "PPCRI",
-          expectedMatches = List("works.collection-path.PPCRI")
-        )
+        assertForQueryResults(index, query = "PPCRI") { results =>
+          results.head shouldBe getVisibleWork("works.collection-path.PPCRI")
+        }
       }
     }
 
@@ -263,39 +237,31 @@ class WorksQueryTest
           "works.collection-path.PPCRI"
         )
 
-        assertResultsMatchForAllowedQueryTypes(
-          index,
-          query = "PP/CRI",
-          expectedMatches = List("works.collection-path.PPCRI")
-        )
+        assertForQueryResults(index, query = "PP/CRI") { results =>
+          results.head shouldBe getVisibleWork("works.collection-path.PPCRI")
+        }
       }
     }
   }
 
-  private def assertResultsMatchForAllowedQueryTypes(
-    index: Index,
-    query: String,
-    expectedMatches: List[String]
-  ): List[Assertion] =
-    SearchQueryType.allowed map { queryType =>
-      val future = worksService.listOrSearch(
-        index,
-        searchOptions = createWorksSearchOptionsWith(
-          searchQuery = Some(SearchQuery(query, queryType))
-        )
+  private def assertForQueryResults[R](index: Index, query: String)(
+    testWith: TestWith[Seq[IndexedWork.Visible], R]
+  ) = SearchQueryType.allowed map { queryType =>
+    val future = worksService.listOrSearch(
+      index,
+      searchOptions = createWorksSearchOptionsWith(
+        searchQuery = Some(SearchQuery(query, queryType))
       )
+    )
 
-      val results = whenReady(future) {
-        _.right.value.results
-      }
-
-      withClue(s"Using: ${queryType.name}") {
-        results.size shouldBe expectedMatches.size
-        results should contain theSameElementsAs expectedMatches.map(
-          getVisibleWork
-        )
-      }
+    val results = whenReady(future) {
+      _.right.value.results
     }
+
+    withClue(s"[Using query: ${queryType.name}]") {
+      testWith(results)
+    }
+  }
 
   private val worksService = new WorksService(
     elasticsearchService = new ElasticsearchService(elasticClient)


### PR DESCRIPTION
This PR:
- adds new rank tests based on feedback in https://github.com/wellcomecollection/catalogue-api/issues/623
- changes all query ANDs to ORs with a `minimum_should_match` set at `80%` 

Still need to update the docs to describe the changes we've made and why

Tests will probably fail until https://github.com/wellcomecollection/catalogue-pipeline/pull/2334 has been merged and deployed, but the candidate query and mapping produce the following results:

<details>

```
➜ AWS_PROFILE=platform-dev yarn rank
yarn run v1.22.19
$ ts-node ./scripts/rank
✔ cluster › rank
✔ query › candidate
✔ index › works-candidate
Running:
  yarn test --index=works-candidate --queryEnv=candidate --cluster=rank --testId=precision --testId=recall --testId=alternative-spellings --testId=order

$ ts-node ./scripts/test --index=works-candidate --queryEnv=candidate --cluster=rank --testId=precision --testId=recall --testId=alternative-spellings --testId=order
✅      "stimming" passes
        Ensure that we return non-typos over typos e.g. query:stimming matches:stimming > swimming

⚠️       "The Piggle" is a known failure
        Example of a known title's prefix, but not the full thing

✅      "DJmjW2cU" passes
        Case insensitive IDs

✅      "Bills of mortality" passes
        Example of a known title's prefix, but not the full thing

✅      "sophies shell" passes
        Searching without punctuation should match a document with punctuation

✅      "Das neue Naturheilverfahren" passes
        Example of a known title's prefix, but not the full thing

✅      "Oxford dictionary of national biography" passes
        Example of a known title's prefix, but not the full thing

✅      "stim" passes
        Exact match on title with lowercasing and punctuation stripping

✅      "bulloch history of bacteriology" passes
        Contributor and title in the same query

✅      "L0033046" passes
        Miro ID matching

✅      "kmebmktz" passes
        Work ID matching

✅      "mammas favorites" passes
        Searching without punctuation should match a document with punctuation

✅      "seq88sr4 qfk4vbp8" passes
        multiple IDs

✅      "Cassils Time lapse" passes
        Contributor and title in the same query

✅      "information law" passes
        Multi-word exact matches at the start of a title should be prioritised https://github.com/wellcomecollection/catalogue-api/issues/466

✅      "2013i" passes
        Reference number as ID

✅      "2599i" passes
        Reference number as ID

✅      "gzv2hhgy" passes
        Image ID matching

⚠️       "عرف" is a known failure
        Matches stemmed arabic text

✅      "WA/HMM/CM benin" passes
        Archive refno and a word from the description

⚠️       "معرفت" is a known failure
        Matches arabic text

✅      "2013i 2599i" passes
        Multiple IDs

⚠️       "الكشف" is a known failure
        Matches arabic text

✅      "wa/hmm benin" passes
        Archive refno and a word from the description

⚠️       "eugenics society annual reports" is a known failure
        Matches archives without providing refnos

✅      "Atherosclerosis: an introduction to atherosclerosis" passes
        Two works with matching titles

⚠️       "لكشف" is a known failure
        Matches stemmed arabic text

✅      "indian journal of medical research 1930-1931" passes
        Query where most search terms (but not all) are in the title

✅      "wa/hmm durham" passes
        Archive refno and a word from the title

✅      "savoire" passes
        french stemming

✅      "conosceva" passes
        italian stemming

✅      "arkaprakāśa" passes
        undefined

✅      "sharh" passes
        undefined

✅      "arbeiten" passes
        undefined

⚠️       "nuğūm" is a known failure
        undefined

⚠️       "Al-ṭibb" is a known failure
        undefined

⚠️       "al-tibb" is a known failure
        undefined

⚠️       "nujum" is a known failure
        undefined

✅      "horse furniture" passes
        Matches ordered terms ahead of unordered terms

✅      "everest chest" passes
        Matches titles over descriptions

✅      "crips" passes
        Pluralised match appears before singular stemmed match

✅      "crip" passes
        Exact singular match appears before pluralised match

✅      "CRIPS" passes
        Capitalised match appears before lower case match

✅      "AIDS" passes
        Capitalised match appears before lower case match

✅      "aid" passes
        Matches exact terms before stemmed terms

✅      "aids poster" passes
        Matches ordered terms ahead of unordered terms

✅      "aids poster" passes
        Matches both terms ahead of single term

✅      "x-ray" passes
        tokens joined by hyphens are matched above tokens which are joined by whitespace

```
</details>

Merging this should close https://github.com/wellcomecollection/catalogue-api/issues/624