### PR TITLE
invert the minimum_should_match percentage

### DIFF
--- a/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -92,7 +92,7 @@ case object WorksMultiMatcher {
               ),
               `type` = Some(BEST_FIELDS),
               operator = Some(OR)
-            ).minimumShouldMatch("80%"),
+            ).minimumShouldMatch("-20%"),
             MultiMatchQuery(
               q,
               queryName = Some("non-english titles and contributors"),
@@ -109,7 +109,7 @@ case object WorksMultiMatcher {
               ),
               `type` = Some(BEST_FIELDS),
               operator = Some(OR)
-            ).minimumShouldMatch("80%")
+            ).minimumShouldMatch("-20%")
           )
         ),
         bool(
@@ -160,7 +160,7 @@ case object WorksMultiMatcher {
             case (boost, field) =>
               FieldWithOptionalBoost(field, boost.map(_.toDouble))
           }
-        ).minimumShouldMatch("80%"),
+        ).minimumShouldMatch("-20%"),
         MultiMatchQuery(
           q,
           queryName = Some("shingles cased"),
@@ -174,7 +174,7 @@ case object WorksMultiMatcher {
             case (boost, field) =>
               FieldWithOptionalBoost(field, boost.map(_.toDouble))
           }
-        ).minimumShouldMatch("80%")
+        ).minimumShouldMatch("-20%")
       )
       .minimumShouldMatch(1)
 }

--- a/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/WorksMultiMatcher.scala
@@ -92,7 +92,7 @@ case object WorksMultiMatcher {
               ),
               `type` = Some(BEST_FIELDS),
               operator = Some(OR)
-            ).minimumShouldMatch("-20%"),
+            ).minimumShouldMatch("-30%"),
             MultiMatchQuery(
               q,
               queryName = Some("non-english titles and contributors"),
@@ -109,7 +109,7 @@ case object WorksMultiMatcher {
               ),
               `type` = Some(BEST_FIELDS),
               operator = Some(OR)
-            ).minimumShouldMatch("-20%")
+            ).minimumShouldMatch("-30%")
           )
         ),
         bool(
@@ -160,7 +160,7 @@ case object WorksMultiMatcher {
             case (boost, field) =>
               FieldWithOptionalBoost(field, boost.map(_.toDouble))
           }
-        ).minimumShouldMatch("-20%"),
+        ).minimumShouldMatch("-30%"),
         MultiMatchQuery(
           q,
           queryName = Some("shingles cased"),
@@ -174,7 +174,7 @@ case object WorksMultiMatcher {
             case (boost, field) =>
               FieldWithOptionalBoost(field, boost.map(_.toDouble))
           }
-        ).minimumShouldMatch("-20%")
+        ).minimumShouldMatch("-30%")
       )
       .minimumShouldMatch(1)
 }

--- a/search/src/test/resources/WorksMultiMatcherQuery.json
+++ b/search/src/test/resources/WorksMultiMatcherQuery.json
@@ -44,7 +44,7 @@
                   "query.titlesAndContributors.shingles^100.0"
                 ],
                 "type": "best_fields",
-                "minimum_should_match": "80%",
+                "minimum_should_match": "-20%",
                 "operator": "Or",
                 "_name": "title and contributor exact spellings"
               }
@@ -61,7 +61,7 @@
                   "query.titlesAndContributors.italian"
                 ],
                 "type": "best_fields",
-                "minimum_should_match": "80%",
+                "minimum_should_match": "-20%",
                 "operator": "Or",
                 "_name": "non-english titles and contributors"
               }
@@ -118,7 +118,7 @@
             "query.lettering"
           ],
           "type": "cross_fields",
-          "minimum_should_match": "80%",
+          "minimum_should_match": "-20%",
           "operator": "Or",
           "_name": "data"
         }
@@ -132,7 +132,7 @@
             "query.partOf.title.shingles_cased^10.0"
           ],
           "type": "most_fields",
-          "minimum_should_match": "80%",
+          "minimum_should_match": "-20%",
           "operator": "Or",
           "_name": "shingles cased"
         }

--- a/search/src/test/resources/WorksMultiMatcherQuery.json
+++ b/search/src/test/resources/WorksMultiMatcherQuery.json
@@ -44,7 +44,7 @@
                   "query.titlesAndContributors.shingles^100.0"
                 ],
                 "type": "best_fields",
-                "minimum_should_match": "-20%",
+                "minimum_should_match": "-30%",
                 "operator": "Or",
                 "_name": "title and contributor exact spellings"
               }
@@ -61,7 +61,7 @@
                   "query.titlesAndContributors.italian"
                 ],
                 "type": "best_fields",
-                "minimum_should_match": "-20%",
+                "minimum_should_match": "-30%",
                 "operator": "Or",
                 "_name": "non-english titles and contributors"
               }
@@ -118,7 +118,7 @@
             "query.lettering"
           ],
           "type": "cross_fields",
-          "minimum_should_match": "-20%",
+          "minimum_should_match": "-30%",
           "operator": "Or",
           "_name": "data"
         }
@@ -132,7 +132,7 @@
             "query.partOf.title.shingles_cased^10.0"
           ],
           "type": "most_fields",
-          "minimum_should_match": "-20%",
+          "minimum_should_match": "-30%",
           "operator": "Or",
           "_name": "shingles cased"
         }


### PR DESCRIPTION
The recent changes to the query have made things our matching logic a bit too permissive.

From a feedback email:

> We looked at searches for:
> - Mary Barnes (sorted for Newest first), that retrieved over 16,000 records, including everybody called Mary or Marie or Marya;
> - stereoscopic photographs (sorted for oldest first), which retrieves over 26,000 results including three 15th century manuscripts, none of which appear to have any relevance to the search term;

As a quick fix, we can invert the `minimum_should_match` percentage from `80%` to `-20%`. 

This should mean that instead of requiring 1 token to be present in a 2-token query, or 2 tokens to be present in a 3-token query, etc, we will require all terms to be present. Set at `-20%`, The `minimum_should_match` condition will only be applied to queries which are longer than 4 tokens., above which the percentage will be rounded down.

See the [the docs for the minimum_should_match parameter](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html) for a more detailed explanation