### PR TITLE
Remove AnyFunSpec from base trait

### DIFF
--- a/search/src/test/scala/weco/api/search/ApiErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/ApiErrorsTest.scala
@@ -1,8 +1,9 @@
 package weco.api.search
 
+import org.scalatest.funspec.AnyFunSpec
 import weco.api.search.works.ApiWorksTestBase
 
-class ApiErrorsTest extends ApiWorksTestBase {
+class ApiErrorsTest extends AnyFunSpec with ApiWorksTestBase {
   it("returns a Not Found error if you try to get an unrecognised path") {
     withApi { route =>
       assertNotFound(route)(

--- a/search/src/test/scala/weco/api/search/ApiSearchTemplatesTest.scala
+++ b/search/src/test/scala/weco/api/search/ApiSearchTemplatesTest.scala
@@ -2,10 +2,11 @@ package weco.api.search
 
 import akka.http.scaladsl.model.ContentTypes
 import io.circe.Json
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.api.search.works.ApiWorksTestBase
 
-class ApiSearchTemplatesTest extends ApiWorksTestBase with Matchers {
+class ApiSearchTemplatesTest extends AnyFunSpec with ApiWorksTestBase with Matchers {
   it("renders a list of available search templates") {
     checkJson { json =>
       json.isObject shouldBe true

--- a/search/src/test/scala/weco/api/search/ApiTestBase.scala
+++ b/search/src/test/scala/weco/api/search/ApiTestBase.scala
@@ -1,10 +1,13 @@
 package weco.api.search
 
 import akka.http.scaladsl.server.Route
-import org.scalatest.Assertion
+import org.scalatest.{Assertion, Suite}
 import weco.api.search.fixtures.ApiFixture
 
+import scala.math
+
 trait ApiTestBase extends ApiFixture {
+  this: Suite =>
   val publicRootUri = "https://api-testing.local/catalogue/v2"
 
   // This is the path relative to which requests are made on the host,
@@ -40,6 +43,13 @@ trait ApiTestBase extends ApiFixture {
       "label": "Gone",
       "description": "$description"
     }"""
+
+  def resultListWithCalculatedPageCount(totalResults: Int, pageSize: Int = 10): String =
+    resultList(
+      pageSize,
+      totalPages = math.ceil(totalResults.toDouble / pageSize).toInt,
+      totalResults = totalResults
+    )
 
   def resultList(
     pageSize: Int = 10,

--- a/search/src/test/scala/weco/api/search/fixtures/ApiFixture.scala
+++ b/search/src/test/scala/weco/api/search/fixtures/ApiFixture.scala
@@ -7,14 +7,13 @@ import akka.http.scaladsl.server.Route
 import com.sksamuel.elastic4s.Index
 import io.circe.parser.parse
 import io.circe.Json
-import org.scalatest.Assertion
-import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.{Assertion, Suite}
 import weco.api.search.SearchApi
 import weco.fixtures.TestWith
 import weco.api.search.models.{ApiConfig, ElasticConfig, QueryConfig}
 
-trait ApiFixture extends AnyFunSpec with ScalatestRouteTest with IndexFixtures {
-
+trait ApiFixture extends ScalatestRouteTest with IndexFixtures {
+  this: Suite =>
   val Status = akka.http.scaladsl.model.StatusCodes
 
   val publicRootUri: String

--- a/search/src/test/scala/weco/api/search/images/ApiImagesTestBase.scala
+++ b/search/src/test/scala/weco/api/search/images/ApiImagesTestBase.scala
@@ -1,5 +1,6 @@
 package weco.api.search.images
 
+import org.scalatest.Suite
 import weco.api.search.ApiTestBase
 import weco.api.search.fixtures.TestDocumentFixtures
 import weco.api.search.json.CatalogueJsonUtil
@@ -9,7 +10,7 @@ trait ApiImagesTestBase
     extends ApiTestBase
     with CatalogueJsonUtil
     with TestDocumentFixtures {
-
+  this: Suite =>
   def imagesListResponse(
     ids: Seq[String],
     strictOrdering: Boolean = false

--- a/search/src/test/scala/weco/api/search/images/ImagesAggregationsTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesAggregationsTest.scala
@@ -1,8 +1,10 @@
 package weco.api.search.images
 
+import org.scalatest.funspec.AnyFunSpec
 import weco.api.search.models.request.SingleImageIncludes
 
-class ImagesAggregationsTest extends ApiImagesTestBase {
+class ImagesAggregationsTest extends AnyFunSpec
+with ApiImagesTestBase {
   it("aggregates by license") {
     val images = (0 to 6).map(i => s"images.different-licenses.$i")
     val displayImages = images

--- a/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesErrorsTest.scala
@@ -1,10 +1,12 @@
 package weco.api.search.images
 
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.prop.TableDrivenPropertyChecks
 import weco.api.search.models.ElasticConfig
 
 class ImagesErrorsTest
-    extends ApiImagesTestBase
+    extends AnyFunSpec
+    with ApiImagesTestBase
     with TableDrivenPropertyChecks {
   describe("returns a 404 for missing resources") {
     it("looking up an image that doesn't exist") {

--- a/search/src/test/scala/weco/api/search/images/ImagesFilteredAggregationsTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesFilteredAggregationsTest.scala
@@ -1,8 +1,9 @@
 package weco.api.search.images
 
+import org.scalatest.funspec.AnyFunSpec
 import weco.api.search.models.request.SingleImageIncludes
 
-class ImagesFilteredAggregationsTest extends ApiImagesTestBase {
+class ImagesFilteredAggregationsTest extends AnyFunSpec with ApiImagesTestBase {
   it("filters and aggregates by license") {
     withImagesApi {
       case (imagesIndex, routes) =>

--- a/search/src/test/scala/weco/api/search/images/ImagesFiltersTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesFiltersTest.scala
@@ -2,9 +2,10 @@ package weco.api.search.images
 
 import akka.http.scaladsl.server.Route
 import org.scalatest.Assertion
+import org.scalatest.funspec.AnyFunSpec
 import weco.fixtures.TestWith
 
-class ImagesFiltersTest extends ApiImagesTestBase {
+class ImagesFiltersTest extends AnyFunSpec with ApiImagesTestBase {
   describe("filtering images by license") {
     it("filters by license") {
       withImagesApi {

--- a/search/src/test/scala/weco/api/search/images/ImagesIncludesTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesIncludesTest.scala
@@ -1,6 +1,8 @@
 package weco.api.search.images
 
-class ImagesIncludesTest extends ApiImagesTestBase {
+import org.scalatest.funspec.AnyFunSpec
+
+class ImagesIncludesTest extends AnyFunSpec with ApiImagesTestBase {
   describe("images includes") {
     it(
       "includes the source contributors on results from the list endpoint if we pass ?include=source.contributors"

--- a/search/src/test/scala/weco/api/search/images/ImagesSimilarityTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesSimilarityTest.scala
@@ -1,8 +1,9 @@
 package weco.api.search.images
 
 import io.circe.Json
+import org.scalatest.funspec.AnyFunSpec
 
-class ImagesSimilarityTest extends ApiImagesTestBase {
+class ImagesSimilarityTest extends AnyFunSpec with ApiImagesTestBase {
 
   /**
     * These tests treat the simple presence of the requested property as a proxy

--- a/search/src/test/scala/weco/api/search/images/ImagesTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesTest.scala
@@ -1,8 +1,9 @@
 package weco.api.search.images
 
+import org.scalatest.funspec.AnyFunSpec
 import weco.api.search.models.request.SingleImageIncludes
 
-class ImagesTest extends ApiImagesTestBase {
+class ImagesTest extends AnyFunSpec with ApiImagesTestBase {
   it("returns a list of images") {
     withImagesApi {
       case (imagesIndex, routes) =>
@@ -112,11 +113,11 @@ class ImagesTest extends ApiImagesTestBase {
 
           assertJsonResponse(
             routes,
-            path =
-              s"$rootPath/images?sort=source.production.dates"
+            path = s"$rootPath/images?sort=source.production.dates"
           ) {
             Status.OK -> imagesListResponse(
-              ids = productionImages, strictOrdering = true
+              ids = productionImages,
+              strictOrdering = true
             )
           }
       }
@@ -133,7 +134,8 @@ class ImagesTest extends ApiImagesTestBase {
               s"$rootPath/images?sort=source.production.dates&sortOrder=asc"
           ) {
             Status.OK -> imagesListResponse(
-              ids = productionImages, strictOrdering = true
+              ids = productionImages,
+              strictOrdering = true
             )
           }
       }
@@ -150,7 +152,8 @@ class ImagesTest extends ApiImagesTestBase {
               s"$rootPath/images?sort=source.production.dates&sortOrder=desc"
           ) {
             Status.OK -> imagesListResponse(
-              ids = productionImages.reverse, strictOrdering = true
+              ids = productionImages.reverse,
+              strictOrdering = true
             )
           }
       }

--- a/search/src/test/scala/weco/api/search/works/ApiWorksTestBase.scala
+++ b/search/src/test/scala/weco/api/search/works/ApiWorksTestBase.scala
@@ -1,6 +1,7 @@
 package weco.api.search.works
 
 import io.circe.Json
+import org.scalatest.Suite
 import weco.api.search.ApiTestBase
 import weco.api.search.fixtures.TestDocumentFixtures
 import weco.api.search.json.CatalogueJsonUtil
@@ -10,6 +11,7 @@ trait ApiWorksTestBase
     extends ApiTestBase
     with CatalogueJsonUtil
     with TestDocumentFixtures {
+  this: Suite =>
 
   def getMinimalDisplayWorks(ids: Seq[String]): Seq[Json] =
     ids
@@ -21,10 +23,19 @@ trait ApiWorksTestBase
     ids: Seq[String],
     includes: WorksIncludes = WorksIncludes.none,
     strictOrdering: Boolean = false
+  ): String =
+    s"{${worksList(ids, includes, strictOrdering)}}"
+
+  private def worksList(
+    ids: Seq[String],
+    includes: WorksIncludes = WorksIncludes.none,
+    strictOrdering: Boolean = false
   ): String = {
     val works =
       ids
-        .map { getVisibleWork }
+        .map {
+          getVisibleWork
+        }
         .map(_.display.withIncludes(includes))
 
     val sortedWorks = if (strictOrdering) {
@@ -32,14 +43,39 @@ trait ApiWorksTestBase
     } else {
       works.sortBy(w => getKey(w, "id").get.asString)
     }
-
     s"""
-       |{
-       |  ${resultList(totalResults = ids.size)},
+       |  ${resultListWithCalculatedPageCount(
+         totalResults = ids.size
+       )},
        |  "results": [
        |    ${sortedWorks.mkString(",")}
        |  ]
-       |}
       """.stripMargin
+  }
+
+  def worksListResponseWithAggs(
+    ids: Seq[String],
+    aggs: Map[String, Seq[(Int, String)]]
+  ) =
+    s"{${worksList(ids)}, ${aggregations(aggs)}}"
+
+  private def aggregations(aggs: Map[String, Seq[(Int, String)]]): String = {
+    val aggregationEntries = aggs map {
+      case (key, buckets) =>
+        val aggregationBuckets = buckets map {
+          case (count, bucketData) =>
+            s"""
+               |{
+               |          "count" : $count,
+               |          "data" : $bucketData,
+               |          "type" : "AggregationBucket"
+               |        }
+               |""".stripMargin
+
+        }
+        s""""$key": {"buckets": [${aggregationBuckets.mkString(",")}], "type" : "Aggregation"}"""
+    }
+    s""" "aggregations":{${aggregationEntries.mkString(",")}, "type" : "Aggregations"}"""
+
   }
 }

--- a/search/src/test/scala/weco/api/search/works/WorksAggregationsTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksAggregationsTest.scala
@@ -1,6 +1,8 @@
 package weco.api.search.works
 
-class WorksAggregationsTest extends ApiWorksTestBase {
+import org.scalatest.funspec.AnyFunSpec
+
+class WorksAggregationsTest extends AnyFunSpec with ApiWorksTestBase {
   it("aggregates by format") {
     withWorksApi {
       case (worksIndex, routes) =>

--- a/search/src/test/scala/weco/api/search/works/WorksErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksErrorsTest.scala
@@ -1,11 +1,12 @@
 package weco.api.search.works
 
 import com.sksamuel.elastic4s.Index
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.prop.TableDrivenPropertyChecks
 import weco.api.search.models.ElasticConfig
 import weco.elasticsearch.IndexConfig
 
-class WorksErrorsTest extends ApiWorksTestBase with TableDrivenPropertyChecks {
+class WorksErrorsTest extends AnyFunSpec with ApiWorksTestBase with TableDrivenPropertyChecks {
 
   val includesString =
     "['identifiers', 'items', 'holdings', 'subjects', 'genres', 'contributors', 'production', 'languages', 'notes', 'formerFrequency', 'designation', 'images', 'parts', 'partOf', 'precededBy', 'succeededBy']"

--- a/search/src/test/scala/weco/api/search/works/WorksFilteredAggregationsTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksFilteredAggregationsTest.scala
@@ -1,8 +1,9 @@
 package weco.api.search.works
 
+import org.scalatest.funspec.AnyFunSpec
 import weco.api.search.models.request.WorksIncludes
 
-class WorksFilteredAggregationsTest extends ApiWorksTestBase {
+class WorksFilteredAggregationsTest extends AnyFunSpec with ApiWorksTestBase {
   val aggregatedWorks =
     (0 to 9).map(i => s"works.examples.filtered-aggregations-tests.$i")
 

--- a/search/src/test/scala/weco/api/search/works/WorksIncludesTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksIncludesTest.scala
@@ -1,6 +1,8 @@
 package weco.api.search.works
 
-class WorksIncludesTest extends ApiWorksTestBase {
+import org.scalatest.funspec.AnyFunSpec
+
+class WorksIncludesTest extends AnyFunSpec with ApiWorksTestBase {
   describe("identifiers includes") {
     it(
       "includes a list of identifiers on a list endpoint if we pass ?include=identifiers"

--- a/search/src/test/scala/weco/api/search/works/WorksRedirectsTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksRedirectsTest.scala
@@ -1,6 +1,8 @@
 package weco.api.search.works
 
-class WorksRedirectsTest extends ApiWorksTestBase {
+import org.scalatest.funspec.AnyFunSpec
+
+class WorksRedirectsTest extends AnyFunSpec with ApiWorksTestBase {
   val redirectSource = "4nwkprdt"
   val redirectTarget = "mv6kix0n"
 

--- a/search/src/test/scala/weco/api/search/works/WorksTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksTest.scala
@@ -1,8 +1,9 @@
 package weco.api.search.works
 
+import org.scalatest.funspec.AnyFunSpec
 import weco.api.search.models.request.WorksIncludes
 
-class WorksTest extends ApiWorksTestBase {
+class WorksTest extends AnyFunSpec with ApiWorksTestBase {
   it("returns a list of works") {
     withWorksApi {
       case (worksIndex, routes) =>

--- a/search/src/test/scala/weco/api/search/works/WorksTestDeleted.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksTestDeleted.scala
@@ -1,6 +1,8 @@
 package weco.api.search.works
 
-class WorksTestDeleted extends ApiWorksTestBase {
+import org.scalatest.funspec.AnyFunSpec
+
+class WorksTestDeleted extends AnyFunSpec with ApiWorksTestBase {
   it("returns an HTTP 410 Gone if looking up a deleted work") {
     withWorksApi {
       case (worksIndex, routes) =>

--- a/search/src/test/scala/weco/api/search/works/WorksTestInvisible.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksTestInvisible.scala
@@ -1,6 +1,8 @@
 package weco.api.search.works
 
-class WorksTestInvisible extends ApiWorksTestBase {
+import org.scalatest.funspec.AnyFunSpec
+
+class WorksTestInvisible extends AnyFunSpec with ApiWorksTestBase {
   it("returns an HTTP 410 Gone if looking up a work with visible = false") {
     withWorksApi {
       case (worksIndex, routes) =>


### PR DESCRIPTION
This is a precursor to some of the test coverage improvements.

The base ApiTestBase does not actually define any tests, so does not need AnyFunSpec.

Later, I will be adding a FeatureSpec test suite to describe the expected Faceting behaviour.