### PR TITLE
upgrade httpx for snapshot_reporter

### DIFF
--- a/snapshots/snapshot_reporter/requirements.txt
+++ b/snapshots/snapshot_reporter/requirements.txt
@@ -20,7 +20,7 @@ h11==0.11.0
     # via httpcore
 httpcore==0.12.0
     # via httpx
-httpx==0.16.0
+httpx==0.27.2
     # via -r requirements.in
 humanize==3.0.1
     # via -r requirements.in


### PR DESCRIPTION
## What does this change?

Part of https://github.com/wellcomecollection/platform/issues/5796
https://github.com/wellcomecollection/catalogue-api/security/dependabot/43

This upgrades httpx to the latest version

### Checklist

- [ ] Does this patch need a change to the documentation?
- [ ] Do you need to update the [Catalogue API Swagger][swagger]?

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml

## How to test

There are no tests 😢 
Wait until the morning to see the report in [#wc-search-alerts](https://wellcome.slack.com/archives/C016NQB58N4)?

## How can we measure success?

One fewer critical vulnerability in the catalogue-api
Reports are posted in [#wc-search-alerts](https://wellcome.slack.com/archives/C016NQB58N4) in the morning ☕ 

## Have we considered potential risks?

This is just the part of the `snapshots` that posts the reports so not very risky, in the grand scheme of things
