### PR TITLE
Adds a simple healthcheck endpoint for the items service

### DIFF
--- a/items/src/main/scala/weco/api/items/ItemsApi.scala
+++ b/items/src/main/scala/weco/api/items/ItemsApi.scala
@@ -36,6 +36,14 @@ class ItemsApi(
         case id =>
           notFound(s"Work not found for identifier $id")
       }
+    },
+    pathPrefix("management") {
+      concat(
+        path("healthcheck") {
+          get {
+            complete("message" -> "ok")
+          }
+        })
     }
   )
 }

--- a/items/src/main/scala/weco/api/items/ItemsApi.scala
+++ b/items/src/main/scala/weco/api/items/ItemsApi.scala
@@ -38,12 +38,11 @@ class ItemsApi(
       }
     },
     pathPrefix("management") {
-      concat(
-        path("healthcheck") {
-          get {
-            complete("message" -> "ok")
-          }
-        })
+      concat(path("healthcheck") {
+        get {
+          complete("message" -> "ok")
+        }
+      })
     }
   )
 }

--- a/terraform/modules/stack/services.tf
+++ b/terraform/modules/stack/services.tf
@@ -93,6 +93,9 @@ module "items_api" {
   vpc_id             = var.vpc_id
   load_balancer_arn  = aws_lb.catalogue_api.arn
 
+  # Use the HTTP healthcheck with a default path of /management/healthcheck
+  tcp_healthcheck = false
+
   use_fargate_spot              = var.environment_name == "stage" ? true : false
   turn_off_outside_office_hours = var.environment_name == "stage" ? true : false
 }


### PR DESCRIPTION
## What does this change?

This change follows https://github.com/wellcomecollection/catalogue-api/pull/736, and adds an HTTP healthcheck to the items API to ensure the scala service has started before it is registered healthy at the NLB and starts serving requests.

## How to test?

- [x] ~Manually check this healthcheck behaves as expected locally running the items API~ edit: we've improved the testing locally situation but not resolved it, I feel ok to try this in stage for now
- [ ] Deploy this change to stage to ensure the terraform applies the change as expected and tasks register as healthy
- [ ] Perform a stage deployment while sending requests to understand if we have eliminated the deployment errors.

## How can we measure success?

No downtime during deployments resulting in a better experience for visitors to the site, and fewer errors that we cannot effectively respond to in the alerts channel.

Currently we do see _only_ items errors during deployment of the catalogue API, see from #wc-platform-alerts in slack during a deployment following updating the search :

<img width="756" alt="Screenshot 2024-01-14 at 15 05 34" src="https://github.com/wellcomecollection/catalogue-api/assets/953792/725d7b6b-e29d-4fe2-a215-999e1d9f1ac2">
service healthcheck:

## Have we considered potential risks?

Changing the health-checks changes the failure modes for the API, although we have tested this principle successfully in https://github.com/wellcomecollection/catalogue-api/pull/736 so the risk is reduced.


