### PR TITLE
New pipeline

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
@@ -10,7 +10,7 @@ case class ElasticConfig(
 trait ElasticConfigBase {
   // We use this to share config across Scala API applications
   // i.e. The API and the snapshot generator.
-  val pipelineDate = "2024-05-13"
+  val pipelineDate = "2024-06-06"
 }
 
 object PipelineClusterElasticConfig extends ElasticConfigBase {


### PR DESCRIPTION
New pipeline to pick up the [changes in inferrer dependencies](https://github.com/wellcomecollection/catalogue-pipeline/pull/2663).

There should be no noticeable difference in behaviour between this and the previous pipeline, but the use of newer versions of libraries may mean that the vectorisations are subtly different.