### PR TITLE
return items with available dates if applicable

### DIFF
--- a/common/display/src/main/scala/weco/catalogue/display_model/locations/DisplayLocation.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/locations/DisplayLocation.scala
@@ -2,7 +2,9 @@ package weco.catalogue.display_model.locations
 
 import io.circe.generic.extras.JsonKey
 
-sealed trait DisplayLocation
+sealed trait DisplayLocation {
+  val accessConditions: List[DisplayAccessCondition]
+}
 
 case class DisplayDigitalLocation(
   locationType: DisplayLocationType,

--- a/common/display/src/main/scala/weco/catalogue/display_model/work/DisplayItem.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/work/DisplayItem.scala
@@ -3,11 +3,10 @@ package weco.catalogue.display_model.work
 import io.circe.generic.extras.JsonKey
 import weco.catalogue.display_model.identifiers.DisplayIdentifier
 import weco.catalogue.display_model.locations.DisplayLocation
-import java.time.ZonedDateTime
 
 case class AvailabilitySlot(
-  from: ZonedDateTime,
-  to: ZonedDateTime
+  from: String,
+  to: String
 )
 case class DisplayItem(
   id: Option[String],

--- a/common/display/src/main/scala/weco/catalogue/display_model/work/DisplayItem.scala
+++ b/common/display/src/main/scala/weco/catalogue/display_model/work/DisplayItem.scala
@@ -3,12 +3,18 @@ package weco.catalogue.display_model.work
 import io.circe.generic.extras.JsonKey
 import weco.catalogue.display_model.identifiers.DisplayIdentifier
 import weco.catalogue.display_model.locations.DisplayLocation
+import java.time.ZonedDateTime
 
+case class AvailabilitySlot(
+  from: ZonedDateTime,
+  to: ZonedDateTime
+)
 case class DisplayItem(
   id: Option[String],
   identifiers: List[DisplayIdentifier],
   title: Option[String] = None,
   note: Option[String] = None,
   locations: List[DisplayLocation] = List(),
+  availableDates: Option[List[AvailabilitySlot]] = None,
   @JsonKey("type") ontologyType: String = "Item"
 )

--- a/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
+++ b/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
@@ -60,9 +60,11 @@ class SierraItemUpdater(sierraSource: SierraSource)(
     for {
       itemEither <- sierraSource.lookupItemEntries(existingItems.keys.toSeq)
 
-      maybeAccessConditions: Map[SierraItemNumber, Option[
-        DisplayAccessCondition
-      ]] = itemEither match {
+      maybeAccessConditions: Map[
+        SierraItemNumber,
+        Option[
+          DisplayAccessCondition
+        ]] = itemEither match {
         case Right(SierraItemDataEntries(_, _, entries)) =>
           entries
             .map(item => {

--- a/items/src/test/scala/weco/api/items/ItemsApiFeatureTest.scala
+++ b/items/src/test/scala/weco/api/items/ItemsApiFeatureTest.scala
@@ -97,8 +97,8 @@ class ItemsApiFeatureTest
              |      ],
              |      "availableDates" : [
              |        {
-             |          "from" : "2024-02-29T13:32:44.943107Z[Europe/London]",
-             |          "to" : "2024-03-14T13:32:44.943107Z[Europe/London]"
+             |          "from" : "2022-01-10T10:00:00+0000",
+             |          "to" : "2022-01-11T10:00:00+0000"
              |        }
              |      ],
              |      "type" : "Item"
@@ -158,7 +158,7 @@ class ItemsApiFeatureTest
         (
           catalogueWorkRequest(workId),
           catalogueWorkResponse(resourceName)
-        ),
+        )
       )
 
       withItemsApi(catalogueResponses) { _ =>

--- a/items/src/test/scala/weco/api/items/ItemsApiFeatureTest.scala
+++ b/items/src/test/scala/weco/api/items/ItemsApiFeatureTest.scala
@@ -95,6 +95,12 @@ class ItemsApiFeatureTest
              |          "type" : "PhysicalLocation"
              |        }
              |      ],
+             |      "availableDates" : [
+             |        {
+             |          "from" : "2024-02-29T13:32:44.943107Z[Europe/London]",
+             |          "to" : "2024-03-14T13:32:44.943107Z[Europe/London]"
+             |        }
+             |      ],
              |      "type" : "Item"
              |    }
              |  ]

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -22,7 +22,6 @@ import weco.sierra.models.identifiers.SierraItemNumber
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import java.time.ZonedDateTime
 
 class ItemUpdateServiceTest
     extends AnyFunSpec
@@ -154,12 +153,8 @@ class ItemUpdateServiceTest
   val availableDates = Some(
     List(
       AvailabilitySlot(
-        ZonedDateTime.parse(
-          "2024-02-29T13:32:44.943107Z[Europe/London]"
-        ),
-        ZonedDateTime
-          .parse("2024-02-29T13:32:44.943107Z[Europe/London]")
-          .plusWeeks(2)
+        "2022-01-10T10:00:00+0000",
+        "2022-01-11T10:00:00+0000"
       )
     )
   )


### PR DESCRIPTION
This returns a hardcoded list of `AvailabilitySlots` with items that satisfying the [conditions](https://github.com/wellcomecollection/catalogue-api/blob/dc94db57e042d6b92b472c1d9ffee2fb81add3da/common/stacks/src/main/scala/weco/api/stacks/models/DisplayItemOps.scala#L71)

NOTE: the last case in the list of `itemStates` should have no available dates:
```
missingItemResponse(workWithAvailableItemNumber),
workWithAvailableItem,
availableOnlineAccessCondition,
availableDates // this should be None, possible bug in the Sierra updater
```
It looks like there's a bug with how the missing items are handled: we keep them in the item list without updating their accessConditions. 

I was trying to reinvent the wheel until I realised there's already a `DisplayAccessConditionOps` class that give you a boolean "isRequestable" from the item's `DisplayAccessCondition`. Might be worth double checking the logic is sound in there

## Pull request checklist

*   Does this patch need a change to the documentation?

    Do you need to update the [Catalogue API Swagger][swagger]?

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml
