### PR TITLE
Update commands in docs to include needed quotes 

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -31,8 +31,8 @@ You will need to have signed in to the AWS on the CLI to allow the application t
 To run with reloading of code changes using [`sbt-revolver`](https://github.com/spray/sbt-revolver) from the root of the repository:
 
 ```bash
-sbt "project search" ~reStart
-sbt "project items" ~reStart
+sbt "project search" "~reStart"
+sbt "project items" "~reStart"
 ```
 
 You should then be able to access the API at `http://localhost:8080/works`.
@@ -40,5 +40,5 @@ You should then be able to access the API at `http://localhost:8080/works`.
 To specify a different pipeline index, you can set the `pipelineDate` environment variable for the search API:
 
 ```bash
-pipelineDate=2021-01-01 sbt "project search" ~reStart
+pipelineDate=2021-01-01 sbt "project search" "~reStart"
 ```


### PR DESCRIPTION
## What?

This change makes a small docs tweak addressing https://github.com/wellcomecollection/catalogue-api/pull/802#pullrequestreview-2245443569 to add needed quotes to the example commands.

> [!Note]
> The use of `[ci skip]` in the commit should avoid this triggering CI builds.