### PR TITLE
Use federated OIDC permissions with AWS to read S3 buckets.

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -3,7 +3,7 @@ name: Update Dependency Graph
 on:
   push:
     branches:
-      - rk/use-gh-oidc-aws-federated # default branch of the project
+      - main
 
 permissions:
   id-token: write

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -4,10 +4,20 @@ on:
   push:
     branches:
       - main # default branch of the project
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
 jobs:
   dependency-graph:
     name: Update Dependency Graph
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.WECO_GHAWS_ROLE_ARN }}
       - uses: scalacenter/sbt-dependency-submission@v2

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -3,7 +3,7 @@ name: Update Dependency Graph
 on:
   push:
     branches:
-      - main # default branch of the project
+      - rk/use-gh-oidc-aws-federated # default branch of the project
 
 permissions:
   id-token: write

--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,7 @@ lazy val snapshot_generator = setupProject(
 
 s3CredentialsProvider := { _ =>
   val builder = new STSAssumeRoleSessionCredentialsProvider.Builder(
-    "arn:aws:iam::760097843905:role/platform-ci",
+    "arn:aws:iam::760097843905:role/terraform-20210811133135108800000001",
     UUID.randomUUID().toString
   )
   builder.build()


### PR DESCRIPTION
## What does this change?

This change uses the [`aws-actions/configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials) GitHub action to assume a role provided by a GitHub OIDC provider set up in AWS (see: https://github.com/wellcomecollection/aws-account-infrastructure/pull/18).

In addition it updates the [role assumed to read Scala dependencies](https://github.com/wellcomecollection/catalogue-api/pull/766/files#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91R81) from S3 to be a [much more restrictive role](https://github.com/wellcomecollection/aws-account-infrastructure/blob/main/accounts/platform/iam_roles.tf#L18). This is required as the operation will now run on GitHub actions runners which do not require such far-reaching permissions and are not under our direct ownership.

See https://github.com/wellcomecollection/buildkite-infrastructure/pull/24 for the change required to allow Buildkite to assume the s3 read role which is also a requirement of this change.

## How to test

- [x] Does the build pass? Is the Scala dependency graph [posted to the GitHub API](https://api.github.com/repos/wellcomecollection/catalogue-api/dependency-graph/snapshots/11564010)?

## How can we measure success?

- [ ] GitHub will correctly report the [dependency graph](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph) for this project and highlight Scala vulnerabilities. This only happens for the default branch, so we'll see this only after merging.

## Have we considered potential risks?

This change does update the permissions of GitHub actions running in this repository (see [discussion here on risks](https://github.com/wellcomecollection/aws-account-infrastructure/pull/18)). We believe the scope of the permissions are restrictive enough to be acceptable in this case.
