### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,22 @@
-## Pull request checklist
+## What does this change?
 
-*   Does this patch need a change to the documentation?
+<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. -->
 
-    Do you need to update the [Catalogue API Swagger][swagger]?
+### Checklist
+
+- [ ] Does this patch need a change to the documentation?
+- [ ] Do you need to update the [Catalogue API Swagger][swagger]?
 
 [swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml
+
+## How to test
+
+<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
+
+## How can we measure success?
+
+<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
+
+## Have we considered potential risks?
+
+<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->


### PR DESCRIPTION
## What does this change?

Updates the PR template for catalogue API, which is a bit sparse to match the organisation one, carrying over the checklist from the previous template. 

### Checklist

- [ ] ~Does this patch need a change to the documentation?~
- [ ] ~Do you need to update the [Catalogue API Swagger][swagger]?~

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml

## How to test

- [ ] Read the template, does it makes sense?

## How can we measure success?

Catalogue API PRs receive better PR descriptions and are more useful to developers.

## Have we considered potential risks?

The template here may get out of sync with the org one, but that is fairly low impact and can be easily rectified.