### PR TITLE
new pipeline 02-09

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
@@ -10,7 +10,7 @@ case class ElasticConfig(
 trait ElasticConfigBase {
   // We use this to share config across Scala API applications
   // i.e. The API and the snapshot generator.
-  val pipelineDate = "2024-02-01"
+  val pipelineDate = "2024-02-09"
 }
 
 object PipelineClusterElasticConfig extends ElasticConfigBase {


### PR DESCRIPTION
This updates the pipeline version to associate the API with a pipeline that has been populated using the [two-stage not-Miro-then-Miro process](https://github.com/wellcomecollection/catalogue-pipeline/pull/2553).  

This ensures that when a digmiro image hits the merger, it is always merged correctly.

Previously, digmiro images were being erroneously created as standalone images when the micro record hit the merger before the corresponding Sierra record.