### PR TITLE
lowercase the venue title to create the Map key

### DIFF
--- a/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
+++ b/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
@@ -153,8 +153,8 @@ class SierraItemUpdater(
                 venue.title.toLowerCase() -> venue.openingTimes.map(
                   openingTime =>
                     AvailabilitySlot(openingTime.open, openingTime.close)
-              )
-          )
+            )
+        )
     ) toMap
 
   private def libraryItemAvailabilities(

--- a/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
+++ b/items/src/main/scala/weco/api/items/services/SierraItemUpdater.scala
@@ -150,11 +150,11 @@ class SierraItemUpdater(
           venuesList
             .map(
               venue =>
-                venue.title -> venue.openingTimes.map(
+                venue.title.toLowerCase() -> venue.openingTimes.map(
                   openingTime =>
                     AvailabilitySlot(openingTime.open, openingTime.close)
-            )
-        )
+              )
+          )
     ) toMap
 
   private def libraryItemAvailabilities(

--- a/items/src/test/scala/weco/api/items/fixtures/ItemsApiGenerators.scala
+++ b/items/src/test/scala/weco/api/items/fixtures/ItemsApiGenerators.scala
@@ -103,7 +103,7 @@ trait ItemsApiGenerators extends LocalResources {
               {
                 "type": "Venue",
                 "id": "venue-id",
-                "title": "library",
+                "title": "Library",
                 "nextOpeningDates": [
                   {
                     "open": "2024-04-24T09:00:00.000Z",
@@ -136,7 +136,7 @@ trait ItemsApiGenerators extends LocalResources {
               {
                 "type": "Venue",
                 "id": "venue-id",
-                "title": "library",
+                "title": "Library",
                 "nextOpeningDates": [
                   {
                     "open": "2024-04-24T09:00:00.000Z",


### PR DESCRIPTION
`key not found: library` 500 thrown in staging in the previous commit
Due to content-api returning the venue title as "Library" which is used as the key in a Map where we then look for "library"

Lowercasing the title so the look up find a match
