### PR TITLE
fix diff_tool German language route

### DIFF
--- a/diff_tool/routes.json
+++ b/diff_tool/routes.json
@@ -47,7 +47,7 @@
   {
     "path": "/works",
     "params": {
-      "language": "ger"
+      "languages": "ger"
     }
   },
   {


### PR DESCRIPTION
The test that looked like it was checking that filters work (using German as an example) was actually performing an unfiltered request, because the wrong query string parameter was being used.
