### PR TITLE
Add the ability to run the search project locally

### DIFF
--- a/common/search/src/main/scala/weco/api/search/config/builders/PipelineElasticClientBuilder.scala
+++ b/common/search/src/main/scala/weco/api/search/config/builders/PipelineElasticClientBuilder.scala
@@ -25,9 +25,10 @@ object PipelineElasticClientBuilder {
 
     val secretsManagerClientBuilder = SecretsManagerClient.builder()
 
-    implicit val secretsClient: SecretsManagerClient = if(isDev) {
+    implicit val secretsClient: SecretsManagerClient = if (isDev) {
       secretsManagerClientBuilder
-        .credentialsProvider(ProfileCredentialsProvider.create("catalogue-developer"))
+        .credentialsProvider(
+          ProfileCredentialsProvider.create("catalogue-developer"))
         .build()
     } else {
       secretsManagerClientBuilder.build()

--- a/common/search/src/main/scala/weco/api/search/config/builders/PipelineElasticClientBuilder.scala
+++ b/common/search/src/main/scala/weco/api/search/config/builders/PipelineElasticClientBuilder.scala
@@ -26,17 +26,19 @@ object PipelineElasticClientBuilder {
     val secretsManagerClientBuilder = SecretsManagerClient.builder()
 
     val (hostType, secretsClientForEnv) = environment match {
-        case ApiEnvironment.Dev =>
-            ("public_host", secretsManagerClientBuilder
+      case ApiEnvironment.Dev =>
+        (
+          "public_host",
+          secretsManagerClientBuilder
             .credentialsProvider(
-                ProfileCredentialsProvider.create("catalogue-developer"))
+              ProfileCredentialsProvider.create("catalogue-developer"))
             .build())
-        case _ =>
-            ("private_host", secretsManagerClientBuilder.build())
+      case _ =>
+        ("private_host", secretsManagerClientBuilder.build())
     }
 
     implicit val secretsClient: SecretsManagerClient = secretsClientForEnv
-    
+
     val hostname = getSecretString(
       s"elasticsearch/pipeline_storage_$pipelineDate/$hostType"
     )

--- a/common/search/src/main/scala/weco/api/search/models/ApiConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ApiConfig.scala
@@ -9,25 +9,24 @@ case class ApiConfig(
   publicHost: String,
   publicRootPath: String,
   defaultPageSize: Int,
+) {
   // Used to determine whether we're running in a dev environment
-  isDev: Boolean
-)
+  def isDev = publicHost == "localhost"
+}
 
 object ApiConfig {
   private val defaultRootUri = "https://api.wellcomecollection.org/catalogue/v2"
 
   def build(config: Config): ApiConfig = {
-    val apiPublicRoot = config
-      .getStringOption("api.public-root")
-      .getOrElse(defaultRootUri)
-
     ApiConfig(
-      publicRootUri = Uri(apiPublicRoot),
+      publicRootUri = Uri(
+        config
+          .getStringOption("api.public-root")
+          .getOrElse(defaultRootUri)
+      ),
       defaultPageSize = config
         .getIntOption("api.pageSize")
         .getOrElse(10),
-      // Infer whether we're running in a dev environment from the public root
-      isDev = apiPublicRoot.contains("localhost")
     )
   }
 
@@ -41,6 +40,5 @@ object ApiConfig {
       publicScheme = publicRootUri.scheme,
       publicRootPath = publicRootUri.path.toString,
       defaultPageSize = defaultPageSize,
-      isDev = isDev
     )
 }

--- a/common/search/src/main/scala/weco/api/search/models/ApiConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ApiConfig.scala
@@ -11,7 +11,18 @@ case class ApiConfig(
   defaultPageSize: Int,
 ) {
   // Used to determine whether we're running in a dev environment
-  def isDev = publicHost == "localhost"
+  def environment: ApiEnvironment = publicHost match {
+    case "localhost" => ApiEnvironment.Dev
+    case _ if publicHost.contains("stage") => ApiEnvironment.Stage
+    case _ => ApiEnvironment.Prod
+  }
+}
+
+sealed trait ApiEnvironment
+object ApiEnvironment {
+  case object Dev extends ApiEnvironment
+  case object Stage extends ApiEnvironment
+  case object Prod extends ApiEnvironment
 }
 
 object ApiConfig {
@@ -31,10 +42,9 @@ object ApiConfig {
   }
 
   def apply(
-    publicRootUri: Uri,
-    defaultPageSize: Int,
-    isDev: Boolean = false
-  ): ApiConfig =
+             publicRootUri: Uri,
+             defaultPageSize: Int,
+           ): ApiConfig =
     ApiConfig(
       publicHost = publicRootUri.authority.host.address,
       publicScheme = publicRootUri.scheme,

--- a/common/search/src/main/scala/weco/api/search/models/ApiConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ApiConfig.scala
@@ -8,32 +8,39 @@ case class ApiConfig(
   publicScheme: String,
   publicHost: String,
   publicRootPath: String,
-  defaultPageSize: Int
+  defaultPageSize: Int,
+  // Used to determine whether we're running in a dev environment
+  isDev: Boolean
 )
 
 object ApiConfig {
   private val defaultRootUri = "https://api.wellcomecollection.org/catalogue/v2"
 
-  def build(config: Config): ApiConfig =
+  def build(config: Config): ApiConfig = {
+    val apiPublicRoot = config
+      .getStringOption("api.public-root")
+      .getOrElse(defaultRootUri)
+
     ApiConfig(
-      publicRootUri = Uri(
-        config
-          .getStringOption("api.public-root")
-          .getOrElse(defaultRootUri)
-      ),
+      publicRootUri = Uri(apiPublicRoot),
       defaultPageSize = config
         .getIntOption("api.pageSize")
-        .getOrElse(10)
+        .getOrElse(10),
+      // Infer whether we're running in a dev environment from the public root
+      isDev = apiPublicRoot.contains("localhost")
     )
+  }
 
   def apply(
     publicRootUri: Uri,
-    defaultPageSize: Int
+    defaultPageSize: Int,
+    isDev: Boolean = false
   ): ApiConfig =
     ApiConfig(
       publicHost = publicRootUri.authority.host.address,
       publicScheme = publicRootUri.scheme,
       publicRootPath = publicRootUri.path.toString,
-      defaultPageSize = defaultPageSize
+      defaultPageSize = defaultPageSize,
+      isDev = isDev
     )
 }

--- a/common/search/src/main/scala/weco/api/search/models/ApiConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ApiConfig.scala
@@ -12,9 +12,9 @@ case class ApiConfig(
 ) {
   // Used to determine whether we're running in a dev environment
   def environment: ApiEnvironment = publicHost match {
-    case "localhost" => ApiEnvironment.Dev
+    case "localhost"                       => ApiEnvironment.Dev
     case _ if publicHost.contains("stage") => ApiEnvironment.Stage
-    case _ => ApiEnvironment.Prod
+    case _                                 => ApiEnvironment.Prod
   }
 }
 
@@ -28,7 +28,7 @@ object ApiEnvironment {
 object ApiConfig {
   private val defaultRootUri = "https://api.wellcomecollection.org/catalogue/v2"
 
-  def build(config: Config): ApiConfig = {
+  def build(config: Config): ApiConfig =
     ApiConfig(
       publicRootUri = Uri(
         config
@@ -39,12 +39,11 @@ object ApiConfig {
         .getIntOption("api.pageSize")
         .getOrElse(10),
     )
-  }
 
   def apply(
-             publicRootUri: Uri,
-             defaultPageSize: Int,
-           ): ApiConfig =
+    publicRootUri: Uri,
+    defaultPageSize: Int,
+  ): ApiConfig =
     ApiConfig(
       publicHost = publicRootUri.authority.host.address,
       publicScheme = publicRootUri.scheme,

--- a/common/search/src/test/scala/weco/api/search/models/ApiConfigTest.scala
+++ b/common/search/src/test/scala/weco/api/search/models/ApiConfigTest.scala
@@ -18,7 +18,23 @@ class ApiConfigTest extends AnyFunSpec with Matchers with Inside {
         publicScheme shouldBe "https"
         publicHost shouldBe "api.wellcomecollection.org"
         publicRootPath shouldBe "/catalogue/v2"
-        apiConfig.isDev shouldBe false
+        apiConfig.environment shouldBe ProdEnvironment
+    }
+  }
+
+  it("correctly identifies a stage environment") {
+    val publicRoot = "https://api-stage.wellcomecollection.org/catalogue/v2"
+    inside(
+      ApiConfig(
+        publicRootUri = Uri(publicRoot),
+        defaultPageSize = 10
+      )
+    ) {
+      case apiConfig@ApiConfig(publicScheme, publicHost, publicRootPath, _) =>
+        publicScheme shouldBe "https"
+        publicHost shouldBe "api-stage.wellcomecollection.org"
+        publicRootPath shouldBe "/catalogue/v2"
+        apiConfig.environment shouldBe StageEnvironment
     }
   }
 
@@ -34,7 +50,7 @@ class ApiConfigTest extends AnyFunSpec with Matchers with Inside {
         publicScheme shouldBe "https"
         publicHost shouldBe "localhost"
         publicRootPath shouldBe "/catalogue/v2"
-        apiConfig.isDev shouldBe true
+        apiConfig.environment shouldBe DevEnvironment
     }
   }
 }

--- a/common/search/src/test/scala/weco/api/search/models/ApiConfigTest.scala
+++ b/common/search/src/test/scala/weco/api/search/models/ApiConfigTest.scala
@@ -18,7 +18,7 @@ class ApiConfigTest extends AnyFunSpec with Matchers with Inside {
         publicScheme shouldBe "https"
         publicHost shouldBe "api.wellcomecollection.org"
         publicRootPath shouldBe "/catalogue/v2"
-        apiConfig.environment shouldBe ProdEnvironment
+        apiConfig.environment shouldBe ApiEnvironment.Prod
     }
   }
 
@@ -34,7 +34,7 @@ class ApiConfigTest extends AnyFunSpec with Matchers with Inside {
         publicScheme shouldBe "https"
         publicHost shouldBe "api-stage.wellcomecollection.org"
         publicRootPath shouldBe "/catalogue/v2"
-        apiConfig.environment shouldBe StageEnvironment
+        apiConfig.environment shouldBe ApiEnvironment.Stage
     }
   }
 
@@ -50,7 +50,7 @@ class ApiConfigTest extends AnyFunSpec with Matchers with Inside {
         publicScheme shouldBe "https"
         publicHost shouldBe "localhost"
         publicRootPath shouldBe "/catalogue/v2"
-        apiConfig.environment shouldBe DevEnvironment
+        apiConfig.environment shouldBe ApiEnvironment.Dev
     }
   }
 }

--- a/common/search/src/test/scala/weco/api/search/models/ApiConfigTest.scala
+++ b/common/search/src/test/scala/weco/api/search/models/ApiConfigTest.scala
@@ -14,10 +14,27 @@ class ApiConfigTest extends AnyFunSpec with Matchers with Inside {
         defaultPageSize = 10
       )
     ) {
-      case ApiConfig(publicScheme, publicHost, publicRootPath, _) =>
+      case apiConfig@ApiConfig(publicScheme, publicHost, publicRootPath, _) =>
         publicScheme shouldBe "https"
         publicHost shouldBe "api.wellcomecollection.org"
         publicRootPath shouldBe "/catalogue/v2"
+        apiConfig.isDev shouldBe false
+    }
+  }
+
+  it("correctly identifies a dev environment") {
+    val publicRoot = "https://localhost:8080/catalogue/v2"
+    inside(
+      ApiConfig(
+        publicRootUri = Uri(publicRoot),
+        defaultPageSize = 10
+      )
+    ) {
+      case apiConfig@ApiConfig(publicScheme, publicHost, publicRootPath, _) =>
+        publicScheme shouldBe "https"
+        publicHost shouldBe "localhost"
+        publicRootPath shouldBe "/catalogue/v2"
+        apiConfig.isDev shouldBe true
     }
   }
 }

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -26,6 +26,8 @@ The CI flow looks as follows:
 Currently only the search API can be run locally. It will use the configured pipeline index in
 [`ElastiConfig.scala`](../common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala).
 
