### PR TITLE
Report sbt dependency graph to dependabopt

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,13 @@
+# .github/workflows/dependency-graph.yml
+name: Update Dependency Graph
+on:
+  push:
+    branches:
+      - main # default branch of the project
+jobs:
+  dependency-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: scalacenter/sbt-dependency-submission@v2


### PR DESCRIPTION
## Who is this change for?

Developers who want to understand if there are any security issues with our code.

## What does this change do?

This allows Dependabot to have visibility of security issues in our dependencies and raise relevant alerts.

See: https://github.com/scalacenter/sbt-dependency-submission

> [!NOTE]
> This change does not automatically raise PRs to fix issues, we probably require scala-steward or similar for that.

See https://www.scala-lang.org/blog/2022/07/18/secure-your-dependencies-on-github.html for more information.
