### PR TITLE
Increase resources for works search api service

### DIFF
--- a/terraform/modules/stack/services.tf
+++ b/terraform/modules/stack/services.tf
@@ -36,8 +36,8 @@ module "search_api" {
     metrics_namespace = "search-api"
   }
 
-  app_cpu    = var.environment_name == "prod" ? 512 : 256
-  app_memory = var.environment_name == "prod" ? 1024 : 512
+  app_cpu    = var.environment_name == "prod" ? 1024 : 512
+  app_memory = var.environment_name == "prod" ? 2048 : 1024
 
   secrets = var.apm_secret_config
 


### PR DESCRIPTION
## What does this change?

>[!Note]
> This terraform change is applied.

Following some testing with https://github.com/wellcomecollection/catalogue-api/pull/832, it appears that the works search service is under-resourced. It's likely we were "right-sized" up to the edge of what was feasible and this change has tipped us over edge handling larger vectors for image search. 

This change increases the resources for the stage & prod works service to accommodate the higher resource requirements.

## How to test

- [ ] Deploy this change, does stage deploy successfully?

## How can we measure success?

Successful deployments in stage & prod.

## Have we considered potential risks?

This should deploy seamlessly in prod due to healthchecks and blue/green deployment. It will increase costs slightly!