### PR TITLE
Allow filters in rank

### DIFF
--- a/rank/data/tests/works.json
+++ b/rank/data/tests/works.json
@@ -5,6 +5,18 @@
         "eval": "equalTo1",
         "cases": [
             {
+                "searchTerms": "Mackie",
+                "ratings": [
+                    "k8ccmj6t"
+                ],
+                "description": "An exact match in the title and description, and filtering for archives",
+                "filter": {
+                    "term": {
+                        "query.format.id": "h"
+                    }
+                }
+            },
+            {
                 "searchTerms": "information law",
                 "ratings": [
                     "zkg7xqm7"
@@ -452,7 +464,11 @@
                     "ae5kymcs"
                 ],
                 "description": "An exact matches in the title should appear before a misspelled match in the contributor and title. Also uses a filter",
-                "filter": {"term": {"query.format.id": "h"}}
+                "filter": {
+                    "term": {
+                        "query.format.id": "h"
+                    }
+                }
             }
         ]
     }

--- a/rank/data/tests/works.json
+++ b/rank/data/tests/works.json
@@ -119,6 +119,14 @@
                 ],
                 "description": "Example of a known title's prefix, but not the full thing",
                 "knownFailure": true
+            },
+            {
+                "searchTerms": "Hunterian wa/hmm",
+                "ratings": [
+                    "f3gpbk74"
+                ],
+                "description": "archive reference number and a word from the title",
+                "knownFailure": true
             }
         ],
         "metric": {
@@ -433,6 +441,18 @@
                 "after": [
                     "thgzs6pd"
                 ]
+            },
+            {
+                "searchTerms": "Mackie",
+                "before": [
+                    "k8ccmj6t",
+                    "s2tnttyn"
+                ],
+                "after": [
+                    "ae5kymcs"
+                ],
+                "description": "An exact matches in the title should appear before a misspelled match in the contributor and title. Also uses a filter",
+                "filter": {"term": {"query.format.id": "h"}}
             }
         ]
     }

--- a/rank/data/tests/works.json
+++ b/rank/data/tests/works.json
@@ -5,18 +5,6 @@
         "eval": "equalTo1",
         "cases": [
             {
-                "searchTerms": "Mackie",
-                "ratings": [
-                    "k8ccmj6t"
-                ],
-                "description": "An exact match in the title and description, and filtering for archives",
-                "filter": {
-                    "term": {
-                        "query.format.id": "h"
-                    }
-                }
-            },
-            {
                 "searchTerms": "information law",
                 "ratings": [
                     "zkg7xqm7"

--- a/rank/scripts/search.ts
+++ b/rank/scripts/search.ts
@@ -26,7 +26,19 @@ async function go() {
     message: 'What are you looking for?'
   }).then(({ value }) => value)
 
-  const results = await search({ index, queryEnv, searchTerms })
+  const filter = await prompts({
+    type: 'text',
+    name: 'value',
+    message: 'Any filters?'
+  }).then(({ value }) => value)
+
+  const results = await search({ index, queryEnv, searchTerms, filter })
+
+  // @ts-ignore
+  if (results.hits.total.value === 0) {
+    console.log('No results found')
+    return
+  }
 
   results.hits.hits.map((hit, i) => {
     const title = hit._source.display.title

--- a/rank/src/services/order.ts
+++ b/rank/src/services/order.ts
@@ -39,7 +39,7 @@ async function testOrder({
   const results = await Promise.all(
     // for each test case, run a search
     test.cases.map(async (testCase) => {
-      const { searchTerms, description, knownFailure } = testCase
+      const { searchTerms, description, knownFailure, filter } = testCase
 
       // run the search for the test case and return all results
       const searchResponse = await client.searchTemplate({
@@ -48,7 +48,8 @@ async function testOrder({
           source: JSON.stringify({
             query: template.query,
             track_total_hits: true,
-            size: 10000
+            size: 10000,
+            ...(filter ? { post_filter: filter } : {})
           }),
           params: { query: testCase.searchTerms }
         }

--- a/rank/src/services/search.ts
+++ b/rank/src/services/search.ts
@@ -8,12 +8,14 @@ type Props = {
   searchTerms: string
   queryEnv: QueryEnv
   index: Index
+  filter?: any
 }
 
 async function search({
   queryEnv,
   index,
   searchTerms,
+  filter
 }: Props): Promise<estypes.SearchTemplateResponse<Record<string, any>>> {
   const template = await getTemplate(queryEnv, index)
   const client = await getRankClient()
@@ -23,9 +25,10 @@ async function search({
       source: JSON.stringify({
         query: template.query,
         track_total_hits: true,
+        ...(filter ? { post_filter: JSON.parse(filter) } : {})
       }),
-      params: { query: searchTerms, size: 100 },
-    },
+      params: { query: searchTerms, size: 100 }
+    }
   })
 }
 

--- a/rank/src/types/searchTemplate.ts
+++ b/rank/src/types/searchTemplate.ts
@@ -7,7 +7,6 @@ export type Cluster = typeof clusters[number]
 export const namespaces = ['works', 'images'] as const
 export type Namespace = typeof namespaces[number]
 
-export type Query = string | unknown
 export type Index = string
 export type SearchTemplateString = `${QueryEnv}/${Index}`
 
@@ -15,10 +14,10 @@ export class SearchTemplate {
   index: Index
   namespace: Namespace
   queryEnv: QueryEnv
-  query: Query
+  query: string
   id: SearchTemplateString
 
-  constructor(queryEnv: QueryEnv, index: Index, query: Query) {
+  constructor(queryEnv: QueryEnv, index: Index, query: string) {
     this.queryEnv = queryEnv
     this.index = index
     this.query = query

--- a/rank/src/types/test.ts
+++ b/rank/src/types/test.ts
@@ -10,6 +10,7 @@ export type TestCase = {
   after?: string[]
   description?: string
   knownFailure?: boolean
+  filter?: any
 }
 
 export type Test = {


### PR DESCRIPTION
Adds the ability to filter results when building rank tests, or when searching through the CLI

closes #626 

Rank tests won't pass until https://github.com/wellcomecollection/catalogue-api/pull/625 and https://github.com/wellcomecollection/catalogue-pipeline/pull/2334 have been merged and deployed.