### PR TITLE
Remove some bad tf around healthchecks

### DIFF
--- a/terraform/modules/stack/services.tf
+++ b/terraform/modules/stack/services.tf
@@ -48,9 +48,6 @@ module "search_api" {
   vpc_id             = var.vpc_id
   load_balancer_arn  = aws_lb.catalogue_api.arn
 
-  # Use the HTTP healthcheck with a default path of /management/healthcheck
-  tcp_healthcheck = false
-
   use_fargate_spot              = var.environment_name == "stage" ? true : false
   turn_off_outside_office_hours = var.environment_name == "stage" ? true : false
 }
@@ -92,9 +89,6 @@ module "items_api" {
   cluster_arn        = var.cluster_arn
   vpc_id             = var.vpc_id
   load_balancer_arn  = aws_lb.catalogue_api.arn
-
-  # Use the HTTP healthcheck with a default path of /management/healthcheck
-  tcp_healthcheck = false
 
   use_fargate_spot              = var.environment_name == "stage" ? true : false
   turn_off_outside_office_hours = var.environment_name == "stage" ? true : false


### PR DESCRIPTION
This change removes some invalid TF introduced in:

- https://github.com/wellcomecollection/catalogue-api/pull/749
- https://github.com/wellcomecollection/catalogue-api/pull/747

> [!NOTE]
> We do not need to trigger a build for this change, so should rebase and merge leaving only the commit with "[skip ci]" in the message on main which will [cause buildkite to ignore it](https://buildkite.com/docs/pipelines/skipping).
