### PR TITLE
Migrate from Akka to Pekko

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/ApiConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ApiConfig.scala
@@ -1,6 +1,6 @@
 package weco.api.search.models
 
-import akka.http.scaladsl.model.Uri
+import org.apache.pekko.http.scaladsl.model.Uri
 import com.typesafe.config.Config
 import weco.typesafe.config.builders.EnrichConfig.RichConfig
 

--- a/common/search/src/test/scala/weco/api/search/models/ApiConfigTest.scala
+++ b/common/search/src/test/scala/weco/api/search/models/ApiConfigTest.scala
@@ -1,6 +1,6 @@
 package weco.api.search.models
 
-import akka.http.scaladsl.model.Uri
+import org.apache.pekko.http.scaladsl.model.Uri
 import org.scalatest.Inside
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers

--- a/items/src/main/scala/weco/api/items/ItemsApi.scala
+++ b/items/src/main/scala/weco/api/items/ItemsApi.scala
@@ -1,6 +1,6 @@
 package weco.api.items
 
-import akka.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.server.Route
 import weco.Tracing
 import weco.api.items.responses.LookupItemStatus
 import weco.api.items.services.{ItemUpdateService, WorkLookup}

--- a/items/src/main/scala/weco/api/items/Main.scala
+++ b/items/src/main/scala/weco/api/items/Main.scala
@@ -16,7 +16,7 @@ import weco.monitoring.typesafe.CloudWatchBuilder
 import weco.api.search.models.{ApiConfig, ApiEnvironment}
 import weco.typesafe.WellcomeTypesafeApp
 import weco.http.WellcomeHttpApp
-import weco.http.client.{PekkoHttpClient, HttpGet}
+import weco.http.client.{HttpGet, PekkoHttpClient}
 import weco.http.monitoring.HttpMetrics
 import weco.sierra.http.SierraSource
 

--- a/items/src/main/scala/weco/api/items/Main.scala
+++ b/items/src/main/scala/weco/api/items/Main.scala
@@ -1,7 +1,7 @@
 package weco.api.items
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model.Uri
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.Uri
 import com.typesafe.config.Config
 import weco.Tracing
 import weco.api.items.config.builders.SierraOauthHttpClientBuilder
@@ -16,7 +16,7 @@ import weco.monitoring.typesafe.CloudWatchBuilder
 import weco.api.search.models.{ApiConfig, ApiEnvironment}
 import weco.typesafe.WellcomeTypesafeApp
 import weco.http.WellcomeHttpApp
-import weco.http.client.{AkkaHttpClient, HttpGet}
+import weco.http.client.{PekkoHttpClient, HttpGet}
 import weco.http.monitoring.HttpMetrics
 import weco.sierra.http.SierraSource
 
@@ -49,7 +49,7 @@ object Main extends WellcomeTypesafeApp {
     )
     val sierraSource = new SierraSource(client)
 
