### PR TITLE
fixes rank test: use reference number that is in sync in both pipelines

### DIFF
--- a/rank/data/tests/works.json
+++ b/rank/data/tests/works.json
@@ -19,9 +19,9 @@
                 "description": "Case insensitive IDs"
             },
             {
-                "searchTerms": "2013i",
+                "searchTerms": "546735i",
                 "ratings": [
-                    "uemqqmb9"
+                    "mx9q4kdp"
                 ],
                 "description": "Reference number as ID"
             },


### PR DESCRIPTION
I think this should fix the rank tests
Issue is pipeline-2023-06-09 and pipeline-2023-06-23 are out of sync
This test case now uses a reference id that returns the same top result when querying either index