### PR TITLE
Use the new Terraform module to create ACM certificates

### DIFF
--- a/terraform/catalogue_api/.terraform.lock.hcl
+++ b/terraform/catalogue_api/.terraform.lock.hcl
@@ -2,19 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.45.0"
+  version = "4.61.0"
   hashes = [
-    "h1:9l/yDPt/OPG6a0ITu7amfq1LjdnWHTsOgn/KOxM26HA=",
-    "zh:0fdbb3af75ff55807466533f97eb314556ec41a908a543d7cafb06546930f7c6",
-    "zh:20656895744fa0f4607096b9681c77b2385f450b1577f9151d3070818378a724",
-    "zh:390f316d00f25a5e45ef5410961fd05bf673068c1b701dc752d11df6d8e741d7",
-    "zh:3da70f9de241d5f66ea9994ef1e0beddfdb005fa2d2ef6712392f57c5d2e4844",
-    "zh:65de63cc0f97c85c28a19db560c546aa25f4f403dbf4783ac53c3918044cf180",
-    "zh:6fc52072e5a66a5d0510aaa2b373a2697895f51398613c68619d8c0c95fc75f5",
-    "zh:7c1da61092bd1206a020e3ee340ab11be8a4f9bb74e925ca1229ea5267fb3a62",
-    "zh:94e533d86ce3c08e7102dcabe34ba32ae7fd7819fd0aedef28f48d29e635eae2",
-    "zh:a3180d4826662e19e71cf20e925a2be8613a51f2f3f7b6d2643ac1418b976d58",
-    "zh:c783df364928c77fd4dec5419533b125bebe2d50212c4ad609f83b701c2d981a",
-    "zh:e1279bde388cb675d324584d965c6d22c3ec6890b13de76a50910a3bcd84ed64",
+    "h1:GrboLwI2hok/i8xfq87uS9kUKPqAE8b/1iJTEupRthY=",
   ]
 }

--- a/terraform/snapshots/.terraform.lock.hcl
+++ b/terraform/snapshots/.terraform.lock.hcl
@@ -2,23 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "4.53.0"
+  version = "4.61.0"
   hashes = [
-    "h1:SamdqgizhmtJ7ejTM/G8RoxMoKC1ovLnd1jBzCFkI7c=",
-    "zh:0d44171544a916adf0fa96b7d0851a49d8dec98f71f0229dfd2d178958b3996b",
-    "zh:16945808ce26b86af7f5a77c4ab1154da786208c793abb95b8f918b4f48daded",
-    "zh:1a57a5a30cef9a5867579d894b74f60bb99afc7ca0d030d49a80ad776958b428",
-    "zh:2c718734ae17430d7f598ca0b4e4f86d43d66569c72076a10f4ace3ff8dfc605",
-    "zh:46fdf6301cb2fa0a4d122d1a8f75f047b6660c24851d6a4537ee38926a86485d",
-    "zh:53a53920b38a9e1648e85c6ee33bccf95bfcd067bffc4934a2af55621e6a6bd9",
-    "zh:548d927b234b1914c43169224b03f641d0961a4e312e5c6508657fce27b66db4",
-    "zh:57c847b2a5ae41ddea20b18ef006369d36bfdc4dec7f542f60e22a47f7b6f347",
-    "zh:79f7402b581621ba69f5a07ce70299735c678beb265d114d58955d04f0d39f87",
-    "zh:8970109a692dc4ecbda98a0969da472da4759db90ce22f2a196356ea85bb2cf7",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a500cc4ffcad854dec0cf6f97751930a53c9f278f143a4355fa8892aa77c77bf",
-    "zh:b687c20b42a8b9e9e9f56c42e3b3c6859c043ec72b8907a6e4d4b64068e11df5",
-    "zh:e2c592e96822b78287554be43c66398f658c74c4ae3796f6b9e6d4b0f1f7f626",
-    "zh:ff1c4a46fdc988716c6fc28925549600093fc098828237cb1a30264e15cf730f",
+    "h1:GrboLwI2hok/i8xfq87uS9kUKPqAE8b/1iJTEupRthY=",
   ]
 }

--- a/terraform/snapshots/cloudfront.tf
+++ b/terraform/snapshots/cloudfront.tf
@@ -47,7 +47,7 @@ resource "aws_cloudfront_distribution" "data_api" {
   price_class = "PriceClass_100"
 
   viewer_certificate {
-    acm_certificate_arn      = aws_acm_certificate_validation.catalogue_api_validation.certificate_arn
+    acm_certificate_arn      = module.certificate.arn
     minimum_protocol_version = "TLSv1"
     ssl_support_method       = "sni-only"
   }

--- a/terraform/snapshots/domain.tf
+++ b/terraform/snapshots/domain.tf
@@ -4,39 +4,17 @@ data "aws_route53_zone" "dotorg" {
   name = "wellcomecollection.org."
 }
 
-resource "aws_acm_certificate" "data_page" {
-  provider = aws.us_east_1
+module "certificate" {
+  source = "github.com/wellcomecollection/terraform-aws-acm-certificate?ref=v1.0.0"
 
-  domain_name       = var.data_page_url
-  validation_method = "DNS"
+  domain_name = var.data_page_url
 
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_route53_record" "cert_validation" {
-  provider = aws.dns
-  for_each = {
-    for dvo in aws_acm_certificate.data_page.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      type   = dvo.resource_record_type
-      record = dvo.resource_record_value
-    }
-  }
-
-  name    = each.value.name
-  type    = each.value.type
   zone_id = data.aws_route53_zone.dotorg.id
-  records = [each.value.record]
-  ttl     = 60
-}
 
-resource "aws_acm_certificate_validation" "catalogue_api_validation" {
-  provider = aws.us_east_1
-
-  certificate_arn         = aws_acm_certificate.data_page.arn
-  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+  providers = {
+    aws     = aws.us_east_1
+    aws.dns = aws.dns
+  }
 }
 
 resource "aws_route53_record" "data_page" {


### PR DESCRIPTION
This reduces a bit of repetition; standardises our approach to creating certificates. In particular this was still using the old count/lookup approach, but we have a nicer way using `foreach` now.

For https://github.com/wellcomecollection/platform/issues/5677