### PR TITLE
Bump the SBT version from 1.4.1 to 1.9.8

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.4.1
+sbt.version=1.9.8
 


### PR DESCRIPTION
## What does this change?

The 1.4.1 version of SBT has an issue with the version of the JNA library is uses which prevents it from loading on M1 macs.

```console
➜  scala-libs git:(main) ✗ sbt
copying runtime jar...
[info] [launcher] getting org.scala-sbt sbt 1.4.1  (this may take some time)...
[info] [launcher] getting Scala 2.12.12 (for sbt)...
java.lang.UnsatisfiedLinkError: Can't load library: /Users/kennyr/Library/Caches/JNA/temp/jna12269094481575250405.tmp
```

See: https://github.com/sbt/io/issues/320

## How to test?

The most recent version (1.9.8) of sbt seems to work with this project, so upgrading.

- [ ] Build and test locally, does it succeed?
- [ ] Does this PR get a green tick when running in CI?

## How can we measure success?

People working on this project with M1 macs can build and test it.

## Have we considered potential risks?

Jumping from 1.4.x to 1.9.x is a large version leap ... there may be some breaking changes [lurking in the release notes](https://github.com/sbt/sbt/releases). However if the project builds and tests without error we can be somewhat reassured that we have not met any.