### PR TITLE
Change the way we handle the lookup of unhandled items

### DIFF
--- a/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
+++ b/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
@@ -1,10 +1,7 @@
 package weco.api.items.services
 
 import grizzled.slf4j.Logging
-import weco.api.stacks.models.{
-  DisplayItemOps,
-  SierraItemIdentifier
-}
+import weco.api.stacks.models.{DisplayItemOps, SierraItemIdentifier}
 import weco.catalogue.display_model.identifiers.DisplayIdentifierType
 import weco.catalogue.display_model.locations.{
   DisplayAccessCondition,
@@ -112,7 +109,8 @@ class SierraItemUpdater(sierraSource: SierraSource)(
 
     for {
       accessConditions <- staleItems.size match {
-        case 0 => Future.successful(Map.empty[SierraItemNumber, DisplayAccessCondition])
+        case 0 =>
+          Future.successful(Map.empty[SierraItemNumber, DisplayAccessCondition])
         case _ => getAccessConditions(staleItems)
       }
 

--- a/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
+++ b/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
@@ -2,7 +2,6 @@ package weco.api.items.services
 
 import grizzled.slf4j.Logging
 import weco.api.stacks.models.{
-  CatalogueAccessMethod,
   DisplayItemOps,
   SierraItemIdentifier
 }
@@ -112,7 +111,10 @@ class SierraItemUpdater(sierraSource: SierraSource)(
     )
 
     for {
-      accessConditions <- getUpdatedAccessConditions(staleItems)
+      accessConditions <- staleItems.size match {
+        case 0 => Future.successful(Map.empty[SierraItemNumber, DisplayAccessCondition])
+        case _ => getAccessConditions(staleItems)
+      }
 
       updatedItems = itemMap.map {
         case (sierraId, item) =>
@@ -123,34 +125,4 @@ class SierraItemUpdater(sierraSource: SierraSource)(
       }
     } yield updatedItems.toSeq
   }
-
-  /** Given a series of item IDs, get the most up-to-date access condition
-    * information from Sierra.
-    *
-    */
-  private def getUpdatedAccessConditions(
-    itemIds: Map[SierraItemNumber, Option[DisplayLocationType]]
-  ): Future[Map[SierraItemNumber, DisplayAccessCondition]] =
-    itemIds.size match {
-      case 0 => Future.successful(Map())
-
-      case _ =>
-        for {
-          accessConditionsMap <- getAccessConditions(itemIds)
-
-          // It is possible for there to be a situation where Sierra does not know about
-          // an Item that is in the Catalogue API, but this situation should be very rare.
-          // For example an item has been deleted but the change has not yet propagated.
-          // In that case it gets method "NotRequestable".
-          missingItemIds = itemIds.keySet.diff(accessConditionsMap.keySet)
-
-          missingItemsMap = missingItemIds
-            .map(
-              _ -> DisplayAccessCondition(
-                method = CatalogueAccessMethod.NotRequestable
-              )
-            )
-            .toMap
-        } yield accessConditionsMap ++ missingItemsMap
-    }
 }

--- a/items/src/test/resources/sierra-item-on-loan.json
+++ b/items/src/test/resources/sierra-item-on-loan.json
@@ -1,0 +1,87 @@
+{
+  "barcode": "22501739848",
+  "bibIds": [
+    "1589866"
+  ],
+  "callNumber": "B105.T54 2004W48h",
+  "copyNo": 1,
+  "createdDate": "2013-06-17T07:54:52Z",
+  "deleted": false,
+  "fixedFields": {
+    "108": {
+      "display": "Open shelves",
+      "label": "OPACMSG",
+      "value": "o"
+    },
+    "58": {
+      "label": "COPY #",
+      "value": "1"
+    },
+    "61": {
+      "display": "book",
+      "label": "I TYPE",
+      "value": "0"
+    },
+    "70": {
+      "label": "IN LOC",
+      "value": "0"
+    },
+    "79": {
+      "display": "Medical Collection",
+      "label": "LOCATION",
+      "value": "wgmem"
+    },
+    "88": {
+      "display": "Available",
+      "label": "STATUS",
+      "value": "-"
+    },
+    "97": {
+      "label": "IMESSAGE",
+      "value": "-"
+    },
+    "98": {
+      "label": "PDATE",
+      "value": "2021-05-11T14:38:43Z"
+    }
+  },
+  "holdCount": 0,
+  "id": "1835534",
+  "itemType": "book",
+  "location": {
+    "code": "wgmem",
+    "name": "Medical Collection"
+  },
+  "status": {
+    "code": "-",
+    "display": "Available"
+  },
+  "suppressed": false,
+  "updatedDate": "2021-06-09T12:32:03Z",
+  "varFields": [
+    {
+      "content": "22501739848",
+      "fieldTag": "b"
+    },
+    {
+      "fieldTag": "c",
+      "ind1": "0",
+      "ind2": "0",
+      "marcTag": "949",
+      "subfields": [
+        {
+          "content": "B105.T54 2004W48h",
+          "tag": "a"
+        }
+      ]
+    },
+    {
+      "content": "1",
+      "fieldTag": "g"
+    },
+    {
+      "content": ".i15566638",
+      "fieldTag": "y"
+    }
+  ]
+}

--- a/items/src/test/resources/work-with-items-on-loan.json
+++ b/items/src/test/resources/work-with-items-on-loan.json
@@ -1,0 +1,102 @@
+{
+  "physicalDescription": "1 volume ; 24 cm",
+  "items": [
+    {
+      "id": "ankgmzj2",
+      "identifiers": [
+        {
+          "identifierType": {
+            "id": "sierra-system-number",
+            "label": "Sierra system number",
+            "type": "IdentifierType"
+          },
+          "value": "i18355341",
+          "type": "Identifier"
+        },
+        {
+          "identifierType": {
+            "id": "sierra-identifier",
+            "label": "Sierra identifier",
+            "type": "IdentifierType"
+          },
+          "value": "1835534",
+          "type": "Identifier"
+        }
+      ],
+      "locations": [
+        {
+          "label": "Medical Collection",
+          "accessConditions": [
+            {
+              "method": {
+                "id": "open-shelves",
+                "label": "Open shelves",
+                "type": "AccessMethod"
+              },
+              "status": {
+                "id": "temporarily-unavailable",
+                "label": "Temporarily unavailable",
+                "type": "AccessStatus"
+              },
+              "note": "Item is in use by another reader. Please ask at Library Enquiry Desk.",
+              "type": "AccessCondition"
+            }
+          ],
+          "shelfmark": "B105.T54 2004W48h",
+          "locationType": {
+            "id": "open-shelves",
+            "label": "Open shelves",
+            "type": "LocationType"
+          },
+          "type": "PhysicalLocation"
+        }
+      ],
+      "type": "Item"
+    }
+  ],
+  "workType": {
+    "id": "a",
+    "label": "Books",
+    "type": "Format"
+  },
+  "identifiers": [
+    {
+      "identifierType": {
+        "id": "sierra-system-number",
+        "label": "Sierra system number",
+        "type": "IdentifierType"
+      },
+      "value": "b15898660",
+      "type": "Identifier"
+    },
+    {
+      "identifierType": {
+        "id": "sierra-identifier",
+        "label": "Sierra identifier",
+        "type": "IdentifierType"
+      },
+      "value": "1589866",
+      "type": "Identifier"
+    },
+    {
+      "identifierType": {
+        "id": "isbn",
+        "label": "International Standard Book Number",
+        "type": "IdentifierType"
+      },
+      "value": "0007140967",
+      "type": "Identifier"
+    }
+  ],
+  "alternativeTitles": [],
+  "id": "g2773269",
+  "title": "How mumbo-jumbo conquered the world / Francis Wheen.",
+  "type": "Work",
+  "availabilities": [
+    {
+      "id": "open-shelves",
+      "label": "Open shelves",
+      "type": "Availability"
+    }
+  ]
+}

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -126,16 +126,15 @@ class ItemUpdateServiceTest
     )
   }
 
