### PR TITLE
Add addDependencyTreePlugin plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,3 +4,4 @@ addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
 addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.19.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.3.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+addDependencyTreePlugin


### PR DESCRIPTION
## What does this change?

This change adds a plugin to generate and search dependency graphs with sbt. This is useful when we see errors caused by transitive dependencies, so we can work out which libraries we directly specify pull these in.

See https://github.com/sbt/sbt-dependency-graph for the history of this plugin built into sbt after version 1.4.

https://www.scala-sbt.org/1.x/docs/sbt-1.4-Release-Notes.html#sbt-dependency-graph+is+in-sourced

This depends on (and the need for it was identified in) https://github.com/wellcomecollection/catalogue-api/pull/737

## How to test?

- [x] Check out this repository and run one of the graph generation commands e.g. `dependencyBrowseTreeHTML`, (after selecting the items project `sbt project items`.

## How can we measure success?

It's easier for people working on this project to solve issues with dependencies.

## Have we considered the potential risks?

This change enables a plugin that is part of sbt post version 1.4 and should not impact the build, so risks are minimal.



