### PR TITLE
Update dependency workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - rk/test-dep-updates
 
 permissions:
   id-token: write
@@ -16,8 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v4
+      - name: Setup JDK
+        uses: actions/setup-java@v4
         with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ secrets.S3_SCALA_RELEASES_READ_ROLE_ARN }}
+          distribution: temurin
+          java-version: 17
+          cache: sbt
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1.1.0
       - uses: scalacenter/sbt-dependency-submission@v2


### PR DESCRIPTION
## What does this change?

Noticed while working on https://github.com/wellcomecollection/catalogue-api/pull/837

This change fixes the update dependency graph workflow used to push scala deps to dependabot for analysis.

Currently this error happens:
<img width="1506" alt="Screenshot 2025-01-16 at 11 26 49" src="https://github.com/user-attachments/assets/b89c0632-2f84-499d-8ea8-7a15b04f6bcd" />

## How to test

- [ ] Run the workflow on this branch, does it succeed?

## How can we measure success?

We continue to monitor dependencies.

## Have we considered potential risks?

This should not impact anything other than the dependency update workflow.