### PR TITLE
limit self aggregation to filter value list size

### DIFF
--- a/search/src/main/scala/weco/api/search/models/ElasticAggregations.scala
+++ b/search/src/main/scala/weco/api/search/models/ElasticAggregations.scala
@@ -41,7 +41,6 @@ trait ElasticAggregations extends Logging {
           ).recoverWith {
             case err =>
               warn("Failed to parse aggregation from ES", err)
-              println(s"Failed to parse aggregation from ES: $err")
               Failure(err)
           }.toOption
         )


### PR DESCRIPTION
Placing in a PR in case it does turn out to be useful.

This PR implements https://github.com/wellcomecollection/catalogue-api/issues/712

However, AFAICT, it doesn't make a noticeable difference to performance, and introduces a possible source of error (where the self agg should return more buckets than the filter value count due to terms with different ids but same label).  So I'm not going to merge it.