### PR TITLE
Add @wellcomecollection/developers to /terraform folder in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,3 +5,6 @@
 # from @wellcomecollection/developers when updating pipeline config
 /CODEOWNERS	@wellcomecollection/developers
 /.buildkite/    @wellcomecollection/developers
+
+# Allow reviews from all developers on infrastructure changes
+/terraform/    @wellcomecollection/developers


### PR DESCRIPTION
## What is this change?

This change allows reviews from all developers to be sufficient for terraform changes. At present an approval to merge a PR for a terraform change must come from someone in the scala-reviewers group, we probably want to widen that.

## How to test?

Merge it and see if developers outside the scala-reviewers group can approve terraform changes.