-  def availableItem(sierraItemNumber: SierraItemNumber) = {
-    val availableOnline = DisplayAccessCondition(
-      method = CatalogueAccessMethod.OnlineRequest
-    )
-
+  def availableItem(sierraItemNumber: SierraItemNumber) =
     createPhysicalItemWith(
       sierraItemNumber = sierraItemNumber,
-      accessCondition = availableOnline
+      accessCondition = availableOnlineAccessCondition
     )
-  }
+
+  val availableOnlineAccessCondition = DisplayAccessCondition(
+    method = CatalogueAccessMethod.OnlineRequest
+  )
 
   val onHoldAccessCondition = DisplayAccessCondition(
     method = CatalogueAccessMethod.NotRequestable,
@@ -289,7 +288,7 @@ class ItemUpdateServiceTest
       (
         missingItemResponse(workWithAvailableItemNumber),
         workWithAvailableItem,
-        notRequestableAccessCondition
+        availableOnlineAccessCondition
       )
     )
 


### PR DESCRIPTION
When the items API is asked to look up an item status, it:

1) fetches the item from Sierra
2) tries to work out what the latest status of the item is

What happens if:

i)  we can't fetch the item from Sierra, or
ii) we can't work out what the new status should be

We have some logic in the old `getUpdatedAccessConditions` method which would add a default access condition of 'not requestable', but this drops any context about why – for example, if the catalogue API tells us that an item is not requestable because it's on loan, the items API will lose that descriptive message.

This default access condition was meant for (i) but it was being applied to (ii) also.  I'm not entirely sure it's the right behaviour and it was only an edge case anyway, so I've removed it.

I've also added a test for the "item on loan to staff" case, which is what we care about here.

For https://github.com/wellcomecollection/platform/issues/5632