### PR TITLE
Customise the akka-http timeout response to be JSON

### DIFF
--- a/search/src/main/scala/weco/api/search/SearchApi.scala
+++ b/search/src/main/scala/weco/api/search/SearchApi.scala
@@ -1,5 +1,11 @@
 package weco.api.search
 
+import akka.http.scaladsl.model.{
+  ContentTypes,
+  HttpEntity,
+  HttpResponse,
+  StatusCodes
+}
 import akka.http.scaladsl.server.{
   MalformedQueryParamRejection,
   RejectionHandler,
@@ -16,6 +22,7 @@ import weco.api.search.elasticsearch.{
 import weco.api.search.models._
 import weco.api.search.rest._
 import weco.catalogue.display_model.rest.IdentifierDirectives
+import weco.http.models.DisplayError
 
 import scala.concurrent.ExecutionContext
 
@@ -29,69 +36,75 @@ class SearchApi(
     with IdentifierDirectives {
 
   def routes: Route = handleRejections(rejectionHandler) {
-    ignoreTrailingSlash {
-      concat(
-        path("works") {
-          MultipleWorksParams.parse { worksController.multipleWorks }
-        },
-        path("works" / Segment) {
-          case id if looksLikeCanonicalId(id) =>
-            SingleWorkParams.parse {
-              worksController.singleWork(id, _)
+    withRequestTimeoutResponse(request => timeoutResponse) {
+      ignoreTrailingSlash {
+        concat(
+          path("works") {
+            MultipleWorksParams.parse {
+              worksController.multipleWorks
             }
-
-          case id =>
-            notFound(s"Work not found for identifier $id")
-        },
-        path("images") {
-          MultipleImagesParams.parse { imagesController.multipleImages }
-        },
-        path("images" / Segment) {
-          case id if looksLikeCanonicalId(id) =>
-            SingleImageParams.parse {
-              imagesController.singleImage(id, _)
-            }
-
-          case id => notFound(s"Image not found for identifier $id")
-        },
-        path("search-templates.json") {
-          getSearchTemplates
-        },
-        path("_elasticConfig") {
-          getElasticConfig
-        },
-        pathPrefix("management") {
-          concat(
-            path("healthcheck") {
-              get {
-                complete("message" -> "ok")
+          },
+          path("works" / Segment) {
+            case id if looksLikeCanonicalId(id) =>
+              SingleWorkParams.parse {
+                worksController.singleWork(id, _)
               }
-            },
-            path("clusterhealth") {
-              getClusterHealth
-            },
-            // This endpoint is meant for the diff tool; it gives a breakdown of the
-            // different work types (e.g. Visible, Redirected, Deleted) in the index
-            // the API is using.
-            //
-            // It allows the diff tool to get stats about the API without knowing
-            // which ES cluster the API is connecting to or which index it's using.
-            path("_workTypes") {
-              get {
-                withFuture {
-                  worksController.countWorkTypes(elasticConfig.worksIndex).map {
-                    case Right(tally) => complete(tally)
-                    case Left(err) =>
-                      internalError(
-                        new Throwable(s"Error counting work types: $err")
-                      )
+
+            case id =>
+              notFound(s"Work not found for identifier $id")
+          },
+          path("images") {
+            MultipleImagesParams.parse {
+              imagesController.multipleImages
+            }
+          },
+          path("images" / Segment) {
+            case id if looksLikeCanonicalId(id) =>
+              SingleImageParams.parse {
+                imagesController.singleImage(id, _)
+              }
+
+            case id => notFound(s"Image not found for identifier $id")
+          },
+          path("search-templates.json") {
+            getSearchTemplates
+          },
+          path("_elasticConfig") {
+            getElasticConfig
+          },
+          pathPrefix("management") {
+            concat(
+              path("healthcheck") {
+                get {
+                  complete("message" -> "ok")
+                }
+              },
+              path("clusterhealth") {
+                getClusterHealth
+              },
+              // This endpoint is meant for the diff tool; it gives a breakdown of the
+              // different work types (e.g. Visible, Redirected, Deleted) in the index
+              // the API is using.
+              //
+              // It allows the diff tool to get stats about the API without knowing
+              // which ES cluster the API is connecting to or which index it's using.
+              path("_workTypes") {
+                get {
+                  withFuture {
+                    worksController.countWorkTypes(elasticConfig.worksIndex).map {
+                      case Right(tally) => complete(tally)
+                      case Left(err) =>
+                        internalError(
+                          new Throwable(s"Error counting work types: $err")
+                        )
+                    }
                   }
                 }
               }
-            }
-          )
-        }
-      )
+            )
+          }
+        )
+      }
     }
   }
 
@@ -153,6 +166,20 @@ class SearchApi(
         )
       )
     }
+
+  val timeoutResponse = HttpResponse(
+    StatusCodes.ServiceUnavailable,
+    entity =
+      HttpEntity(
+        contentType = ContentTypes.`application/json`,
+        string = toJson(
+          DisplayError(
+            statusCode = StatusCodes.ServiceUnavailable,
+            description = "The server was not able to produce a timely response to your request. Please try again in a short while!"
+          )
+        )
+      )
+  )
 
   def rejectionHandler =
     RejectionHandler.newBuilder

--- a/search/src/main/scala/weco/api/search/SearchApi.scala
+++ b/search/src/main/scala/weco/api/search/SearchApi.scala
@@ -91,13 +91,15 @@ class SearchApi(
               path("_workTypes") {
                 get {
                   withFuture {
-                    worksController.countWorkTypes(elasticConfig.worksIndex).map {
-                      case Right(tally) => complete(tally)
-                      case Left(err) =>
-                        internalError(
-                          new Throwable(s"Error counting work types: $err")
-                        )
-                    }
+                    worksController
+                      .countWorkTypes(elasticConfig.worksIndex)
+                      .map {
+                        case Right(tally) => complete(tally)
+                        case Left(err) =>
+                          internalError(
+                            new Throwable(s"Error counting work types: $err")
+                          )
+                      }
                   }
                 }
               }
@@ -169,16 +171,16 @@ class SearchApi(
 
   val timeoutResponse = HttpResponse(
     StatusCodes.ServiceUnavailable,
-    entity =
-      HttpEntity(
-        contentType = ContentTypes.`application/json`,
-        string = toJson(
-          DisplayError(
-            statusCode = StatusCodes.ServiceUnavailable,
-            description = "The server was not able to produce a timely response to your request. Please try again in a short while!"
-          )
+    entity = HttpEntity(
+      contentType = ContentTypes.`application/json`,
+      string = toJson(
+        DisplayError(
+          statusCode = StatusCodes.ServiceUnavailable,
+          description =
+            "The server was not able to produce a timely response to your request. Please try again in a short while!"
         )
       )
+    )
   )
 
   def rejectionHandler =


### PR DESCRIPTION
The front-end expects that the catalogue API will always return errors in JSON, but if we get a timeout we're returning the default akka-http response:

    The server was not able to produce a timely response to your request.
    Please try again in a short while!⏎

This wraps that error in our JSON error type, which should make it easier for the front-end to handle.

I considered adding a test for this, but this particular query doesn't timeout with an empty index (unsurprisingly) and I don't think it's worth the time to get a full repro.

For https://github.com/wellcomecollection/platform/issues/5665