### PR TITLE
Update API local running

### DIFF
--- a/common/search/src/main/scala/weco/api/search/config/builders/PipelineElasticClientBuilder.scala
+++ b/common/search/src/main/scala/weco/api/search/config/builders/PipelineElasticClientBuilder.scala
@@ -4,7 +4,7 @@ import com.sksamuel.elastic4s.ElasticClient
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest
-import weco.api.search.models.{ApiEnvironment, PipelineClusterElasticConfig}
+import weco.api.search.models.{ApiEnvironment, ElasticConfig}
 import weco.elasticsearch.ElasticClientBuilder
 
 object PipelineElasticClientBuilder {
@@ -19,7 +19,7 @@ object PipelineElasticClientBuilder {
 
   def apply(
     serviceName: String,
-    pipelineDate: String = PipelineClusterElasticConfig.pipelineDate,
+    pipelineDate: String = ElasticConfig.pipelineDate,
     environment: ApiEnvironment = ApiEnvironment.Prod
   ): ElasticClient = {
 

--- a/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
@@ -1,22 +1,28 @@
 package weco.api.search.models
 
 import com.sksamuel.elastic4s.Index
+import grizzled.slf4j.Logging
 
 case class ElasticConfig(
   worksIndex: Index,
   imagesIndex: Index
 )
 
-trait ElasticConfigBase {
+object ElasticConfig {
   // We use this to share config across Scala API applications
   // i.e. The API and the snapshot generator.
   val pipelineDate = "2024-06-06"
 }
 
-object PipelineClusterElasticConfig extends ElasticConfigBase {
-  def apply(): ElasticConfig =
+object PipelineClusterElasticConfig extends Logging {
+  def apply(overrideDate: Option[String] = None): ElasticConfig = {
+    val date = overrideDate.getOrElse(ElasticConfig.pipelineDate)
+
+    info(s"Using pipeline date: $date")
+
     ElasticConfig(
-      worksIndex = Index(s"works-indexed-$pipelineDate"),
-      imagesIndex = Index(s"images-indexed-$pipelineDate")
+      worksIndex = Index(s"works-indexed-$date"),
+      imagesIndex = Index(s"images-indexed-$date")
     )
+  }
 }

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -36,3 +36,9 @@ sbt "project items" ~reStart
 ```
 
 You should then be able to access the API at `http://localhost:8080/works`.
+
+To specify a different pipeline index, you can set the `pipelineDate` environment variable for the search API:
+
+```bash
+pipelineDate=2021-01-01 sbt "project search" ~reStart
+```

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -103,7 +103,7 @@ object ExternalDependencies {
     // See https://github.com/wellcomecollection/scala-libs/blob/main/project/Dependencies.scala
     val pekko = "1.0.3"
     val pekkoHttp = "1.0.1"
-    val aws2 = "2.11.14"
+    val aws2 = "2.25.28"
   }
 
   val circeOpticsDependencies = Seq(
@@ -129,6 +129,10 @@ object ExternalDependencies {
     "software.amazon.awssdk" % "sts" % versions.aws2
   )
 
+  val otherAwsDependencies  = Seq(
+    "software.amazon.awssdk" % "sso" % versions.aws2
+  )
+
   val scalacsvDependencies = Seq(
     "com.github.tototoshi" %% "scala-csv" % versions.scalacsv
   )
@@ -150,7 +154,8 @@ object CatalogueDependencies {
       WellcomeDependencies.httpTypesafeLibrary ++
       ExternalDependencies.pekkoHttpDependencies ++
       ExternalDependencies.scalacsvDependencies ++
-      ExternalDependencies.secretsDependencies
+      ExternalDependencies.secretsDependencies ++
+      ExternalDependencies.otherAwsDependencies
 
   val searchDependencies: Seq[ModuleID] =
     ExternalDependencies.circeOpticsDependencies

--- a/search/src/main/resources/application.conf
+++ b/search/src/main/resources/application.conf
@@ -12,3 +12,5 @@ http.externalBaseURL="http://localhost:8080/"
 http.externalBaseURL=${?app_base_url}
 
 aws.metrics.namespace=${?metrics_namespace}
+
+dev.pipelineDate=${?pipelineDate}

--- a/search/src/main/scala/weco/api/search/Main.scala
+++ b/search/src/main/scala/weco/api/search/Main.scala
@@ -4,16 +4,13 @@ import org.apache.pekko.actor.ActorSystem
 import com.typesafe.config.Config
 import weco.Tracing
 import weco.api.search.config.builders.PipelineElasticClientBuilder
-import weco.api.search.models.{
-  ApiConfig,
-  ApiEnvironment,
-  PipelineClusterElasticConfig
-}
+import weco.api.search.models.{ApiConfig, ApiEnvironment, ElasticConfig, PipelineClusterElasticConfig}
 import weco.typesafe.WellcomeTypesafeApp
 import weco.http.WellcomeHttpApp
 import weco.http.monitoring.HttpMetrics
 import weco.http.typesafe.HTTPServerBuilder
 import weco.monitoring.typesafe.CloudWatchBuilder
+import weco.typesafe.config.builders.EnrichConfig.RichConfig
 
 import scala.concurrent.ExecutionContext
 
@@ -27,21 +24,35 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val apiConfig: ApiConfig = ApiConfig.build(config)
 
-    apiConfig.environment match {
+    val (elasticClient, elasticConfig) =  apiConfig.environment match {
       case ApiEnvironment.Dev =>
         info(s"Running in dev mode.")
+        val pipelineDateOverride = config.getStringOption("dev.pipelineDate")
+        val pipelineDate = pipelineDateOverride.getOrElse(ElasticConfig.pipelineDate)
+        if(pipelineDateOverride.isDefined) warn(s"Overridden pipeline date: $pipelineDate")
+
+        (
+          PipelineElasticClientBuilder(
+            serviceName = "catalogue_api",
+            pipelineDate = pipelineDate,
+            environment = apiConfig.environment
+          ),
+          PipelineClusterElasticConfig(
+            config.getStringOption("dev.pipelineDate")
+          )
+        )
       case _ =>
         info(s"Running in deployed mode (environment=${apiConfig.environment})")
         // Only initialise tracing in deployed environments
         Tracing.init(config)
+        (
+          PipelineElasticClientBuilder(
+            serviceName = "catalogue_api",
+            environment = apiConfig.environment
+          ),
+          PipelineClusterElasticConfig()
+        )
     }
-
-    val elasticClient = PipelineElasticClientBuilder(
-      serviceName = "catalogue_api",
-      environment = apiConfig.environment
-    )
-
-    val elasticConfig = PipelineClusterElasticConfig()
 
     val router = new SearchApi(
       elasticClient = elasticClient,

--- a/search/src/main/scala/weco/api/search/Main.scala
+++ b/search/src/main/scala/weco/api/search/Main.scala
@@ -4,7 +4,12 @@ import org.apache.pekko.actor.ActorSystem
 import com.typesafe.config.Config
 import weco.Tracing
 import weco.api.search.config.builders.PipelineElasticClientBuilder
-import weco.api.search.models.{ApiConfig, ApiEnvironment, ElasticConfig, PipelineClusterElasticConfig}
+import weco.api.search.models.{
+  ApiConfig,
+  ApiEnvironment,
+  ElasticConfig,
+  PipelineClusterElasticConfig
+}
 import weco.typesafe.WellcomeTypesafeApp
 import weco.http.WellcomeHttpApp
 import weco.http.monitoring.HttpMetrics
@@ -24,12 +29,14 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val apiConfig: ApiConfig = ApiConfig.build(config)
 
-    val (elasticClient, elasticConfig) =  apiConfig.environment match {
+    val (elasticClient, elasticConfig) = apiConfig.environment match {
       case ApiEnvironment.Dev =>
         info(s"Running in dev mode.")
         val pipelineDateOverride = config.getStringOption("dev.pipelineDate")
-        val pipelineDate = pipelineDateOverride.getOrElse(ElasticConfig.pipelineDate)
-        if(pipelineDateOverride.isDefined) warn(s"Overridden pipeline date: $pipelineDate")
+        val pipelineDate =
+          pipelineDateOverride.getOrElse(ElasticConfig.pipelineDate)
+        if (pipelineDateOverride.isDefined)
+          warn(s"Overridden pipeline date: $pipelineDate")
 
         (
           PipelineElasticClientBuilder(


### PR DESCRIPTION
## What does this change?

This change updates the search API to enable running locally. This needed doing to accommodate the new SSO method of developer sign-in and includes a small improvement to allow setting of the pipeline date in dev without a code change that might accidentally get committed. 

## How to test

- [ ] Follow the updated docs, can you run the search API locally?

## How can we measure success?

Easier for developers to run the search API locally.

## Have we considered potential risks?

This change updates configuration to re-point the pipeline to a new index in some cases, however it should only work when the dev environment is detected, and has been tested to ensure it falls back to the hard-coded value when no environment variable is specified.