### PR TITLE
Use a different record for the smoke test

### DIFF
--- a/smoke_tests/processorFunctions.js
+++ b/smoke_tests/processorFunctions.js
@@ -1,4 +1,5 @@
 const AWS = require('aws-sdk');
+AWS.config.update({region:'eu-west-1'});
 
 module.exports = {
     addApiKey: addApiKey,

--- a/smoke_tests/smokeTests.yml
+++ b/smoke_tests/smokeTests.yml
@@ -33,16 +33,16 @@ scenarios:
           url: "/images"
           expect:
             statusCode: 200
-  - name: "/works/awa6c6gm"
+  - name: "/works/b7nfeg9j"
     flow:
       - get:
-          url: "/works/awa6c6gm"
+          url: "/works/b7nfeg9j"
           expect:
             statusCode: 200
-  - name: "/works/awa6c6gm/items"
+  - name: "/works/b7nfeg9j/items"
     flow:
       - get:
-          url: "/works/awa6c6gm/items"
+          url: "/works/b7nfeg9j/items"
           beforeRequest: addApiKey
           expect:
             statusCode: 200


### PR DESCRIPTION
The smoke tests have started failing because of a change in the underlying data.  Nature (awa6c6gm, redirecting to vruhajjv) does not have `items`, which means that the test on lines 42-48 have now started failing because "/works/awa6c6gm/items" returns a 500 error.

Leaving aside that it should probably return a client error rather than a server error, it is still necessary to change this test to use a record that returns 200 when `items` are requested.