### PR TITLE
Add default code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,7 @@
 # These are default codeowners, later rules take precedence
 *	@wellcomecollection/scala-reviewers
+
+# To ensure only properly audited changes are run in CI, we require reviews
+# from @wellcomecollection/developers when updating pipeline config
+/CODEOWNERS	@wellcomecollection/developers
+/.buildkite/    @wellcomecollection/developers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,2 @@
-# To ensure only properly audited changes are run in CI, we require reviews
-# from @wellcomecollection/buildkite-admin when updating pipeline config
-
-/.buildkite/	@wellcomecollection/buildkite-admin
-/builds/      @wellcomecollection/buildkite-admin
+# These are default codeowners, later rules take precedence
+*	@wellcomecollection/scala-reviewers


### PR DESCRIPTION
## What does this change?

- `buildkite-admins` is not a team anymore, so I changed it to `developers` after a chat with Robert, although the change means that it's not a smaller group that can approve PRs related to those folders/files, but a bigger one, it's changes that don't require Scala knowledge so I believe it makes sense to widen the net. Let me know if not.
- I've added a default code owner (`scala-reviewers`) so they automatically get added to PRs as reviewers and they are the people most likely to review them properly.

## How to test

I guess once it's in, and a PR gets created we could check it adds it automatically to reviewers?

## How can we measure success?

Are PRs not going unnoticed anymore 👀 

## Have we considered potential risks?

I don't think there is any.