### PR TITLE
Adds a simple healthcheck endpoint for the requests service

### DIFF
--- a/concepts/src/app.ts
+++ b/concepts/src/app.ts
@@ -5,6 +5,7 @@ import {
   conceptController,
   conceptsController,
   errorHandler,
+  healthcheckController,
 } from "./controllers";
 import { Config } from "../config";
 import { Clients } from "./types";
@@ -16,6 +17,7 @@ const createApp = (clients: Clients, config: Config) => {
 
   app.get("/concepts", conceptsController(clients, config));
   app.get("/concepts/:id", conceptController(clients, config));
+  app.get("/management/healthcheck", healthcheckController(config));
 
   app.use(errorHandler);
 

--- a/concepts/src/controllers/healthcheck.ts
+++ b/concepts/src/controllers/healthcheck.ts
@@ -1,0 +1,16 @@
+import { RequestHandler } from "express";
+import asyncHandler from "express-async-handler";
+import { Config } from "../../config";
+
+type PathParams = { id: string };
+
+const healthcheckController = (config: Config): RequestHandler<PathParams> => {
+  return asyncHandler(async (req, res) => {
+    res.status(200).json({
+      status: "ok",
+      config,
+    });
+  });
+};
+
+export default healthcheckController;

--- a/concepts/src/controllers/index.ts
+++ b/concepts/src/controllers/index.ts
@@ -1,5 +1,6 @@
 import conceptController from "./concept";
 import conceptsController from "./concepts";
+import healthcheckController from "./healthcheck";
 
 export { errorHandler } from "./error";
-export { conceptController, conceptsController };
+export { conceptController, conceptsController, healthcheckController };

--- a/requests/src/main/scala/weco/api/requests/RequestsApi.scala
+++ b/requests/src/main/scala/weco/api/requests/RequestsApi.scala
@@ -50,7 +50,14 @@ class RequestsApi(
           } ~ get {
             lookupRequests(userIdentifier)
           }
-      }
+      },
+    pathPrefix("management") {
+      concat(path("healthcheck") {
+        get {
+          complete("message" -> "ok")
+        }
+      })
+    }
   )
 }
 

--- a/terraform/modules/service/target_group.tf
+++ b/terraform/modules/service/target_group.tf
@@ -15,22 +15,10 @@ resource "aws_lb_target_group" "tcp" {
   # updated service.  Reducing this parameter to 90s makes deployments faster.
   deregistration_delay = 90
 
-  dynamic "health_check" {
-    for_each = var.tcp_healthcheck == false ? toset([]) : toset([1])
-
-    content {
-      protocol = "TCP"
-    }
-  }
-
-  dynamic "health_check" {
-    for_each = var.tcp_healthcheck == true ? toset([]) : toset([1])
-
-    content {
-      protocol = "HTTP"
-      path     = var.healthcheck_path
-      matcher  = "200"
-    }
+  health_check {
+    protocol = "HTTP"
+    path     = var.healthcheck_path
+    matcher  = "200"
   }
 }
 

--- a/terraform/modules/service/variables.tf
+++ b/terraform/modules/service/variables.tf
@@ -73,14 +73,7 @@ variable "app_memory" {
   type = number
 }
 
-variable "tcp_healthcheck" {
-  # TODO: Remove this when all services use HTTP healthcheck
-  type    = bool
-  default = true
-}
-
 variable "healthcheck_path" {
-  # Note: this is only used when tcp_healthcheck is set to false
   type    = string
   default = "/management/healthcheck"
 }


### PR DESCRIPTION
## What does this change?

This change follows https://github.com/wellcomecollection/catalogue-api/pull/739, and adds an HTTP healthcheck to the requests API to ensure the Scala service has started before it is registered healthy at the NLB and starts serving requests.

A further [change will need to be made in the wellcomecollection/identity](https://github.com/wellcomecollection/identity/blob/main/infra/modules/ecs_service/target_group.tf) respository to have the identity infrastructure pay attention to the new endpoint. 

The required change will be similar to the one in [this repository to add a HTTP healthcheck](https://github.com/wellcomecollection/catalogue-api/pull/736).

See https://github.com/wellcomecollection/identity/pull/398

## How to test?

- [x] Deploy this change to stage to ensure the terraform applies the change as expected and tasks register as healthy
- [ ] Perform a stage deployment while sending requests to understand if we have eliminated any deployment errors.

## How can we measure success?

No downtime during deployments resulting in a better experience for visitors to the site, and fewer errors that we cannot effectively respond to in the alerts channel.