### PR TITLE
Reduce the cost of running the catalogue API

### DIFF
--- a/terraform/modules/service/main.tf
+++ b/terraform/modules/service/main.tf
@@ -1,25 +1,25 @@
 module "log_router_container" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.13.1"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/firelens?ref=v3.15.3"
   namespace = var.service_name
 
   use_privatelink_endpoint = true
 }
 
 module "log_router_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.13.1"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.15.3"
   secrets   = module.log_router_container.shared_secrets_logging
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "nginx_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.13.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/nginx/apigw?ref=v3.15.3"
 
   forward_port      = var.container_port
   log_configuration = module.log_router_container.container_log_configuration
 }
 
 module "app_container" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.13.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v3.15.3"
   name   = "app"
 
   image = var.container_image
@@ -31,13 +31,13 @@ module "app_container" {
 }
 
 module "app_container_secrets_permissions" {
-  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.13.1"
+  source    = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/secrets?ref=v3.15.3"
   secrets   = var.secrets
   role_name = module.task_definition.task_execution_role_name
 }
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.13.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v3.15.3"
 
   cpu    = var.app_cpu
   memory = var.app_memory
@@ -52,7 +52,7 @@ module "task_definition" {
 }
 
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.13.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v3.15.3"
 
   cluster_arn  = var.cluster_arn
   service_name = var.service_name
@@ -65,10 +65,12 @@ module "service" {
   security_group_ids = var.security_group_ids
 
   desired_task_count = var.desired_task_count
-  use_fargate_spot   = var.use_fargate_spot
 
   target_group_arn = aws_lb_target_group.tcp.arn
 
   container_name = module.nginx_container.container_name
   container_port = module.nginx_container.container_port
+
+  use_fargate_spot              = var.use_fargate_spot
+  turn_off_outside_office_hours = var.turn_off_outside_office_hours
 }

--- a/terraform/modules/service/variables.tf
+++ b/terraform/modules/service/variables.tf
@@ -31,6 +31,11 @@ variable "use_fargate_spot" {
   default = false
 }
 
+variable "turn_off_outside_office_hours" {
+  type    = bool
+  default = false
+}
+
 variable "cluster_arn" {
   type = string
 }

--- a/terraform/modules/stack/services.tf
+++ b/terraform/modules/stack/services.tf
@@ -47,6 +47,9 @@ module "search_api" {
   cluster_arn        = var.cluster_arn
   vpc_id             = var.vpc_id
   load_balancer_arn  = aws_lb.catalogue_api.arn
+
+  use_fargate_spot              = var.environment_name == "stage" ? true : false
+  turn_off_outside_office_hours = var.environment_name == "stage" ? true : false
 }
 
 module "items_api" {
@@ -86,6 +89,9 @@ module "items_api" {
   cluster_arn        = var.cluster_arn
   vpc_id             = var.vpc_id
   load_balancer_arn  = aws_lb.catalogue_api.arn
+
+  use_fargate_spot              = var.environment_name == "stage" ? true : false
+  turn_off_outside_office_hours = var.environment_name == "stage" ? true : false
 }
 
 module "concepts_api" {
@@ -117,4 +123,7 @@ module "concepts_api" {
   cluster_arn        = var.cluster_arn
   vpc_id             = var.vpc_id
   load_balancer_arn  = aws_lb.catalogue_api.arn
+
+  use_fargate_spot              = var.environment_name == "stage" ? true : false
+  turn_off_outside_office_hours = var.environment_name == "stage" ? true : false
 }


### PR DESCRIPTION
* Use Fargate Spot for running stage services
* Turn off the stage APIs outside office hours

Note: this check is deliberately a conservative check for the `stage` environment (opting in to cost-saving behaviour) rather than a loose check that we're not in the `prod` environment (opting out).  This means we're less likely to implement cost-saving in an environment which is part of a production service.

For https://github.com/wellcomecollection/platform/issues/5704