### PR TITLE
Add a script to open a concepts-pipeline PR when the API version changes

### DIFF
--- a/.buildkite/pipeline.deploy-prod.yml
+++ b/.buildkite/pipeline.deploy-prod.yml
@@ -99,3 +99,10 @@ steps:
     plugins:
       - wellcomecollection/aws-assume-role#v0.2.2:
           role: "arn:aws:iam::756629837203:role/catalogue-ci"
+
+  - wait
+
+  - label: "Bump the concepts-pipeline (if necessary)"
+    command: |
+      pip3 install boto3 http3
+      python3 .buildkite/scripts/open_concepts_pipeline_pr.py

--- a/.buildkite/pipeline.deploy-prod.yml
+++ b/.buildkite/pipeline.deploy-prod.yml
@@ -106,3 +106,5 @@ steps:
     command: |
       pip3 install boto3 http3
       python3 .buildkite/scripts/open_concepts_pipeline_pr.py
+    agents:
+      queue: nano

--- a/.buildkite/scripts/commands.py
+++ b/.buildkite/scripts/commands.py
@@ -1,0 +1,32 @@
+import subprocess
+import sys
+
+
+def _subprocess_run(cmd, exit_on_error=True):
+    print("*** Running %r" % " ".join(cmd))
+
+    output = []
+    pipe = subprocess.Popen(
+        cmd, encoding="utf8", stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    )
+
+    # Await command completion and print lines as they come in
+    for stdout_line in iter(pipe.stdout.readline, ""):
+        print(stdout_line, end="")
+        output.append(stdout_line)
+
+    # Extract results
+    pipe.communicate()
+    return_code = pipe.returncode
+
+    if return_code != 0 and exit_on_error:
+        sys.exit(return_code)
+
+    return "".join(output).strip()
+
+
+def git(*args, exit_on_error=True):
+    """Run a Git command and return its output."""
+    cmd = ["git"] + list(args)
+
+    return _subprocess_run(cmd, exit_on_error=exit_on_error)

--- a/.buildkite/scripts/open_concepts_pipeline_pr.py
+++ b/.buildkite/scripts/open_concepts_pipeline_pr.py
@@ -103,6 +103,7 @@ def create_concepts_pipeline_pull_request(*, pipeline_date):
         try:
             update_catalogue_pipeline_version(pipeline_date=pipeline_date)
         except AlreadyAtLatestVersionException:
+            print("concepts-pipeline repo is up to date, nothing to do!")
             return
 
         branch_name = f"point-concepts-pipeline-at-{pipeline_date}"