+You will need to have signed in to the AWS on the CLI to allow the application to assume the required role.
+
 From the root of the repository:
 
 ```bash

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -1,6 +1,6 @@
 ### Continuous integration
 
-The [current latest default branch](https://buildkite.com/wellcomecollection/catalogue-api) build [deploys to staging automatically](https://buildkite.com/wellcomecollection/catalogue-api-deploy-stage). 
+The [current latest default branch](https://buildkite.com/wellcomecollection/catalogue-api) build [deploys to staging automatically](https://buildkite.com/wellcomecollection/catalogue-api-deploy-stage).
 
 After a deployment to stage environment, we run [smoke tests](smoke_tests/README.md) against the stage API and then [e2e tests](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/playwright/README.md) on the front-end pointing the production wellcomecollection.org at the stage catalogue API.
 
@@ -14,9 +14,22 @@ The CI flow looks as follows:
 
 ## Dependencies
 
-* Java 1.8
-* Scala 2.12
-* SBT
-* Terraform
-* Docker
-* Make
+- Java 1.8
+- Scala 2.12
+- SBT
+- Terraform
+- Docker
+- Make
+
+## Running locally
+
+Currently only the search API can be run locally. It will use the configured pipeline index in
+[`ElastiConfig.scala`](../common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala).
+
+From the root of the repository:
+
+```bash
+sbt "project search" run
+```
+
+You should then be able to access the API at `http://localhost:8080/works`.

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -28,10 +28,10 @@ Currently only the search API can be run locally. It will use the configured pip
 
 You will need to have signed in to the AWS on the CLI to allow the application to assume the required role.
 
