### PR TITLE
upgrade httpx for diff_tool, httpcore and h11 to match

### DIFF
--- a/diff_tool/requirements.txt
+++ b/diff_tool/requirements.txt
@@ -14,11 +14,11 @@ charset-normalizer==2.0.12
     # via httpx
 click==8.1.2
     # via -r requirements.in
-h11==0.12.0
+h11==0.14
     # via httpcore
-httpcore==0.14.7
+httpcore==1.0.6
     # via httpx
-httpx==0.22.0
+httpx==0.27.2
     # via -r requirements.in
 humanize==4.0.0
     # via -r requirements.in


### PR DESCRIPTION
## What does this change?

Part of https://github.com/wellcomecollection/platform/issues/5796
https://github.com/wellcomecollection/catalogue-api/security/dependabot/12

This upgrades httpx + httpcore and h11 because of deps version conflicts
Diff tool ran locally successfully

### Checklist

- [ ] Does this patch need a change to the documentation?
- [ ] Do you need to update the [Catalogue API Swagger][swagger]?

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml

## How to test

Follow the instructions in catalogue-api/diff_tool/README.md
Run `./diff_tool.py --console` so as to see the output 

## How can we measure success?

One fewer critical vulnerability in the catalogue-api

## Have we considered potential risks?

If this happens to fail in the CI pipeline, it could block deployments of the catalogue-api
