### PR TITLE
resolve dependency conflicts

### DIFF
--- a/snapshots/snapshot_reporter/requirements.txt
+++ b/snapshots/snapshot_reporter/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile
 #
-boto3==1.26.64
+boto3==1.28.16
     # via -r requirements.in
-botocore==1.29.64
+botocore==1.31.16
     # via
     #   boto3
     #   s3transfer
@@ -14,11 +14,11 @@ certifi==2020.6.20
     # via
     #   elasticsearch
     #   httpx
-elasticsearch==7.9.1
+elasticsearch==8.10.0
     # via -r requirements.in
-h11==0.11.0
+h11==0.14
     # via httpcore
-httpcore==0.12.0
+httpcore==1.0.6
     # via httpx
 httpx==0.27.2
     # via -r requirements.in
@@ -30,7 +30,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   -r requirements.in
     #   botocore
@@ -46,7 +46,7 @@ sniffio==1.1.0
     # via
     #   httpcore
     #   httpx
-urllib3==1.25.10
+urllib3==1.26.2
     # via
     #   botocore
     #   elasticsearch


### PR DESCRIPTION
## What does this change?

Following [this](https://github.com/wellcomecollection/catalogue-api/pull/821) 
I must have forgotten to run pip3 install because when I went to do it before zipping the deployment package, there was a bunch of conflicts 🙈 
The old version (without [this](https://github.com/wellcomecollection/catalogue-api/pull/821)) is still up because this gets deployed manually so no harm done

### Checklist

- [ ] Does this patch need a change to the documentation?
- [ ] Do you need to update the [Catalogue API Swagger][swagger]?

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml

## How to test

Run `pip3 install -r requirements.txt` in `catalogue-api/snapshots/snapshot_reporter` there should be no conflicts

## How can we measure success?

snapshot_reporter can be packages with its dependencies

## Have we considered potential risks?

Same as [this](https://github.com/wellcomecollection/catalogue-api/pull/821) 
