### PR TITLE
Add option for HTTP healthcheck, enable for works

### DIFF
--- a/terraform/catalogue_api/.terraform.lock.hcl
+++ b/terraform/catalogue_api/.terraform.lock.hcl
@@ -2,8 +2,23 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "4.61.0"
+  version = "5.32.0"
   hashes = [
-    "h1:GrboLwI2hok/i8xfq87uS9kUKPqAE8b/1iJTEupRthY=",
+    "h1:2f5gFVQju3QK0CmJqgBlN7p4781eBRsPJ55JkisZZas=",
+    "zh:0778714f25cd003a1f6a7e6f111532511943458f702dd165619d5bce91047f91",
+    "zh:1c47ab9115ad9dbcde4641de5ea749994de784ed4365fbd9932d20d6c49a7d60",
+    "zh:2db6bddc3afa134b30c08c21660a4ce4de9d60e160152c3fb61b0074c8ed9434",
+    "zh:321efba04200fbdc950e1b81c39979f934a8364380b6dfa011849adadb6f0406",
+    "zh:51e0aed098e5e886823e1abb0baab68e2cffab2b9c71e092a9a8b225e5c15782",
+    "zh:61052027761e88da0bf316055cd4a0d94500b939776a20f5e7173a573a545afc",
+    "zh:6feafeca95ec2411cb20b693c38e9f5dbe02ceb9a98931a06e0157d9a19788bc",
+    "zh:957d01c63c9f0de76cf6db4506cfcab527d3b02909b72f67ddd7fe1c9fd7fcd0",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2938d841ac5a313afdbbabd0913bf78a5cad0fdbdd9bf712d84343a086b40ec",
+    "zh:ad8d6b460205578eed5b6eaf638e3b0aaa42a88a5be386312ded47a579971d12",
+    "zh:ad9fc0f1ddad7bf4362ddb8d06cd09468c3de129beb02913704d4285d85fb7b1",
+    "zh:c25a09ae96b4cd651c1c532e56a1b98482ed2166cef56f488fd525a2a4d57579",
+    "zh:d64e51af49a9f9f88aa2bc4ed30e93e99210ecbb8c03dbc65e20f53835d9ba1a",
+    "zh:e69f370da6911a79425aa0e2c1ae43f012d07716b859940d7debddab11e3b0f8",
   ]
 }

--- a/terraform/modules/service/target_group.tf
+++ b/terraform/modules/service/target_group.tf
@@ -15,8 +15,21 @@ resource "aws_lb_target_group" "tcp" {
   # updated service.  Reducing this parameter to 90s makes deployments faster.
   deregistration_delay = 90
 
-  health_check {
-    protocol = "TCP"
+  dynamic "health_check" {
+    for_each = var.tcp_healthcheck == true ? toset([]) : toset([1])
+
+    content {
+      protocol = "TCP"
+    }
+  }
+
+  dynamic "health_check" {
+    for_each = var.tcp_healthcheck == false ? toset([]) : toset([1])
+
+    content {
+      protocol = "HTTP"
+      path = var.healthcheck_path
+    }
   }
 }
 

--- a/terraform/modules/service/target_group.tf
+++ b/terraform/modules/service/target_group.tf
@@ -28,7 +28,7 @@ resource "aws_lb_target_group" "tcp" {
 
     content {
       protocol = "HTTP"
-      path = var.healthcheck_path
+      path     = var.healthcheck_path
     }
   }
 }

--- a/terraform/modules/service/target_group.tf
+++ b/terraform/modules/service/target_group.tf
@@ -16,7 +16,7 @@ resource "aws_lb_target_group" "tcp" {
   deregistration_delay = 90
 
   dynamic "health_check" {
-    for_each = var.tcp_healthcheck == true ? toset([]) : toset([1])
+    for_each = var.tcp_healthcheck == false ? toset([]) : toset([1])
 
     content {
       protocol = "TCP"
@@ -24,7 +24,7 @@ resource "aws_lb_target_group" "tcp" {
   }
 
   dynamic "health_check" {
-    for_each = var.tcp_healthcheck == false ? toset([]) : toset([1])
+    for_each = var.tcp_healthcheck == true ? toset([]) : toset([1])
 
     content {
       protocol = "HTTP"

--- a/terraform/modules/service/target_group.tf
+++ b/terraform/modules/service/target_group.tf
@@ -29,6 +29,7 @@ resource "aws_lb_target_group" "tcp" {
     content {
       protocol = "HTTP"
       path     = var.healthcheck_path
+      matcher  = "200"
     }
   }
 }

--- a/terraform/modules/service/variables.tf
+++ b/terraform/modules/service/variables.tf
@@ -72,3 +72,15 @@ variable "app_cpu" {
 variable "app_memory" {
   type = number
 }
+
+variable "tcp_healthcheck" {
+  # TODO: Remove this when all services use HTTP healthcheck
+  type    = bool
+  default = true
+}
+
+variable "healthcheck_path" {
+  # Note: this is only used when tcp_healthcheck is set to false
+  type    = string
+  default = "/management/healthcheck"
+}

--- a/terraform/modules/service/variables.tf
+++ b/terraform/modules/service/variables.tf
@@ -84,3 +84,4 @@ variable "healthcheck_path" {
   type    = string
   default = "/management/healthcheck"
 }
+

--- a/terraform/modules/stack/services.tf
+++ b/terraform/modules/stack/services.tf
@@ -48,6 +48,9 @@ module "search_api" {
   vpc_id             = var.vpc_id
   load_balancer_arn  = aws_lb.catalogue_api.arn
 
+  # Use the HTTP healthcheck with a default path of /management/healthcheck
+  tcp_healthcheck = false
+
   use_fargate_spot              = var.environment_name == "stage" ? true : false
   turn_off_outside_office_hours = var.environment_name == "stage" ? true : false
 }


### PR DESCRIPTION
## What does this change?

This change adds the option to select a [HTTP healthcheck for a services target group](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html). The reason for this change is to avoid downtime during deploys, as at present the TCP healthcheck will only wait for nginx to be able to open a connection although the underlying scala service may not yet have started.

By default the HTTP healthcheck uses the `/management/healthcheck` endpoint (already present in the works service), and will register as healthy if that endpoint returns a 200 (see https://api.wellcomecollection.org/catalogue/v2/management/healthcheck).

> [!NOTE] 
> The intention is to roll this our for the catalogue-api works service to start with, and then add the necessary endpoints to the items and concepts service, finally removing the option for a TCP health-check. In addition further work is required to properly report the health of the service as being able to respond from the app container isn't definitive proof the app is "healthy".

## How can we test?

- [x] Manually check this healthcheck behaves as expected in the stage environment and tasks register as healthy
- [x] Deploy this change to stage to ensure the terraform applies the change as expected and tasks register as healthy
- [x] Perform a stage deployment while sending requests to understand if we have eliminated the deployment errors.

## How can we measure success?

No downtime during deployments resulting in a better experience for visitors to the site, and fewer errors that we cannot effectively respond to in the alerts channel.

## Have we considered potential risks?

Changing the health-checks changes the failure modes for the API, we should test thoroughly in stage before deploying to prod, consider _and document_ the impact of extending the health check to fail in other situations (e.g. elasticsearch is unavailable).