-    val contentHttpClient = new AkkaHttpClient() with HttpGet {
+    val contentHttpClient = new PekkoHttpClient() with HttpGet {
       override val baseUri: Uri = config.getString("content.api.publicRoot")
     }
     val venueOpeningTimeLookup = new VenueOpeningTimesLookup(contentHttpClient)
@@ -67,7 +67,7 @@ object Main extends WellcomeTypesafeApp {
 
     val itemUpdateService = new ItemUpdateService(itemUpdaters)
 
-    val catalogueHttpClient = new AkkaHttpClient() with HttpGet {
+    val catalogueHttpClient = new PekkoHttpClient() with HttpGet {
       override val baseUri: Uri = config.getString("catalogue.api.publicRoot")
     }
 

--- a/items/src/main/scala/weco/api/items/config/builders/SierraOauthHttpClientBuilder.scala
+++ b/items/src/main/scala/weco/api/items/config/builders/SierraOauthHttpClientBuilder.scala
@@ -1,14 +1,14 @@
 package weco.api.items.config.builders
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model.Uri
-import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.http.scaladsl.model.headers.BasicHttpCredentials
 import com.typesafe.config.Config
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest
 import weco.api.search.models.ApiEnvironment
-import weco.http.client.{AkkaHttpClient, HttpGet, HttpPost}
+import weco.http.client.{PekkoHttpClient, HttpGet, HttpPost}
 import weco.sierra.http.SierraOauthHttpClient
 import weco.typesafe.config.builders.EnrichConfig._
 
@@ -48,7 +48,7 @@ object SierraOauthHttpClientBuilder {
       s"stacks/prod/sierra_api_secret"
     )
 
-    val client = new AkkaHttpClient() with HttpGet with HttpPost {
+    val client = new PekkoHttpClient() with HttpGet with HttpPost {
       override val baseUri: Uri = Uri(
         config.requireString("sierra.api.baseUrl")
       )

--- a/items/src/main/scala/weco/api/items/config/builders/SierraOauthHttpClientBuilder.scala
+++ b/items/src/main/scala/weco/api/items/config/builders/SierraOauthHttpClientBuilder.scala
@@ -8,7 +8,7 @@ import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest
 import weco.api.search.models.ApiEnvironment
-import weco.http.client.{PekkoHttpClient, HttpGet, HttpPost}
+import weco.http.client.{HttpGet, HttpPost, PekkoHttpClient}
 import weco.sierra.http.SierraOauthHttpClient
 import weco.typesafe.config.builders.EnrichConfig._
 

--- a/items/src/main/scala/weco/api/items/responses/LookupItemStatus.scala
+++ b/items/src/main/scala/weco/api/items/responses/LookupItemStatus.scala
@@ -1,6 +1,10 @@
 package weco.api.items.responses
 
-import org.apache.pekko.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
+import org.apache.pekko.http.scaladsl.model.{
+  ContentTypes,
+  HttpEntity,
+  HttpResponse
+}
 import org.apache.pekko.http.scaladsl.server.Route
 import weco.api.items.models.DisplayItemsList
 import weco.api.items.services._

--- a/items/src/main/scala/weco/api/items/responses/LookupItemStatus.scala
+++ b/items/src/main/scala/weco/api/items/responses/LookupItemStatus.scala
@@ -1,7 +1,7 @@
 package weco.api.items.responses
 
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
-import akka.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
+import org.apache.pekko.http.scaladsl.server.Route
 import weco.api.items.models.DisplayItemsList
 import weco.api.items.services._
 import weco.api.stacks.models.CatalogueWork

--- a/items/src/main/scala/weco/api/items/services/VenueOpeningTimesLookup.scala
+++ b/items/src/main/scala/weco/api/items/services/VenueOpeningTimesLookup.scala
@@ -1,9 +1,9 @@
 package weco.api.items.services
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model.Uri.Path
-import akka.http.scaladsl.model.{HttpEntity, StatusCodes}
-import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.Uri.Path
+import org.apache.pekko.http.scaladsl.model.{HttpEntity, StatusCodes}
+import org.apache.pekko.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 import grizzled.slf4j.Logging
 import weco.http.client.{HttpClient, HttpGet}
 import weco.http.json.CirceMarshalling

--- a/items/src/main/scala/weco/api/items/services/WorkLookup.scala
+++ b/items/src/main/scala/weco/api/items/services/WorkLookup.scala
@@ -1,9 +1,9 @@
 package weco.api.items.services
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model.Uri.Path
-import akka.http.scaladsl.model.{HttpEntity, StatusCodes}
-import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.Uri.Path
+import org.apache.pekko.http.scaladsl.model.{HttpEntity, StatusCodes}
+import org.apache.pekko.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 import grizzled.slf4j.Logging
 import weco.api.stacks.models.CatalogueWork
 import weco.http.client.{HttpClient, HttpGet}

--- a/items/src/test/scala/weco/api/items/ItemsApiFeatureTest.scala
+++ b/items/src/test/scala/weco/api/items/ItemsApiFeatureTest.scala
@@ -1,6 +1,6 @@
 package weco.api.items
 
-import akka.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model._
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers

--- a/items/src/test/scala/weco/api/items/fixtures/ItemsApiFixture.scala
+++ b/items/src/test/scala/weco/api/items/fixtures/ItemsApiFixture.scala
@@ -1,6 +1,6 @@
 package weco.api.items.fixtures
 
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
+import org.apache.pekko.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
 import org.scalatest.Suite
 import weco.api.items.ItemsApi
 import weco.api.items.services.{

--- a/items/src/test/scala/weco/api/items/fixtures/ItemsApiGenerators.scala
+++ b/items/src/test/scala/weco/api/items/fixtures/ItemsApiGenerators.scala
@@ -1,6 +1,6 @@
 package weco.api.items.fixtures
 
-import akka.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model._
 import weco.fixtures.LocalResources
 import weco.http.json.DisplayJsonUtil
 import weco.http.models.DisplayError

--- a/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
+++ b/items/src/test/scala/weco/api/items/services/ItemUpdateServiceTest.scala
@@ -1,6 +1,6 @@
 package weco.api.items.services
 
-import akka.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model._
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers

--- a/items/src/test/scala/weco/api/items/services/VenueOpeningTimesLookupTest.scala
+++ b/items/src/test/scala/weco/api/items/services/VenueOpeningTimesLookupTest.scala
@@ -1,11 +1,11 @@
 package weco.api.items.services
 
-import akka.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model._
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.akka.fixtures.Akka
+import weco.pekko.fixtures.Pekko
 import weco.api.items.fixtures.ItemsApiGenerators
 import weco.api.items.models.{OpenClose, VenueOpeningTimes}
 import weco.catalogue.display_model.generators.IdentifiersGenerators
@@ -19,7 +19,7 @@ class VenueOpeningTimesLookupTest
     extends AnyFunSpec
     with Matchers
     with EitherValues
-    with Akka
+    with Pekko
     with ScalaFutures
     with IdentifiersGenerators
     with ItemsApiGenerators {

--- a/items/src/test/scala/weco/api/items/services/WorkLookupTest.scala
+++ b/items/src/test/scala/weco/api/items/services/WorkLookupTest.scala
@@ -1,11 +1,11 @@
 package weco.api.items.services
 
-import akka.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model._
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.akka.fixtures.Akka
+import weco.pekko.fixtures.Pekko
 import weco.api.items.fixtures.ItemsApiGenerators
 import weco.api.stacks.models.{CatalogueAccessMethod, CatalogueWork}
 import weco.catalogue.display_model.identifiers.{
@@ -30,7 +30,7 @@ class WorkLookupTest
     extends AnyFunSpec
     with Matchers
     with EitherValues
-    with Akka
+    with Pekko
     with ScalaFutures
     with IdentifiersGenerators
     with ItemsApiGenerators {

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -3,7 +3,7 @@ import sbt._
 
 object Common {
   val settings: Seq[Def.Setting[_]] = Seq(
-    scalaVersion := "2.12.15",
+    scalaVersion := "2.12.16",
     organization := "weco",
     resolvers ++= Seq(
       "Wellcome releases" at "s3://releases.mvn-repo.wellcomecollection.org/"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -101,8 +101,8 @@ object ExternalDependencies {
 
     // This should match the version used in scala-libs
     // See https://github.com/wellcomecollection/scala-libs/blob/main/project/Dependencies.scala
-    val akka = "2.6.20"
-    val akkaHttp = "10.2.9"
+    val pekko = "1.0.3"
+    val pekkoHttp = "1.0.1"
     val aws2 = "2.11.14"
   }
 
@@ -119,9 +119,9 @@ object ExternalDependencies {
     "org.scalatest" %% "scalatest" % versions.scalatest % "test"
   )
 
-  val akkaHttpDependencies = Seq(
-    "com.typesafe.akka" %% "akka-testkit" % versions.akka % "test",
-    "com.typesafe.akka" %% "akka-http-testkit" % versions.akkaHttp % "test"
+  val pekkoHttpDependencies = Seq(
+    "org.apache.pekko" %% "pekko-testkit" % versions.pekko % "test",
+    "org.apache.pekko" %% "pekko-http-testkit" % versions.pekkoHttp % "test"
   )
 
   val secretsDependencies = Seq(
@@ -148,7 +148,7 @@ object CatalogueDependencies {
       WellcomeDependencies.typesafeLibrary ++
       WellcomeDependencies.monitoringLibrary ++
       WellcomeDependencies.httpTypesafeLibrary ++
-      ExternalDependencies.akkaHttpDependencies ++
+      ExternalDependencies.pekkoHttpDependencies ++
       ExternalDependencies.scalacsvDependencies ++
       ExternalDependencies.secretsDependencies
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object WellcomeDependencies {
 
-  val defaultVersion = "32.41.1" // This is automatically bumped by the scala-libs release process, do not edit this line manually
+  val defaultVersion = "32.42.0" // This is automatically bumped by the scala-libs release process, do not edit this line manually
 
   lazy val versions = new {
     val typesafe = defaultVersion

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,1 +1,1 @@
-scalaVersion := "2.12.15"
+scalaVersion := "2.12.16"

--- a/requests/src/main/scala/weco/api/requests/Main.scala
+++ b/requests/src/main/scala/weco/api/requests/Main.scala
@@ -11,7 +11,7 @@ import weco.api.requests.services.{
 }
 import weco.api.search.models.ApiConfig
 import weco.http.WellcomeHttpApp
-import weco.http.client.{PekkoHttpClient, HttpGet}
+import weco.http.client.{HttpGet, PekkoHttpClient}
 import weco.http.monitoring.HttpMetrics
 import weco.http.typesafe.HTTPServerBuilder
 import weco.monitoring.typesafe.CloudWatchBuilder

--- a/requests/src/main/scala/weco/api/requests/Main.scala
+++ b/requests/src/main/scala/weco/api/requests/Main.scala
@@ -1,7 +1,7 @@
 package weco.api.requests
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model.Uri
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.Uri
 import com.typesafe.config.Config
 import weco.Tracing
 import weco.api.requests.services.{
@@ -11,7 +11,7 @@ import weco.api.requests.services.{
 }
 import weco.api.search.models.ApiConfig
 import weco.http.WellcomeHttpApp
-import weco.http.client.{AkkaHttpClient, HttpGet}
+import weco.http.client.{PekkoHttpClient, HttpGet}
 import weco.http.monitoring.HttpMetrics
 import weco.http.typesafe.HTTPServerBuilder
 import weco.monitoring.typesafe.CloudWatchBuilder
@@ -33,7 +33,7 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val apiConfig: ApiConfig = ApiConfig.build(config)
 
-    val httpClient = new AkkaHttpClient() with HttpGet {
+    val httpClient = new PekkoHttpClient() with HttpGet {
       override val baseUri: Uri = config.getString("catalogue.api.publicRoot")
     }
 

--- a/requests/src/main/scala/weco/api/requests/RequestsApi.scala
+++ b/requests/src/main/scala/weco/api/requests/RequestsApi.scala
@@ -1,7 +1,7 @@
 package weco.api.requests
 
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server.{Directive, PathMatcher, Route}
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.server.{Directive, PathMatcher, Route}
 import weco.api.requests.models.ItemRequest
 import weco.api.requests.responses.{CreateRequest, LookupPendingRequests}
 import weco.api.requests.services.RequestsService

--- a/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
@@ -1,7 +1,7 @@
 package weco.api.requests.responses
 
-import akka.http.scaladsl.model.{HttpEntity, StatusCode, StatusCodes}
-import akka.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.model.{HttpEntity, StatusCode, StatusCodes}
+import org.apache.pekko.http.scaladsl.server.Route
 import grizzled.slf4j.Logging
 import weco.api.requests.models.HoldRejected
 import weco.api.requests.services.RequestsService

--- a/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/CreateRequest.scala
@@ -1,6 +1,10 @@
 package weco.api.requests.responses
 
-import org.apache.pekko.http.scaladsl.model.{HttpEntity, StatusCode, StatusCodes}
+import org.apache.pekko.http.scaladsl.model.{
+  HttpEntity,
+  StatusCode,
+  StatusCodes
+}
 import org.apache.pekko.http.scaladsl.server.Route
 import grizzled.slf4j.Logging
 import weco.api.requests.models.HoldRejected

--- a/requests/src/main/scala/weco/api/requests/responses/LookupPendingRequests.scala
+++ b/requests/src/main/scala/weco/api/requests/responses/LookupPendingRequests.scala
@@ -1,6 +1,6 @@
 package weco.api.requests.responses
 
-import akka.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.server.Route
 import weco.api.requests.models.display.DisplayResultsList
 import weco.api.requests.services.RequestsService
 import weco.http.FutureDirectives

--- a/requests/src/main/scala/weco/api/requests/services/ItemLookup.scala
+++ b/requests/src/main/scala/weco/api/requests/services/ItemLookup.scala
@@ -1,9 +1,9 @@
 package weco.api.requests.services
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model.Uri.Path
-import akka.http.scaladsl.model.{HttpEntity, StatusCodes}
-import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.Uri.Path
+import org.apache.pekko.http.scaladsl.model.{HttpEntity, StatusCodes}
+import org.apache.pekko.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 import grizzled.slf4j.Logging
 import weco.api.requests.models.RequestedItemWithWork
 import weco.api.stacks.models.{CatalogueWork, DisplayItemOps}

--- a/requests/src/main/scala/weco/api/requests/services/SierraRequestsService.scala
+++ b/requests/src/main/scala/weco/api/requests/services/SierraRequestsService.scala
@@ -1,6 +1,6 @@
 package weco.api.requests.services
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import grizzled.slf4j.Logging
 import weco.api.requests.models.{HoldAccepted, HoldNote, HoldRejected}
 import weco.api.stacks.models.{DisplayItemOps, SierraItemIdentifier}

--- a/requests/src/test/scala/weco/api/requests/RequestingScenarioTest.scala
+++ b/requests/src/test/scala/weco/api/requests/RequestingScenarioTest.scala
@@ -1,9 +1,9 @@
 package weco.api.requests
 
-import akka.http.scaladsl.model.HttpMethods.POST
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.apache.pekko.http.scaladsl.model.HttpMethods.POST
+import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.GivenWhenThen
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.featurespec.AnyFeatureSpec

--- a/requests/src/test/scala/weco/api/requests/RequestsApiFeatureTest.scala
+++ b/requests/src/test/scala/weco/api/requests/RequestsApiFeatureTest.scala
@@ -1,7 +1,7 @@
 package weco.api.requests
 
-import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{
+import org.apache.pekko.http.scaladsl.model.headers.RawHeader
+import org.apache.pekko.http.scaladsl.model.{
   ContentTypes,
   HttpEntity,
   HttpMethods,
@@ -9,8 +9,8 @@ import akka.http.scaladsl.model.{
   HttpResponse,
   StatusCodes
 }
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.apache.pekko.http.scaladsl.server.Directives._
+import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers

--- a/requests/src/test/scala/weco/api/requests/fixtures/ItemLookupFixture.scala
+++ b/requests/src/test/scala/weco/api/requests/fixtures/ItemLookupFixture.scala
@@ -1,7 +1,7 @@
 package weco.api.requests.fixtures
 
-import akka.http.scaladsl.model._
-import weco.akka.fixtures.Akka
+import org.apache.pekko.http.scaladsl.model._
+import weco.pekko.fixtures.Pekko
 import weco.api.requests.services.ItemLookup
 import weco.catalogue.display_model.identifiers.DisplayIdentifier
 import weco.fixtures.TestWith
@@ -10,7 +10,7 @@ import weco.http.fixtures.HttpFixtures
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait ItemLookupFixture extends Akka with HttpFixtures {
+trait ItemLookupFixture extends Pekko with HttpFixtures {
   def withItemLookup[R](
     responses: Seq[(HttpRequest, HttpResponse)]
   )(testWith: TestWith[ItemLookup, R]): R =

--- a/requests/src/test/scala/weco/api/requests/fixtures/RequestsApiFixture.scala
+++ b/requests/src/test/scala/weco/api/requests/fixtures/RequestsApiFixture.scala
@@ -1,6 +1,6 @@
 package weco.api.requests.fixtures
 
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import org.apache.pekko.http.scaladsl.model.{HttpRequest, HttpResponse}
 import org.scalatest.Suite
 import weco.api.requests.RequestsApi
 import weco.api.requests.services.RequestsService

--- a/requests/src/test/scala/weco/api/requests/fixtures/SierraServiceFixture.scala
+++ b/requests/src/test/scala/weco/api/requests/fixtures/SierraServiceFixture.scala
@@ -1,6 +1,6 @@
 package weco.api.requests.fixtures
 
-import akka.http.scaladsl.model.{
+import org.apache.pekko.http.scaladsl.model.{
   ContentTypes,
   HttpEntity,
   HttpMethods,
@@ -8,7 +8,7 @@ import akka.http.scaladsl.model.{
   HttpResponse,
   Uri
 }
-import weco.akka.fixtures.Akka
+import weco.pekko.fixtures.Pekko
 import weco.api.requests.services.SierraRequestsService
 import weco.fixtures.{RandomGenerators, TestWith}
 import weco.http.client.{HttpGet, HttpPost, MemoryHttpClient}
@@ -22,7 +22,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 trait SierraServiceFixture
     extends HttpFixtures
-    with Akka
+    with Pekko
     with RandomGenerators {
   def createItemRequest(itemNumber: SierraItemNumber): HttpRequest = {
     val fieldList = SierraSource.requiredItemFields.mkString(",")

--- a/requests/src/test/scala/weco/api/requests/services/ItemLookupTest.scala
+++ b/requests/src/test/scala/weco/api/requests/services/ItemLookupTest.scala
@@ -1,6 +1,6 @@
 package weco.api.requests.services
 
-import akka.http.scaladsl.model.{HttpResponse, Uri}
+import org.apache.pekko.http.scaladsl.model.{HttpResponse, Uri}
 import io.circe.Json
 import io.circe.parser._
 import org.scalatest.EitherValues

--- a/requests/src/test/scala/weco/api/requests/services/SierraRequestsServiceTest.scala
+++ b/requests/src/test/scala/weco/api/requests/services/SierraRequestsServiceTest.scala
@@ -1,6 +1,6 @@
 package weco.api.requests.services
 
-import akka.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model._
 import org.scalatest.EitherValues
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.funspec.AnyFunSpec

--- a/search/src/main/scala/weco/api/search/Main.scala
+++ b/search/src/main/scala/weco/api/search/Main.scala
@@ -1,6 +1,6 @@
 package weco.api.search
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.typesafe.config.Config
 import weco.Tracing
 import weco.api.search.config.builders.PipelineElasticClientBuilder

--- a/search/src/main/scala/weco/api/search/SearchApi.scala
+++ b/search/src/main/scala/weco/api/search/SearchApi.scala
@@ -1,12 +1,12 @@
 package weco.api.search
 
-import akka.http.scaladsl.model.{
+import org.apache.pekko.http.scaladsl.model.{
   ContentTypes,
   HttpEntity,
   HttpResponse,
   StatusCodes
 }
-import akka.http.scaladsl.server.{
+import org.apache.pekko.http.scaladsl.server.{
   MalformedQueryParamRejection,
   RejectionHandler,
   Route,

--- a/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchErrorHandler.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/ElasticsearchErrorHandler.scala
@@ -1,6 +1,6 @@
 package weco.api.search.elasticsearch
 
-import akka.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.model.StatusCodes
 import com.sksamuel.elastic4s.ElasticError
 import grizzled.slf4j.Logging
 import weco.http.models.DisplayError

--- a/search/src/main/scala/weco/api/search/rest/CustomDirectives.scala
+++ b/search/src/main/scala/weco/api/search/rest/CustomDirectives.scala
@@ -1,7 +1,7 @@
 package weco.api.search.rest
 
-import akka.http.scaladsl.model.Uri
-import akka.http.scaladsl.server.{Directive, Route}
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.http.scaladsl.server.{Directive, Route}
 import weco.api.search.elasticsearch.{
   ElasticsearchError,
   ElasticsearchErrorHandler,
@@ -23,7 +23,7 @@ trait CustomDirectives extends FutureDirectives {
       uri
         .withScheme(apiConfig.publicScheme)
         .withHost(apiConfig.publicHost)
-        // akka-http uses 0 to indicate no explicit port in the URI
+        // pekko-http uses 0 to indicate no explicit port in the URI
         .withPort(0)
         .withPath(
           Uri.Path(apiConfig.publicRootPath) ++ uri.path

--- a/search/src/main/scala/weco/api/search/rest/DisplayResultList.scala
+++ b/search/src/main/scala/weco/api/search/rest/DisplayResultList.scala
@@ -1,6 +1,6 @@
 package weco.api.search.rest
 
-import akka.http.scaladsl.model.Uri
+import org.apache.pekko.http.scaladsl.model.Uri
 import io.circe.Json
 import io.circe.generic.extras.JsonKey
 import weco.api.search.json.CatalogueJsonUtil

--- a/search/src/main/scala/weco/api/search/rest/ImagesController.scala
+++ b/search/src/main/scala/weco/api/search/rest/ImagesController.scala
@@ -1,6 +1,6 @@
 package weco.api.search.rest
 
-import akka.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.server.Route
 import cats.implicits._
 import com.sksamuel.elastic4s.Index
 import weco.Tracing

--- a/search/src/main/scala/weco/api/search/rest/Pagination.scala
+++ b/search/src/main/scala/weco/api/search/rest/Pagination.scala
@@ -1,6 +1,6 @@
 package weco.api.search.rest
 
-import akka.http.scaladsl.model.Uri
+import org.apache.pekko.http.scaladsl.model.Uri
 import weco.api.search.models.{ResultList, SearchOptions}
 
 object PaginationLimits {

--- a/search/src/main/scala/weco/api/search/rest/QueryParams.scala
+++ b/search/src/main/scala/weco/api/search/rest/QueryParams.scala
@@ -1,8 +1,8 @@
 package weco.api.search.rest
 
 import java.time.LocalDate
-import akka.http.scaladsl.server.{Directive, Directives, ValidationRejection}
-import akka.http.scaladsl.unmarshalling.Unmarshaller
+import org.apache.pekko.http.scaladsl.server.{Directive, Directives, ValidationRejection}
+import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller
 import com.github.tototoshi.csv.CSVParser
 import io.circe.{Decoder, Json}
 import weco.api.search.rest.MultipleWorksParams.{

--- a/search/src/main/scala/weco/api/search/rest/QueryParams.scala
+++ b/search/src/main/scala/weco/api/search/rest/QueryParams.scala
@@ -1,7 +1,11 @@
 package weco.api.search.rest
 
 import java.time.LocalDate
-import org.apache.pekko.http.scaladsl.server.{Directive, Directives, ValidationRejection}
+import org.apache.pekko.http.scaladsl.server.{
+  Directive,
+  Directives,
+  ValidationRejection
+}
 import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller
 import com.github.tototoshi.csv.CSVParser
 import io.circe.{Decoder, Json}

--- a/search/src/main/scala/weco/api/search/rest/SingleWorkDirectives.scala
+++ b/search/src/main/scala/weco/api/search/rest/SingleWorkDirectives.scala
@@ -1,7 +1,7 @@
 package weco.api.search.rest
 
-import akka.http.scaladsl.model.StatusCodes.Found
-import akka.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.model.StatusCodes.Found
+import org.apache.pekko.http.scaladsl.server.Route
 import weco.api.search.elasticsearch.ElasticsearchError
 import weco.api.search.models.index.IndexedWork
 

--- a/search/src/main/scala/weco/api/search/rest/WorksController.scala
+++ b/search/src/main/scala/weco/api/search/rest/WorksController.scala
@@ -1,6 +1,6 @@
 package weco.api.search.rest
 
-import akka.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.server.Route
 import com.sksamuel.elastic4s.Index
 import weco.Tracing
 import weco.api.search.elasticsearch.{ElasticsearchError, ElasticsearchService}

--- a/search/src/main/scala/weco/api/search/rest/WorksParams.scala
+++ b/search/src/main/scala/weco/api/search/rest/WorksParams.scala
@@ -1,6 +1,6 @@
 package weco.api.search.rest
 
-import akka.http.scaladsl.server.Directive
+import org.apache.pekko.http.scaladsl.server.Directive
 import io.circe.Decoder
 import weco.api.search.models._
 import weco.api.search.models.request._
@@ -14,11 +14,11 @@ case class SingleWorkParams(
 
 object SingleWorkParams extends QueryParamsUtils {
 
-  // This is a custom akka-http directive which extracts SingleWorkParams
+  // This is a custom pekko-http directive which extracts SingleWorkParams
   // data from the query string, returning an invalid response when any given
   // parameter is not correctly parsed. More info on custom directives is
   // available here:
-  // https://doc.akka.io/docs/akka-http/current/routing-dsl/directives/custom-directives.html
+  // https://pekko.apache.org/docs/pekko-http/1.0/routing-dsl/directives/custom-directives.html
   def parse: Directive[Tuple1[SingleWorkParams]] =
     parameters(
       "include".as[WorksIncludes].?
@@ -143,11 +143,11 @@ object MultipleWorksParams extends QueryParamsUtils {
   import CommonDecoders._
   import SingleWorkParams.includesDecoder
 
-  // This is a custom akka-http directive which extracts MultipleWorksParams
+  // This is a custom pekko-http directive which extracts MultipleWorksParams
   // data from the query string, returning an invalid response when any given
   // parameter is not correctly parsed. More info on custom directives is
   // available here:
-  // https://doc.akka.io/docs/akka-http/current/routing-dsl/directives/custom-directives.html
+  // https://pekko.apache.org/docs/pekko-http/1.0/routing-dsl/directives/custom-directives.html
   //
   // Scala has a max tuple size of about 22, so we break these up into nested
   // blocks to avoid hitting the limit.

--- a/search/src/test/resources/logback-test.xml
+++ b/search/src/test/resources/logback-test.xml
@@ -20,6 +20,6 @@
   <logger name="io.netty" level="OFF"/>
   <logger name="com.amazonaws" level="OFF"/>
   <logger name="software.amazon.awssdk" level="OFF"/>
-  <logger name="akka.actor" level="OFF"/>
+  <logger name="pekko.actor" level="OFF"/>
   <logger name="com.sksamuel.elastic4s" level="OFF"/>
 </configuration>

--- a/search/src/test/resources/logback-test.xml
+++ b/search/src/test/resources/logback-test.xml
@@ -20,6 +20,6 @@
   <logger name="io.netty" level="OFF"/>
   <logger name="com.amazonaws" level="OFF"/>
   <logger name="software.amazon.awssdk" level="OFF"/>
-  <logger name="pekko.actor" level="OFF"/>
+  <logger name="org.apache.pekko.actor" level="OFF"/>
   <logger name="com.sksamuel.elastic4s" level="OFF"/>
 </configuration>

--- a/search/src/test/scala/weco/api/search/ApiSearchTemplatesTest.scala
+++ b/search/src/test/scala/weco/api/search/ApiSearchTemplatesTest.scala
@@ -1,6 +1,6 @@
 package weco.api.search
 
-import akka.http.scaladsl.model.ContentTypes
+import org.apache.pekko.http.scaladsl.model.ContentTypes
 import io.circe.Json
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers

--- a/search/src/test/scala/weco/api/search/ApiTestBase.scala
+++ b/search/src/test/scala/weco/api/search/ApiTestBase.scala
@@ -1,6 +1,6 @@
 package weco.api.search
 
-import akka.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.server.Route
 import org.scalatest.{Assertion, Suite}
 import weco.api.search.fixtures.ApiFixture
 

--- a/search/src/test/scala/weco/api/search/FacetingFeatures.scala
+++ b/search/src/test/scala/weco/api/search/FacetingFeatures.scala
@@ -1,5 +1,5 @@
 package weco.api.search
-import akka.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.model.StatusCodes
 import io.circe.Json
 import org.scalactic.source
 import org.scalatest.{Assertion, GivenWhenThen, Informing, Inspectors}

--- a/search/src/test/scala/weco/api/search/fixtures/ApiFixture.scala
+++ b/search/src/test/scala/weco/api/search/fixtures/ApiFixture.scala
@@ -1,9 +1,9 @@
 package weco.api.search.fixtures
 
-import akka.http.scaladsl.testkit.ScalatestRouteTest
-import akka.http.scaladsl.model.{ContentTypes, StatusCode, Uri}
-import akka.http.scaladsl.model.headers.Host
-import akka.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
+import org.apache.pekko.http.scaladsl.model.{ContentTypes, StatusCode, Uri}
+import org.apache.pekko.http.scaladsl.model.headers.Host
+import org.apache.pekko.http.scaladsl.server.Route
 import com.sksamuel.elastic4s.Index
 import io.circe.parser.parse
 import io.circe.Json
@@ -14,7 +14,7 @@ import weco.api.search.models.{ApiConfig, ElasticConfig}
 
 trait ApiFixture extends ScalatestRouteTest with IndexFixtures {
   this: Suite =>
-  val Status = akka.http.scaladsl.model.StatusCodes
+  val Status = org.apache.pekko.http.scaladsl.model.StatusCodes
 
   val publicRootUri: String
 

--- a/search/src/test/scala/weco/api/search/fixtures/JsonServer.scala
+++ b/search/src/test/scala/weco/api/search/fixtures/JsonServer.scala
@@ -1,6 +1,6 @@
 package weco.api.search.fixtures
 
-import akka.http.scaladsl.model.StatusCode
+import org.apache.pekko.http.scaladsl.model.StatusCode
 import io.circe.Json
 
 trait JsonServer {

--- a/search/src/test/scala/weco/api/search/fixtures/LocalJsonServerFixture.scala
+++ b/search/src/test/scala/weco/api/search/fixtures/LocalJsonServerFixture.scala
@@ -1,7 +1,7 @@
 package weco.api.search.fixtures
 
-import akka.http.scaladsl.model.{ContentTypes, StatusCode}
-import akka.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.model.{ContentTypes, StatusCode}
+import org.apache.pekko.http.scaladsl.server.Route
 import io.circe.Json
 import org.scalatest.TestSuite
 import weco.api.search.ApiTestBase

--- a/search/src/test/scala/weco/api/search/images/ImagesFiltersTest.scala
+++ b/search/src/test/scala/weco/api/search/images/ImagesFiltersTest.scala
@@ -1,6 +1,6 @@
 package weco.api.search.images
 
-import akka.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.server.Route
 import org.scalatest.Assertion
 import org.scalatest.funspec.AnyFunSpec
 import weco.fixtures.TestWith

--- a/search/src/test/scala/weco/api/search/rest/CustomDirectivesTest.scala
+++ b/search/src/test/scala/weco/api/search/rest/CustomDirectivesTest.scala
@@ -1,7 +1,7 @@
 package weco.api.search.rest
 
-import akka.http.scaladsl.model.Uri
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import weco.api.search.models.ApiConfig

--- a/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala
@@ -1,6 +1,6 @@
 package weco.api.search.works
 
-import akka.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.server.Route
 import org.scalatest.Assertion
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.prop.TableDrivenPropertyChecks

--- a/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/Main.scala
+++ b/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/Main.scala
@@ -1,6 +1,6 @@
 package weco.api.snapshot_generator
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import com.typesafe.config.Config
 import software.amazon.awssdk.services.s3.S3Client
 import weco.api.search.config.builders.PipelineElasticClientBuilder

--- a/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/services/SnapshotGeneratorWorkerService.scala
+++ b/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/services/SnapshotGeneratorWorkerService.scala
@@ -1,6 +1,6 @@
 package weco.api.snapshot_generator.services
 
-import akka.Done
+import org.apache.pekko.Done
 import weco.api.snapshot_generator.models.SnapshotJob
 import weco.json.JsonUtil._
 import weco.messaging.MessageSender

--- a/snapshots/snapshot_generator/src/test/resources/logback-test.xml
+++ b/snapshots/snapshot_generator/src/test/resources/logback-test.xml
@@ -20,6 +20,6 @@
   <logger name="io.netty" level="OFF"/>
   <logger name="com.amazonaws" level="OFF"/>
   <logger name="software.amazon.awssdk" level="OFF"/>
-  <logger name="akka.actor" level="OFF"/>
+  <logger name="pekko.actor" level="OFF"/>
   <logger name="com.sksamuel.elastic4s" level="OFF"/>
 </configuration>

--- a/snapshots/snapshot_generator/src/test/resources/logback-test.xml
+++ b/snapshots/snapshot_generator/src/test/resources/logback-test.xml
@@ -20,6 +20,6 @@
   <logger name="io.netty" level="OFF"/>
   <logger name="com.amazonaws" level="OFF"/>
   <logger name="software.amazon.awssdk" level="OFF"/>
-  <logger name="pekko.actor" level="OFF"/>
+  <logger name="org.apache.pekko.actor" level="OFF"/>
   <logger name="com.sksamuel.elastic4s" level="OFF"/>
 </configuration>

--- a/snapshots/snapshot_generator/src/test/scala/weco/api/snapshot_generator/SnapshotGeneratorFeatureTest.scala
+++ b/snapshots/snapshot_generator/src/test/scala/weco/api/snapshot_generator/SnapshotGeneratorFeatureTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.Assertion
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import weco.akka.fixtures.Akka
+import weco.pekko.fixtures.Pekko
 import weco.api.search.fixtures.TestDocumentFixtures
 import weco.api.snapshot_generator.fixtures.{
   SnapshotServiceFixture,
@@ -25,7 +25,7 @@ class SnapshotGeneratorFeatureTest
     extends AnyFunSpec
     with Eventually
     with Matchers
-    with Akka
+    with Pekko
     with S3GzipUtils
     with JsonAssertions
     with IntegrationPatience

--- a/snapshots/snapshot_generator/src/test/scala/weco/api/snapshot_generator/fixtures/WorkerServiceFixture.scala
+++ b/snapshots/snapshot_generator/src/test/scala/weco/api/snapshot_generator/fixtures/WorkerServiceFixture.scala
@@ -1,6 +1,6 @@
 package weco.api.snapshot_generator.fixtures
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import org.scalatest.Suite
 import weco.api.snapshot_generator.services.SnapshotGeneratorWorkerService
 import weco.fixtures.TestWith


### PR DESCRIPTION
## Pull request checklist

https://github.com/wellcomecollection/platform/issues/5754

Migrate from Akka to Pekko. Functionality should stay the same as before. 

See https://github.com/wellcomecollection/scala-libs/pull/246 for more information.