### PR TITLE
5695-use new 2023-06-01 pipeline, now with added Accession Numbers

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
@@ -10,7 +10,7 @@ case class ElasticConfig(
 trait ElasticConfigBase {
   // We use this to share config across Scala API applications
   // i.e. The API and the snapshot generator.
-  val pipelineDate = "2023-03-29"
+  val pipelineDate = "2023-06-01"
 }
 
 object PipelineClusterElasticConfig extends ElasticConfigBase {


### PR DESCRIPTION
## Pull request checklist

*   Does this patch need a change to the documentation?

    Do you need to update the [Catalogue API Swagger][swagger]? No

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml

This is part of this [issue](https://github.com/wellcomecollection/platform/issues/5695): expose accession numbers for archives