### PR TITLE
needs higher version of python

### DIFF
--- a/diff_tool/Dockerfile
+++ b/diff_tool/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.7-alpine
+FROM public.ecr.aws/docker/library/python:3.12-alpine
 
 LABEL maintainer = "Wellcome Collection <dev@wellcomecollection.org>"
 LABEL description = "A Docker image for deploying our Docker images to AWS"


### PR DESCRIPTION
## What does this change?

Following [this](https://github.com/wellcomecollection/catalogue-api/pull/822) `pip install -r requirements.txt` is failing in CI because the new version of the packages are not compatible with python3.7
Tested it locally with python3.12 and it seems to fix the problem 

### Checklist

- [ ] Does this patch need a change to the documentation?
- [ ] Do you need to update the [Catalogue API Swagger][swagger]?

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml

## How to test

Follow the instructions in catalogue-api/diff_tool/README.md but make sure you're using python3.12
Run ./diff_tool.py --console so as to see the output

## How can we measure success?

diff_tools can run in CI

## Have we considered potential risks?

Might not work out 
