### PR TITLE
Add the ability to run the items project locally

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -23,15 +23,16 @@ The CI flow looks as follows:
 
 ## Running locally
 
-Currently only the search API can be run locally. It will use the configured pipeline index in
+Currently only the search & items API can be run locally. It will use the configured pipeline index in
 [`ElastiConfig.scala`](../common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala).
 
 You will need to have signed in to the AWS on the CLI to allow the application to assume the required role.
 
-To run with hot-reloading of code changes using [`sbt-revolver`](https://github.com/spray/sbt-revolver) from the root of the repository:
+To run with reloading of code changes using [`sbt-revolver`](https://github.com/spray/sbt-revolver) from the root of the repository:
 
 ```bash
 sbt "project search" ~reStart
+sbt "project items" ~reStart
 ```
 
 You should then be able to access the API at `http://localhost:8080/works`.

--- a/items/src/main/resources/application.conf
+++ b/items/src/main/resources/application.conf
@@ -5,7 +5,7 @@ apm.service.name=${?apm_service_name}
 apm.environment=${?apm_environment}
 
 api.public-root="http://localhost"
-api.public-root=${?api_public_root}
+api.public-root=${?catalogue_api_public_root}
 
 catalogue.api.publicRoot="https://api.wellcomecollection.org/catalogue/v2"
 catalogue.api.publicRoot=${?catalogue_api_public_root}

--- a/items/src/main/resources/application.conf
+++ b/items/src/main/resources/application.conf
@@ -4,14 +4,21 @@ apm.secret=${?apm_secret}
 apm.service.name=${?apm_service_name}
 apm.environment=${?apm_environment}
 
+api.public-root="http://localhost"
+api.public-root=${?api_public_root}
+
+catalogue.api.publicRoot="https://api.wellcomecollection.org/catalogue/v2"
 catalogue.api.publicRoot=${?catalogue_api_public_root}
+
+content.api.publicRoot="https://api.wellcomecollection.org/content/v0"
 content.api.publicRoot=${?content_api_public_root}
 
 http.host="0.0.0.0"
+http.port=8080
 http.port=${?app_port}
+http.externalBaseURL="http://localhost:8080/"
 http.externalBaseURL=${?app_base_url}
 
 aws.metrics.namespace=${?metrics_namespace}
-sierra.api.key=${?sierra_api_key}
-sierra.api.secret=${?sierra_api_secret}
+sierra.api.baseUrl="libsys.wellcomelibrary.org"
 sierra.api.baseUrl=${?sierra_base_url}

--- a/items/src/main/scala/weco/api/items/Main.scala
+++ b/items/src/main/scala/weco/api/items/Main.scala
@@ -5,7 +5,12 @@ import akka.http.scaladsl.model.Uri
 import com.typesafe.config.Config
 import weco.Tracing
 import weco.api.items.config.builders.SierraOauthHttpClientBuilder
-import weco.api.items.services.{ItemUpdateService, SierraItemUpdater, VenueOpeningTimesLookup, WorkLookup}
+import weco.api.items.services.{
+  ItemUpdateService,
+  SierraItemUpdater,
+  VenueOpeningTimesLookup,
+  WorkLookup
+}
 import weco.http.typesafe.HTTPServerBuilder
 import weco.monitoring.typesafe.CloudWatchBuilder
 import weco.api.search.models.{ApiConfig, ApiEnvironment}

--- a/items/src/main/scala/weco/api/items/config/builders/SierraOauthHttpClientBuilder.scala
+++ b/items/src/main/scala/weco/api/items/config/builders/SierraOauthHttpClientBuilder.scala
@@ -1,0 +1,80 @@
+package weco.api.items.config.builders
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import com.typesafe.config.Config
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest
+import weco.api.search.models.ApiEnvironment
+import weco.http.client.{AkkaHttpClient, HttpGet, HttpPost}
+import weco.sierra.http.SierraOauthHttpClient
+import weco.typesafe.config.builders.EnrichConfig._
+
+import scala.concurrent.ExecutionContext
+
+// This replaces the implementation of SierraOauthHttpClientBuilder
+// from scala-libs as we would like to use the SecretsManagerClient
+// to get our config rather than the config file. We should probably
+// remove this from scala-libs, after removing any other usages (
+// currently the requests service).
+object SierraOauthHttpClientBuilder {
+  def build(config: Config, environment: ApiEnvironment = ApiEnvironment.Prod)(
+    implicit
+    as: ActorSystem,
+    ec: ExecutionContext,
+  ): SierraOauthHttpClient = {
+
+    val secretsManagerClientBuilder = SecretsManagerClient.builder()
+
+    val secretsClientForEnv= environment match {
+      case ApiEnvironment.Dev =>
+        secretsManagerClientBuilder
+          .credentialsProvider(
+            ProfileCredentialsProvider.create("catalogue-developer"))
+          .build()
+      case _ =>
+        secretsManagerClientBuilder.build()
+    }
+
+    implicit val secretsClient: SecretsManagerClient = secretsClientForEnv
+
+    val username = getSecretString(
+      s"stacks/prod/sierra_api_key"
+    )
+
+    val password = getSecretString(
+      s"stacks/prod/sierra_api_secret"
+    )
+
+    val client = new AkkaHttpClient() with HttpGet with HttpPost {
+      override val baseUri: Uri = Uri(
+        config.requireString("sierra.api.baseUrl")
+      )
+    }
+
+    new SierraOauthHttpClient(
+      client,
+      credentials = BasicHttpCredentials(
+        username = username,
+        password = password
+      )
+    )
+  }
+
+  private def getSecretString(
+                               id: String
+                             )(implicit secretsClient: SecretsManagerClient) = {
+    val request =
+      GetSecretValueRequest
+        .builder()
+        .secretId(id)
+        .build()
+
+    secretsClient
+      .getSecretValue(request)
+      .secretString()
+  }
+}
+

--- a/items/src/main/scala/weco/api/items/config/builders/SierraOauthHttpClientBuilder.scala
+++ b/items/src/main/scala/weco/api/items/config/builders/SierraOauthHttpClientBuilder.scala
@@ -28,7 +28,7 @@ object SierraOauthHttpClientBuilder {
 
     val secretsManagerClientBuilder = SecretsManagerClient.builder()
 
-    val secretsClientForEnv= environment match {
+    val secretsClientForEnv = environment match {
       case ApiEnvironment.Dev =>
         secretsManagerClientBuilder
           .credentialsProvider(
@@ -64,8 +64,8 @@ object SierraOauthHttpClientBuilder {
   }
 
   private def getSecretString(
-                               id: String
-                             )(implicit secretsClient: SecretsManagerClient) = {
+    id: String
+  )(implicit secretsClient: SecretsManagerClient) = {
     val request =
       GetSecretValueRequest
         .builder()
@@ -77,4 +77,3 @@ object SierraOauthHttpClientBuilder {
       .secretString()
   }
 }
-

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -125,10 +125,7 @@ object ExternalDependencies {
   )
 
   val secretsDependencies = Seq(
-    "software.amazon.awssdk" % "secretsmanager" % versions.aws2
-  )
-
-  val stsDependencies = Seq(
+    "software.amazon.awssdk" % "secretsmanager" % versions.aws2,
     "software.amazon.awssdk" % "sts" % versions.aws2
   )
 
@@ -153,8 +150,7 @@ object CatalogueDependencies {
       WellcomeDependencies.httpTypesafeLibrary ++
       ExternalDependencies.akkaHttpDependencies ++
       ExternalDependencies.scalacsvDependencies ++
-      ExternalDependencies.secretsDependencies ++
-      ExternalDependencies.stsDependencies
+      ExternalDependencies.secretsDependencies
 
   val searchDependencies: Seq[ModuleID] =
     ExternalDependencies.circeOpticsDependencies
@@ -171,7 +167,9 @@ object CatalogueDependencies {
       WellcomeDependencies.typesafeLibrary
 
   val itemsDependencies: Seq[ModuleID] =
-    WellcomeDependencies.sierraTypesafeLibrary
+    WellcomeDependencies.sierraTypesafeLibrary ++
+      ExternalDependencies.secretsDependencies
+
 
   val requestsDependencies: Seq[ModuleID] =
     WellcomeDependencies.sierraTypesafeLibrary


### PR DESCRIPTION
## What does this change?

Allow the items project to run locally, in order to better test changes by querying a configured real Sierra.

Follows: https://github.com/wellcomecollection/catalogue-api/pull/774

## How to test

Attempt to run this project locally, does it work?

## How can we measure success?

Developers have much better understanding of how their changes will work when deployed to production.

## Have we considered potential risks?

We have changed the `application.conf` so unless parameters are overridden by env vars when deployed unexpected behaviour may occur. Looking at the terraform config for this service it appears the params for which new defaults are provided are overwritten.