### PR TITLE
Removes soft fails for e2es as not flaky no mo

### DIFF
--- a/.buildkite/pipeline.deploy-prod.yml
+++ b/.buildkite/pipeline.deploy-prod.yml
@@ -100,7 +100,6 @@ steps:
   - label: "E2E Tests: PROD Front-end / PROD Catalogue API"
     branches: "main"
     trigger: "experience-e2e"
-    soft_fail: true # Added 2023-06-02 due to issues with flaky tests - to be removed as soon as is practical
     build:
       env:
         PLAYWRIGHT_BASE_URL: https://wellcomecollection.org

--- a/.buildkite/pipeline.deploy-stage.yml
+++ b/.buildkite/pipeline.deploy-stage.yml
@@ -57,7 +57,6 @@ steps:
   - label: "E2E Tests: PROD Front-end / STAGE Catalogue API"
     branches: "main"
     trigger: "experience-e2e"
-    soft_fail: true # Added 2023-06-02 due to issues with flaky tests - to be removed as soon as is practical
     build:
       env:
         PLAYWRIGHT_BASE_URL: https://wellcomecollection.org


### PR DESCRIPTION
Reverts https://github.com/wellcomecollection/catalogue-api/pull/661 as we don't want to live dangerously anymore and e2es should not be as flaky as they were last year. Them failing _should_ be a fail. 

## Pull request checklist

* Does this patch need a change to the documentation? **No**
* Do you need to update the [Catalogue API Swagger][swagger]? **No**

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml
