### PR TITLE
Update WorksQuery.json to include shelfmark

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
@@ -11,7 +11,7 @@ case class ElasticConfig(
 object ElasticConfig {
   // We use this to share config across Scala API applications
   // i.e. The API and the snapshot generator.
-  val pipelineDate = "2024-06-06"
+  val pipelineDate = "2024-08-15"
 }
 
 object PipelineClusterElasticConfig extends Logging {

--- a/search/src/main/resources/WorksQuery.json
+++ b/search/src/main/resources/WorksQuery.json
@@ -47,14 +47,24 @@
             "query.identifiers.value",
             "query.items.id",
             "query.items.identifiers.value",
-            "query.items.shelfmark*",
             "query.images.id",
             "query.images.identifiers.value",
-            "query.referenceNumber*",
-            "query.collectionPath*"
+            "query.referenceNumber*"
           ],
           "type": "cross_fields",
           "boost": 100,
+          "operator": "OR",
+          "minimum_should_match": 1
+        }
+      },
+      {
+        "multi_match": {
+          "_name": "ids_with_path_lax",
+          "query": "{{query}}",
+          "analyzer": "lowercase_whitespace_tokens",
+          "fields": ["query.items.shelfmark*", "query.collectionPath*"],
+          "type": "cross_fields",
+          "boost": 50,
           "operator": "OR",
           "minimum_should_match": 1
         }

--- a/search/src/main/resources/WorksQuery.json
+++ b/search/src/main/resources/WorksQuery.json
@@ -47,6 +47,7 @@
             "query.identifiers.value",
             "query.items.id",
             "query.items.identifiers.value",
+            "query.items.shelfmark.value",
             "query.images.id",
             "query.images.identifiers.value",
             "query.referenceNumber*",

--- a/search/src/main/resources/WorksQuery.json
+++ b/search/src/main/resources/WorksQuery.json
@@ -47,7 +47,7 @@
             "query.identifiers.value",
             "query.items.id",
             "query.items.identifiers.value",
-            "query.items.shelfmark.value",
+            "query.items.shelfmark*",
             "query.images.id",
             "query.images.identifiers.value",
             "query.referenceNumber*",
@@ -101,6 +101,7 @@
                   "query.identifiers.value",
                   "query.items.id",
                   "query.items.identifiers.value",
+                  "query.items.shelfmark*",
                   "query.images.id",
                   "query.images.identifiers.value",
                   "query.collectionPath*"


### PR DESCRIPTION
## What does this change?

This change updates search queries to include the shelfmark value added by https://github.com/wellcomecollection/catalogue-pipeline/pull/2693.

We add a new block to the works query:

```
      {
        "multi_match": {
          "_name": "ids_with_path_lax",
          "query": "{{query}}",
          "analyzer": "lowercase_whitespace_tokens",
          "fields": ["query.items.shelfmark*", "query.collectionPath*"],
          "type": "cross_fields",
          "boost": 50,
          "operator": "OR",
          "minimum_should_match": 1
        }
      },
```

Here matches on multipart IDs (shelfmark & collection path) are boosted less than other ID matches because the nature of these identifiers is that small parts of them may collide with valid searches (for example "of", "wa", "sa") pushing matching results for this ID parts above other results in a way that may confuse users. 

This change was revealed by, and tested with `wellcomecollection/rank`: https://github.com/wellcomecollection/rank/pull/111/files

> [!Note]
> This PR changes the way collection paths are searched as they share the same issue as shelf marks described above.

Part of https://github.com/wellcomecollection/catalogue-pipeline/issues/2453

### Checklist

- [ ] ~Does this patch need a change to the documentation?~
- [ ] ~Do you need to update the [Catalogue API Swagger][swagger]?~

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml

## How to test

- [x] Run this locally, pointed at a test pipeline, does it behave as expected?
- [x] Add rank tests to cover some common cases of searching for shelfmarks?
- [x] Do the catalogue-api tests pass?

## How can we measure success?

Collection staff are more easily able to find the works they are looking for.

## Have we considered potential risks?

We should have rank tests to ensure this does not change search query results in unexpected and detrimentatl ways before merging to mititigate risk.