### PR TITLE
Allow catalogue services to read from stacks secret space

### DIFF
--- a/terraform/modules/service/iam.tf
+++ b/terraform/modules/service/iam.tf
@@ -11,6 +11,7 @@ data "aws_iam_policy_document" "get_secrets" {
 
     resources = [
       "arn:aws:secretsmanager:eu-west-1:756629837203:secret:elasticsearch/*",
+      "arn:aws:secretsmanager:eu-west-1:756629837203:secret:stacks/*",
     ]
   }
 }


### PR DESCRIPTION
## What does this change?

This change tries to resolve a deployment issue resulting from the merge of https://github.com/wellcomecollection/catalogue-api/pull/775, which now requires the items API to read a new secret that it does not have access to. We add that permission here.

## How to test

[Attempt a redeployment](https://buildkite.com/wellcomecollection/catalogue-api-deploy-stage/builds/633#018f3d7c-b03b-4378-a19c-b0fb2d7fd298), does it succeed?

## How can we measure success?

Ability to successfully deploy the catalogue service!

## Have we considered potential risks?

We are extending access to this secret for all of the ECS tasks, strictly we should follow least privilege and only give it to the tasks and environment that needs it. This is a small enough expansion of scope for my to be comfortable in this case.