### PR TITLE
fix lead time bug + add test case

### DIFF
--- a/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
+++ b/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
@@ -9,12 +9,14 @@ import weco.catalogue.display_model.locations.{
   DisplayPhysicalLocation
 }
 import weco.catalogue.display_model.work.{AvailabilitySlot, DisplayItem}
+import weco.api.items.models.OpenClose
 import weco.sierra.http.SierraSource
 import weco.sierra.models.errors.SierraItemLookupError
 import weco.sierra.models.fields.SierraItemDataEntries
 import weco.sierra.models.identifiers.SierraItemNumber
 
-import java.time.{Clock, LocalDateTime}
+import java.time.format.DateTimeFormatter
+import java.time.{Clock, LocalDate, LocalDateTime}
 import scala.concurrent.{ExecutionContext, Future}
 
 /** Updates the AccessCondition of sierra items
@@ -119,10 +121,19 @@ class SierraItemUpdater(
       // other venue to be added as DisplayAccessMethod id -> content-api venue title
     )
 
-    val timeAtVenue = LocalDateTime.now(venueClock)
-    val leadTimeInDays = accessCondition.method.id match {
-      case "online-request" if timeAtVenue.getHour < 10  => 1
-      case "online-request" if timeAtVenue.getHour >= 10 => 2
+    def getLeadTimeInDays(openingTimes: List[OpenClose]): Int = {
+      val timeAtVenue = LocalDateTime.now(venueClock)
+      val isWorkingDay = timeAtVenue.toLocalDate.isEqual(
+        LocalDate.parse(
+          openingTimes.head.open,
+          DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+        )
+      )
+      accessCondition.method.id match {
+        case "online-request" if (timeAtVenue.getHour < 10 || !isWorkingDay) =>
+          1
+        case "online-request" if timeAtVenue.getHour >= 10 => 2
+      }
     }
 
     venueOpeningTimesLookup
@@ -135,10 +146,11 @@ class SierraItemUpdater(
             .map(
               openClose => AvailabilitySlot(openClose.open, openClose.close)
             )
-            // the list of openingTimes, as returned from VenueOpeningTimesLookup, starts at "today"
+            // the list of openingTimes, as returned from VenueOpeningTimesLookup, starts at "closest open day"
+            // (including today)
             // however, it takes ${leadTimeInDays} days for the item to be fetched from stores
             // so we need to drop ${leadTimeInDays} elements from the list of openingTimes
-            .drop(leadTimeInDays)
+            .drop(getLeadTimeInDays(venue.openingTimes))
         case Left(venueOpeningTimesLookupError) =>
           error(
             s"Venue opening times lookup failed: $venueOpeningTimesLookupError"

--- a/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
+++ b/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
@@ -67,9 +67,11 @@ class SierraItemUpdater(
     for {
       itemEither <- sierraSource.lookupItemEntries(existingItems.keys.toSeq)
 
-      maybeAccessConditions: Map[SierraItemNumber, Option[
-        DisplayAccessCondition
-      ]] = itemEither match {
+      maybeAccessConditions: Map[
+        SierraItemNumber,
+        Option[
+          DisplayAccessCondition
+        ]] = itemEither match {
         case Right(SierraItemDataEntries(_, _, entries)) =>
           entries
             .map(item => {

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -453,10 +453,10 @@ class ItemUpdateServiceTest
 
     it(
       "adds correct available dates for the item, when the venue is closed for the next few days"
-      // item is normally available 2 days after the request is made, ie. on the 23rd. However the venue is closed on the 22nd anf 23rd,
-      // so the item is only available on the next opening day+2 days, ie. the 26th
+      // item is normally available the day after the request is made, ie. on the 22nd. However the venue is closed on the 22nd anf 23rd,
+      // so the item is only available the day after the next opening day, ie. 25th
     ) {
-      withClock("2024-04-21T11:00:00.000Z") { clock =>
+      withClock("2024-04-21T08:00:00.000Z") { clock =>
         withSierraItemUpdater(
           availableItemResponses(workWithAvailableItemNumber),
           Seq((contentApiVenueRequest("library"), contentApiVenueResponse())),
@@ -472,6 +472,10 @@ class ItemUpdateServiceTest
 
                 physicalItem.availableDates shouldBe Some(
                   List(
+                    AvailabilitySlot(
+                      "2024-04-25T09:00:00.000Z",
+                      "2024-04-25T19:00:00.000Z"
+                    ),
                     AvailabilitySlot(
                       "2024-04-26T09:00:00.000Z",
                       "2024-04-26T17:00:00.000Z"

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -452,6 +452,40 @@ class ItemUpdateServiceTest
     }
 
     it(
+      "adds correct available dates for the item, when the venue is closed for the next few days"
+      // item is normally available 2 days after the request is made, ie. on the 23rd. However the venue is closed on the 22nd anf 23rd,
+      // so the item is only available on the next opening day+2 days, ie. the 26th
+    ) {
+      withClock("2024-04-21T11:00:00.000Z") { clock =>
+        withSierraItemUpdater(
+          availableItemResponses(workWithAvailableItemNumber),
+          Seq((contentApiVenueRequest("library"), contentApiVenueResponse())),
+          clock
+        ) { itemUpdater =>
+          withItemUpdateService(List(itemUpdater)) { itemUpdateService =>
+            whenReady(itemUpdateService.updateItems(workWithAvailableItem)) {
+              updatedItems =>
+                updatedItems.length shouldBe 2
+
+                val physicalItem = updatedItems.head
+                val digitalItem = updatedItems(1)
+
+                physicalItem.availableDates shouldBe Some(
+                  List(
+                    AvailabilitySlot(
+                      "2024-04-26T09:00:00.000Z",
+                      "2024-04-26T17:00:00.000Z"
+                    )
+                  )
+                )
+                digitalItem shouldBe dummyDigitalItem
+            }
+          }
+        }
+      }
+    }
+
+    it(
       "adds available dates as an empty list if contentApiVenueRequest returns an error"
     ) {
       withClock() { clock =>


### PR DESCRIPTION
## Pull request checklist

*   Does this patch need a change to the documentation? No 

    Do you need to update the [Catalogue API Swagger][swagger]?

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml

NOTE: uncovered an edge case for requests made on a closed day, after 10am. 
The logic previously in place dictated that we should drop the 1st and 2nd nextOpeningDays because the req is made after 10am. 
However in reality the staff will actually **get** the request before 10am on the 1st nextOpeningDay, so we should only drop the 1st nextOpeningDays. 
This is the current behaviour in weco.org