### PR TITLE
guard against getting stuff out of an empty list

### DIFF
--- a/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
+++ b/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
@@ -60,9 +60,11 @@ class SierraItemUpdater(sierraSource: SierraSource)(
     for {
       itemEither <- sierraSource.lookupItemEntries(existingItems.keys.toSeq)
 
-      maybeAccessConditions: Map[SierraItemNumber, Option[
-        DisplayAccessCondition
-      ]] = itemEither match {
+      maybeAccessConditions: Map[
+        SierraItemNumber,
+        Option[
+          DisplayAccessCondition
+        ]] = itemEither match {
         case Right(SierraItemDataEntries(_, _, entries)) =>
           entries
             .map(item => {

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -360,6 +360,41 @@ class ItemUpdateServiceTest
           }
       }
     }
+
+    it(
+      "tolerates missing locations and conditions"
+    ) {
+      val itemNumber = createSierraItemNumber
+      val work = CatalogueWork(
+        id = createCanonicalId,
+        title = None,
+        identifiers = Nil,
+        items = List(
+          DisplayItem(
+            id = Some(createCanonicalId),
+            identifiers = List(
+              DisplayIdentifier(
+                identifierType = DisplayIdentifierType.SierraSystemNumber,
+                value = itemNumber.withCheckDigit
+              )
+            ),
+            locations = Nil
+          )
+        )
+      )
+      withSierraItemUpdater(missingItemResponse(itemNumber)) { itemUpdater =>
+        withItemUpdateService(List(itemUpdater)) { itemUpdateService =>
+          whenReady(itemUpdateService.updateItems(work)) { updatedItems =>
+            updatedItems.length shouldBe 1
+
+            val physicalItem = updatedItems.head
+
+            physicalItem.availableDates shouldBe None
+          }
+        }
+      }
+    }
+
   }
 
   def createPhysicalItemWith(


### PR DESCRIPTION
Fixes https://github.com/wellcomecollection/catalogue-api/issues/759

This is a fairly quick fix, to stop these errors happening, but I would like us to revisit this section of the codebase again soon. 

Although the fix was pretty simple to write, the only existing tests that exercise this function are a bit unwieldy and end-to-endy.  `updateItems` is not very testable and requires a load of context manager setup and boilerplate, when it would be preferable to break it up into a function that takes some inputs and produces some outputs.  Then it would be much simpler to define a more comprehensive suite of tests that exercise all the possibilities.