-From the root of the repository:
+To run with hot-reloading of code changes using [`sbt-revolver`](https://github.com/spray/sbt-revolver) from the root of the repository:
 
 ```bash
-sbt "project search" run
+sbt "project search" ~reStart
 ```
 
 You should then be able to access the API at `http://localhost:8080/works`.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -128,6 +128,10 @@ object ExternalDependencies {
     "software.amazon.awssdk" % "secretsmanager" % versions.aws2
   )
 
+  val stsDependencies = Seq(
+    "software.amazon.awssdk" % "sts" % versions.aws2
+  )
+
   val scalacsvDependencies = Seq(
     "com.github.tototoshi" %% "scala-csv" % versions.scalacsv
   )
@@ -149,7 +153,8 @@ object CatalogueDependencies {
       WellcomeDependencies.httpTypesafeLibrary ++
       ExternalDependencies.akkaHttpDependencies ++
       ExternalDependencies.scalacsvDependencies ++
-      ExternalDependencies.secretsDependencies
+      ExternalDependencies.secretsDependencies ++
+      ExternalDependencies.stsDependencies
 
   val searchDependencies: Seq[ModuleID] =
     ExternalDependencies.circeOpticsDependencies

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,5 @@ addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
 addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.19.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.3.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 addDependencyTreePlugin

--- a/search/src/main/resources/application.conf
+++ b/search/src/main/resources/application.conf
@@ -1,3 +1,4 @@
+api.public-root="http://localhost"
 api.public-root=${?api_public_root}
 apm.server.url=${?apm_server_url}
 apm.secret=${?apm_secret}
@@ -5,8 +6,9 @@ apm.service.name=${?apm_service_name}
 apm.environment=${?apm_environment}
 
 http.host="0.0.0.0"
+http.port=8080
 http.port=${?app_port}
+http.externalBaseURL="http://localhost:8080/"
 http.externalBaseURL=${?app_base_url}
 
 aws.metrics.namespace=${?metrics_namespace}
-

--- a/search/src/main/scala/weco/api/search/Main.scala
+++ b/search/src/main/scala/weco/api/search/Main.scala
@@ -7,7 +7,6 @@ import weco.api.search.config.builders.PipelineElasticClientBuilder
 import weco.api.search.models.{
   ApiConfig,
   ApiEnvironment,
-  DevEnvironment,
   PipelineClusterElasticConfig
 }
 import weco.typesafe.WellcomeTypesafeApp
@@ -28,12 +27,13 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val apiConfig: ApiConfig = ApiConfig.build(config)
 
-    // Don't initialise tracing in dev environments
-    if (apiConfig.environment == ApiEnvironment.Dev) {
-      info(s"Running in dev mode @ ${apiConfig.publicHost}")
-    } else {
-      info(s"Running in deployed mode @ ${apiConfig.publicHost}")
-      Tracing.init(config)
+    apiConfig.environment match {
+      case ApiEnvironment.Dev =>
+        info(s"Running in dev mode.")
+      case _ =>
+        info(s"Running in deployed mode (environment=${apiConfig.environment})")
+        // Only initialise tracing in deployed environments
+        Tracing.init(config)
     }
 
     val elasticClient = PipelineElasticClientBuilder(

--- a/search/src/main/scala/weco/api/search/Main.scala
+++ b/search/src/main/scala/weco/api/search/Main.scala
@@ -4,7 +4,12 @@ import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import weco.Tracing
 import weco.api.search.config.builders.PipelineElasticClientBuilder
-import weco.api.search.models.{ApiConfig, ApiEnvironment, DevEnvironment, PipelineClusterElasticConfig}
+import weco.api.search.models.{
+  ApiConfig,
+  ApiEnvironment,
+  DevEnvironment,
+  PipelineClusterElasticConfig
+}
 import weco.typesafe.WellcomeTypesafeApp
 import weco.http.WellcomeHttpApp
 import weco.http.monitoring.HttpMetrics

--- a/search/src/main/scala/weco/api/search/Main.scala
+++ b/search/src/main/scala/weco/api/search/Main.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import weco.Tracing
 import weco.api.search.config.builders.PipelineElasticClientBuilder
-import weco.api.search.models.{ApiConfig, PipelineClusterElasticConfig}
+import weco.api.search.models.{ApiConfig, ApiEnvironment, DevEnvironment, PipelineClusterElasticConfig}
 import weco.typesafe.WellcomeTypesafeApp
 import weco.http.WellcomeHttpApp
 import weco.http.monitoring.HttpMetrics
@@ -24,16 +24,16 @@ object Main extends WellcomeTypesafeApp {
     implicit val apiConfig: ApiConfig = ApiConfig.build(config)
 
     // Don't initialise tracing in dev environments
-    if (!apiConfig.isDev) {
+    if (apiConfig.environment == ApiEnvironment.Dev) {
+      info(s"Running in dev mode @ ${apiConfig.publicHost}")
+    } else {
       info(s"Running in deployed mode @ ${apiConfig.publicHost}")
       Tracing.init(config)
-    } else {
-      info(s"Running in dev mode @ ${apiConfig.publicHost}")
     }
 
     val elasticClient = PipelineElasticClientBuilder(
       serviceName = "catalogue_api",
-      isDev = apiConfig.isDev
+      environment = apiConfig.environment
     )
 
     val elasticConfig = PipelineClusterElasticConfig()

--- a/search/src/main/scala/weco/api/search/SearchApi.scala
+++ b/search/src/main/scala/weco/api/search/SearchApi.scala
@@ -33,7 +33,6 @@ class SearchApi(
     extends CustomDirectives
     with IdentifierDirectives {
 
-
   def routes: Route = handleRejections(rejectionHandler) {
     withRequestTimeoutResponse(request => timeoutResponse) {
       ignoreTrailingSlash {

--- a/search/src/main/scala/weco/api/search/SearchApi.scala
+++ b/search/src/main/scala/weco/api/search/SearchApi.scala
@@ -33,6 +33,7 @@ class SearchApi(
     extends CustomDirectives
     with IdentifierDirectives {
 
+
   def routes: Route = handleRejections(rejectionHandler) {
     withRequestTimeoutResponse(request => timeoutResponse) {
       ignoreTrailingSlash {


### PR DESCRIPTION
## What does this change?

Allow the search project to run locally, in order to better test changes by querying a configured real Elasticsearch index.

## How to test

Attempt to run this project locally, does it work?

## How can we measure success?

Developers have much better understanding of how their changes will work when deployed to production.

## Have we considered potential risks?

We have changed the`application.conf` so unless parameters are overridden by env vars when deployed unexpected behaviour may occur. Looking at the terraform config for this service it appears the params for which new defaults are provided are overwritten.