--- a/.buildkite/scripts/open_concepts_pipeline_pr.py
+++ b/.buildkite/scripts/open_concepts_pipeline_pr.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+The concepts pipeline needs to subscribe to the catalogue pipeline;
+currently it has the name of the catalogue pipeline in its Terraform.
+
+When we deploy a new catalogue API, this opens a PR on the concepts
+pipeline repo to point it at the new pipeline.
+"""
+
+import contextlib
+import json
+import os
+import re
+import shutil
+import tempfile
+import urllib.request
+
+import boto3
+import httpx
+
+from commands import git
+
+
+def current_pipeline_date():
+    resp = urllib.request.urlopen("https://api.wellcomecollection.org/catalogue/v2/_elasticConfig")
+
+    # this will be a string of the form 'works-indexed-YYYY-MM-DD'
+    works_index = json.load(resp)['worksIndex']
+
+    m = re.search(r'\d{4}-\d{2}-\d{2}', works_index)
+    if m is None:
+        raise RuntimeError(f'Could not work out what the current pipeline date is!')
+
+    return m.group(0)
+
+
+@contextlib.contextmanager
+def working_directory(path):
+    """
+    Changes the working directory to the given path, then returns to the
+    original directory when done.
+    """
+    prev_cwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev_cwd)
+
+
+@contextlib.contextmanager
+def cloned_repo(git_url):
+    """
+    Clones the repository and changes the working directory to the cloned
+    repo.  Cleans up the clone when it's done.
+    """
+    repo_dir = tempfile.mkdtemp()
+
+    git("clone", git_url, repo_dir)
+
+    try:
+        with working_directory(repo_dir):
+            yield
+    finally:
+        shutil.rmtree(repo_dir)
+
+
+class AlreadyAtLatestVersionException(Exception):
+    pass
+
+
+def update_catalogue_pipeline_version(*, pipeline_date):
+    old_lines = list(open("infrastructure/main.tf"))
+
+    with open("infrastructure/main.tf", "w") as out_file:
+        for line in old_lines:
+            if line.startswith("  catalogue_namespace = "):
+                new_line = f'  catalogue_namespace = "{pipeline_date}" // This is automatically bumped by the catalogue-api repo\n'
+
+                if new_line == line:
+                    raise AlreadyAtLatestVersionException()
+
+                out_file.write(new_line)
+            else:
+                out_file.write(line)
+
+
+def get_github_api_key():
+    session = boto3.Session()
+    secrets_client = session.client("secretsmanager")
+
+    secret_value = secrets_client.get_secret_value(SecretId="builds/github_wecobot/scala_libs_pr_bumps")
+
+    return secret_value["SecretString"]
+
+
+def create_concepts_pipeline_pull_request(*, pipeline_date):
+    with cloned_repo("git@github.com:wellcomecollection/concepts-pipeline.git"):
+        try:
+            update_catalogue_pipeline_version(pipeline_date=pipeline_date)
+        except AlreadyAtLatestVersionException:
+            return
+
+        branch_name = f"point-concepts-pipeline-at-{pipeline_date}"
+
+        git("config", "--local", "user.email", "wellcomedigitalplatform@wellcome.ac.uk")
+        git("config", "--local", "user.name", "BuildKite on behalf of Wellcome Collection")
+
+        git("checkout", "-b", branch_name)
+        git("add", "infrastructure/main.tf")
+        git("commit", "-m", f"Point concepts-pipeline at {pipeline_date}")
+        git("push", "origin", branch_name)
+
+        api_key = get_github_api_key()
+
+        client = httpx.Client(auth=("weco-bot", api_key))
+
+        r = client.post(
+            f"https://api.github.com/repos/wellcomecollection/concepts-pipeline/pulls",
+            headers={"Accept": "application/vnd.github.v3+json"},
+            json={
+                "head": branch_name,
+                "base": "main",
+                "title": f"Point concepts-pipeline at {pipeline_date}",
+                "maintainer_can_modify": True,
+                "body": "",
+            }
+        )
+
+        try:
+            r.raise_for_status()
+            new_pr_number = r.json()["number"]
+        except Exception:
+            print(r.json())
+            raise
+
+        r = client.post(
+            f"https://api.github.com/repos/wellcomecollection/concepts-pipeline/pulls/{new_pr_number}/requested_reviewers",
+            headers={"Accept": "application/vnd.github.v3+json"},
+            json={"team_reviewers": ["scala-reviewers"]}
+        )
+
+        print(r.json())
+
+        try:
+            r.raise_for_status()
+        except Exception:
+            raise
+
+
+if __name__ == '__main__':
+    create_concepts_pipeline_pull_request(
+        pipeline_date=current_pipeline_date()
+    )

--- a/.buildkite/scripts/open_concepts_pipeline_pr.py
+++ b/.buildkite/scripts/open_concepts_pipeline_pr.py
@@ -22,14 +22,16 @@ from commands import git
 
 
 def current_pipeline_date():
-    resp = urllib.request.urlopen("https://api.wellcomecollection.org/catalogue/v2/_elasticConfig")
+    resp = urllib.request.urlopen(
+        "https://api.wellcomecollection.org/catalogue/v2/_elasticConfig"
+    )
 
     # this will be a string of the form 'works-indexed-YYYY-MM-DD'
-    works_index = json.load(resp)['worksIndex']
+    works_index = json.load(resp)["worksIndex"]
 
-    m = re.search(r'\d{4}-\d{2}-\d{2}', works_index)
+    m = re.search(r"\d{4}-\d{2}-\d{2}", works_index)
     if m is None:
-        raise RuntimeError(f'Could not work out what the current pipeline date is!')
+        raise RuntimeError(f"Could not work out what the current pipeline date is!")
 
     return m.group(0)
 
@@ -89,7 +91,9 @@ def get_github_api_key():
     session = boto3.Session()
     secrets_client = session.client("secretsmanager")
 
-    secret_value = secrets_client.get_secret_value(SecretId="builds/github_wecobot/scala_libs_pr_bumps")
+    secret_value = secrets_client.get_secret_value(
+        SecretId="builds/github_wecobot/scala_libs_pr_bumps"
+    )
 
     return secret_value["SecretString"]
 
@@ -104,7 +108,12 @@ def create_concepts_pipeline_pull_request(*, pipeline_date):
         branch_name = f"point-concepts-pipeline-at-{pipeline_date}"
 
         git("config", "--local", "user.email", "wellcomedigitalplatform@wellcome.ac.uk")
-        git("config", "--local", "user.name", "BuildKite on behalf of Wellcome Collection")
+        git(
+            "config",
+            "--local",
+            "user.name",
+            "BuildKite on behalf of Wellcome Collection",
+        )
 
         git("checkout", "-b", branch_name)
         git("add", "infrastructure/main.tf")
@@ -124,7 +133,7 @@ def create_concepts_pipeline_pull_request(*, pipeline_date):
                 "title": f"Point concepts-pipeline at {pipeline_date}",
                 "maintainer_can_modify": True,
                 "body": "",
-            }
+            },
         )
 
         try:
@@ -137,7 +146,7 @@ def create_concepts_pipeline_pull_request(*, pipeline_date):
         r = client.post(
             f"https://api.github.com/repos/wellcomecollection/concepts-pipeline/pulls/{new_pr_number}/requested_reviewers",
             headers={"Accept": "application/vnd.github.v3+json"},
-            json={"team_reviewers": ["scala-reviewers"]}
+            json={"team_reviewers": ["scala-reviewers"]},
         )
 
         print(r.json())
@@ -148,7 +157,5 @@ def create_concepts_pipeline_pull_request(*, pipeline_date):
             raise
 
 
-if __name__ == '__main__':
-    create_concepts_pipeline_pull_request(
-        pipeline_date=current_pipeline_date()
-    )
+if __name__ == "__main__":
+    create_concepts_pipeline_pull_request(pipeline_date=current_pipeline_date())


### PR DESCRIPTION
I've tested this locally and it created a (now-closed) PR, so I think it's working correctly.

Rough steps:

* After we deploy to prod, what's the prod index date?
* Clone the concepts-pipeline repo
* Bump the catalogue-pipeline date it's looking at – if it's already up-to-date, stop
* Otherwise, push the change, open a PR, ask for devs to review

This is heavily cribbed from a similar script in scala-libs: https://github.com/wellcomecollection/scala-libs/blob/main/.buildkite/scripts/open_downstream_prs.py

See https://github.com/wellcomecollection/concepts-pipeline/pull/107, for https://github.com/wellcomecollection/platform/issues/5666