### PR TITLE
Fix labelled ID aggregations bug

### DIFF
--- a/search/src/main/scala/weco/api/search/models/Aggregation.scala
+++ b/search/src/main/scala/weco/api/search/models/Aggregation.scala
@@ -117,13 +117,18 @@ object AggregationMapping {
   }
 
   def aggregationParser(
-    jsonString: String
+    jsonString: String,
+    globalJsonString: String
   ): Try[Aggregation] = {
+    val unfilteredIdLabelMap = parse(globalJsonString).map {
+      json =>
+        getUnfilteredIdLabelMap(json)
+    }.getOrElse(Map())
+
     parse(jsonString)
       .map { json =>
         val nestedBuckets =
           parseNestedAggregationBuckets(getAllFilteredBuckets(json))
-        val unfilteredIdLabelMap = getUnfilteredIdLabelMap(json)
 
         val nestedBucketsWithUpdatedLabels = nestedBuckets.map { bucket =>
           val id = bucket.data.id

--- a/search/src/main/scala/weco/api/search/models/Aggregation.scala
+++ b/search/src/main/scala/weco/api/search/models/Aggregation.scala
@@ -7,8 +7,10 @@ import io.circe.optics.JsonPath._
 
 import scala.util.{Try}
 
-// Each aggregated field returns aggregation buckets in the following nested format (the two 'nestedSelf' sets of buckets
-// are only included for aggregations with a paired filter):
+// Each aggregated field is associated with two aggregations - a 'filtered' aggregation and a 'global' aggregation.
+//
+// The 'filtered' aggregation has the following structure (the 'nestedSelf' bucket
+// is only included for aggregations with a paired filter):
 //{
 //  "filtered": {
 //    "nested": {
@@ -21,7 +23,11 @@ import scala.util.{Try}
 //        "buckets": [...]
 //      }
 //    }
-//  },
+//  }
+//}
+//
+// The 'global' aggregation has the following structure:
+//{
 //  "nestedSelf": {
 //    "terms": {
 //      "buckets": [...]
@@ -117,7 +123,7 @@ object AggregationMapping {
   }
 
   def aggregationParser(
-    jsonString: String,
+    filteredJsonString: String,
     globalJsonString: String
   ): Try[Aggregation] = {
     val unfilteredIdLabelMap = parse(globalJsonString)
@@ -126,7 +132,7 @@ object AggregationMapping {
       }
       .getOrElse(Map())
 
-    parse(jsonString)
+    parse(filteredJsonString)
       .map { json =>
         val nestedBuckets =
           parseNestedAggregationBuckets(getAllFilteredBuckets(json))

--- a/search/src/main/scala/weco/api/search/models/Aggregation.scala
+++ b/search/src/main/scala/weco/api/search/models/Aggregation.scala
@@ -120,10 +120,11 @@ object AggregationMapping {
     jsonString: String,
     globalJsonString: String
   ): Try[Aggregation] = {
-    val unfilteredIdLabelMap = parse(globalJsonString).map {
-      json =>
+    val unfilteredIdLabelMap = parse(globalJsonString)
+      .map { json =>
         getUnfilteredIdLabelMap(json)
-    }.getOrElse(Map())
+      }
+      .getOrElse(Map())
 
     parse(jsonString)
       .map { json =>

--- a/search/src/main/scala/weco/api/search/models/ElasticAggregations.scala
+++ b/search/src/main/scala/weco/api/search/models/ElasticAggregations.scala
@@ -14,12 +14,12 @@ trait ElasticAggregations extends Logging {
   implicit class EnhancedEsAggregations(aggregations: Elastic4sAggregations) {
     def decodeAgg(name: String): Option[Aggregation] =
       for {
-        aggJson1 <- aggregations.getAgg(name)
-        aggJson2 <- aggregations.getAgg(name + "Global")
-        parsedAggregation <- aggJson1
-          .safeTo[Aggregation] { json =>
-            aggJson2.safeTo[Aggregation] { json2 =>
-              AggregationMapping.aggregationParser(json, json2)
+        filteredAggregation <- aggregations.getAgg(name)
+        globalAggregation <- aggregations.getAgg(name + "Global")
+        parsedAggregation <- filteredAggregation
+          .safeTo[Aggregation] { filteredJson =>
+            globalAggregation.safeTo[Aggregation] { globalJson =>
+              AggregationMapping.aggregationParser(filteredJson, globalJson)
             }
           }
           .toOption

--- a/search/src/main/scala/weco/api/search/models/ElasticAggregations.scala
+++ b/search/src/main/scala/weco/api/search/models/ElasticAggregations.scala
@@ -12,10 +12,10 @@ trait ElasticAggregations extends Logging {
   }
 
   implicit class EnhancedEsAggregations(aggregations: Elastic4sAggregations) {
-    def decodeAgg(name: String): Option[Aggregation] = {
+    def decodeAgg(name: String): Option[Aggregation] =
       for {
         aggJson1 <- aggregations.getAgg(name)
-        aggJson2 <-  aggregations.getAgg(name + "Global")
+        aggJson2 <- aggregations.getAgg(name + "Global")
         parsedAggregation <- aggJson1
           .safeTo[Aggregation] { json =>
             aggJson2.safeTo[Aggregation] { json2 =>
@@ -24,6 +24,5 @@ trait ElasticAggregations extends Logging {
           }
           .toOption
       } yield parsedAggregation
-    }
   }
 }

--- a/search/src/main/scala/weco/api/search/services/AggregationsBuilder.scala
+++ b/search/src/main/scala/weco/api/search/services/AggregationsBuilder.scala
@@ -33,7 +33,10 @@ case class AggregationParams(
   *    - 'filtered': A filter aggregation which applies all filters, *except for* filters paired to the aggregated field itself (see rule 5 in RFC 37).
   *        - 'nested': A nested aggregation which contains a 'labelled ID' sub-aggregation, or a 'label-only' sub-aggregation (see below for more info).
   *        - 'nestedSelf': Only included if a paired filter exists. Same as 'nested', but with a `includeExactValues` property set to the filtered values defined in the paired filter. This ensures that aggregation buckets corresponding to filtered values are always returned, even if they are not in the top N buckets returned by 'nested' (see rule 6 in RFC 37).
-  *    - 'nestedSelf': Same as the other (filtered) 'nestedSelf' but with no filters applied. Only included to cover the special case of a 'labelled ID' aggregation bucket returning an item count of 0 , in which case the 'nestedSelf' aggregation is not able to determine the label matching the corresponding ID (see rule 6 in RFC 37).
+  *
+  * To handle edge cases where a search with an applied filter returns 0 results, each aggregation also has an accompanying global aggregation:
+  *  - '[some.field.path]Global': A global aggregation which ignores the query and all filters
+  *    - 'nestedSelf': Same as the other (filtered) 'nestedSelf' but with no query/filters applied. Only included to cover the special case of a 'labelled ID' aggregation bucket returning an item count of 0, in which case the 'nestedSelf' aggregation is not able to determine the label matching the corresponding ID (see rule 6 in RFC 37).
   */
 trait AggregationsBuilder[AggregationRequest, Filter] {
   def pairedAggregationRequests(

--- a/search/src/main/scala/weco/api/search/services/AggregationsBuilder.scala
+++ b/search/src/main/scala/weco/api/search/services/AggregationsBuilder.scala
@@ -1,7 +1,14 @@
 package weco.api.search.services
 
 import com.sksamuel.elastic4s.ElasticApi.{boolQuery, matchAllQuery, termsAgg}
-import com.sksamuel.elastic4s.requests.searches.aggs.{Aggregation, FilterAggregation, GlobalAggregation, NestedAggregation, TermsAggregation, TermsOrder}
+import com.sksamuel.elastic4s.requests.searches.aggs.{
+  Aggregation,
+  FilterAggregation,
+  GlobalAggregation,
+  NestedAggregation,
+  TermsAggregation,
+  TermsOrder
+}
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.requests.searches.term.TermsQuery
 import weco.api.search.models.Pairable
@@ -98,7 +105,7 @@ trait AggregationsBuilder[AggregationRequest, Filter] {
         subaggs = Seq(Some(filterAggregation)).flatten
       ),
       GlobalAggregation(
-        name = params.name  + "Global",
+        name = params.name + "Global",
         subaggs = Seq(selfAggregation).flatten
       )
     )

--- a/search/src/test/scala/weco/api/search/models/AggregationResultsTest.scala
+++ b/search/src/test/scala/weco/api/search/models/AggregationResultsTest.scala
@@ -59,7 +59,8 @@ class AggregationResultsTest extends AnyFunSpec with Matchers {
               )
             )
           )
-        )
+        ),
+        "formatGlobal" -> Map("global" -> Map())
       )
     )
 
@@ -119,7 +120,9 @@ class AggregationResultsTest extends AnyFunSpec with Matchers {
               )
             )
           )
-        )
+        ),
+        "formatGlobal" -> Map("global" -> Map())
+
       )
     )
     val singleAgg = WorkAggregations(searchResponse)
@@ -187,7 +190,8 @@ class AggregationResultsTest extends AnyFunSpec with Matchers {
               )
             )
           )
-        )
+        ),
+        "formatGlobal" -> Map("global" -> Map())
       )
     )
     val singleAgg = WorkAggregations(searchResponse)

--- a/search/src/test/scala/weco/api/search/models/AggregationResultsTest.scala
+++ b/search/src/test/scala/weco/api/search/models/AggregationResultsTest.scala
@@ -122,7 +122,6 @@ class AggregationResultsTest extends AnyFunSpec with Matchers {
           )
         ),
         "formatGlobal" -> Map("global" -> Map())
-
       )
     )
     val singleAgg = WorkAggregations(searchResponse)
@@ -210,4 +209,78 @@ class AggregationResultsTest extends AnyFunSpec with Matchers {
       )
     )
   }
+
+  it(
+    "correctly populates AggregationBucketData with IDs and labels, even if the filtered aggregation results 0 results"
+  ) {
+    val searchResponse = SearchResponse(
+      took = 1234,
+      isTimedOut = false,
+      isTerminatedEarly = false,
+      suggest = Map(),
+      _shards = Shards(total = 1, failed = 0, successful = 1),
+      scrollId = None,
+      hits = SearchHits(
+        total = Total(0, "potatoes"),
+        maxScore = 0.0,
+        hits = Array()
+      ),
+      _aggregationsAsMap = Map(
+        "format" -> Map(
+          "doc_count" -> 0,
+          "filtered" -> Map(
+            "nested" -> Map(
+              "terms" -> Map(
+                "doc_count_error_upper_bound" -> 0,
+                "sum_other_doc_count" -> 0,
+                "buckets" -> List(
+                  Map(
+                    "key" -> "123",
+                    "doc_count" -> 0,
+                    "labels" -> Map(
+                      "buckets" -> List()
+                    )
+                  )
+                )
+              )
+            )
+          )
+        ),
+        "formatGlobal" -> Map(
+          "nestedSelf" -> Map(
+            "terms" -> Map(
+              "doc_count_error_upper_bound" -> 0,
+              "sum_other_doc_count" -> 0,
+              "buckets" -> List(
+                Map(
+                  "key" -> "123",
+                  "doc_count" -> 393145,
+                  "labels" -> Map(
+                    "buckets" -> List(
+                      Map(
+                        "key" -> "absinthe",
+                        "doc_count" -> 393145
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    val singleAgg = WorkAggregations(searchResponse)
+    singleAgg.get.format shouldBe Some(
+      Aggregation(
+        buckets = List(
+          AggregationBucket(
+            AggregationBucketData("123", "absinthe"),
+            count = 0
+          )
+        )
+      )
+    )
+  }
+
 }

--- a/search/src/test/scala/weco/api/search/services/AggregationsBuilderTest.scala
+++ b/search/src/test/scala/weco/api/search/services/AggregationsBuilderTest.scala
@@ -1,7 +1,7 @@
 package weco.api.search.services
 
 import com.sksamuel.elastic4s.ElasticDsl.termsQuery
-import com.sksamuel.elastic4s.requests.searches.aggs.{FilterAggregation, NestedAggregation, TermsAggregation}
+import com.sksamuel.elastic4s.requests.searches.aggs.{Aggregation, FilterAggregation, NestedAggregation, TermsAggregation}
 import com.sksamuel.elastic4s.requests.searches.queries.compound.BoolQuery
 import org.scalatest.{Inside, LoneElement}
 import org.scalatest.funspec.AnyFunSpec
@@ -36,27 +36,33 @@ class AggregationsBuilderTest
   )
 
   // See AggregationsBuilder class for an explanation of why aggregations are structured this way
-  private def decomposeRootAggregation(rootAggregation: FilterAggregation): DecomposedAggregation = {
+  private def decomposeRootAggregation(rootAggregation: Aggregation, rootGlobalAggregation: Aggregation): DecomposedAggregation = {
     val filteredAggregation = rootAggregation.subaggs.head.asInstanceOf[FilterAggregation]
+
     val filteredNestedAggregation = filteredAggregation.subaggs.head.asInstanceOf[NestedAggregation]
     val filteredNestedSelfAggregation = filteredAggregation.subaggs.lift(1).map(_.asInstanceOf[NestedAggregation])
-    val unfilteredNestedSelfAggregation = rootAggregation.subaggs.lift(1).map(_.asInstanceOf[NestedAggregation])
+    val unfilteredNestedSelfAggregation = rootGlobalAggregation.subaggs
+      .lift(1)
+      .map(_.asInstanceOf[NestedAggregation])
 
     val filteredTermsAggregation = filteredNestedAggregation.subaggs.head.asInstanceOf[TermsAggregation]
-    val filteredTermsSelfAggregation = filteredNestedSelfAggregation.map(_.subaggs.head.asInstanceOf[TermsAggregation])
-    val unfilteredTermsSelfAggregation = unfilteredNestedSelfAggregation.map(_.subaggs.head.asInstanceOf[TermsAggregation])
+    val filteredTermsSelfAggregation = filteredNestedSelfAggregation.map(
+      _.subaggs.head.asInstanceOf[TermsAggregation]
+    )
+    val unfilteredTermsSelfAggregation = unfilteredNestedSelfAggregation.map(
+      _.subaggs.head.asInstanceOf[TermsAggregation]
+    )
 
     DecomposedAggregation(
-      filtered=filteredAggregation,
-      filteredNested=filteredNestedAggregation,
-      filteredNestedSelf=filteredNestedSelfAggregation,
+      filtered = filteredAggregation,
+      filteredNested = filteredNestedAggregation,
+      filteredNestedSelf = filteredNestedSelfAggregation,
       unfilteredNestedSelf = unfilteredNestedSelfAggregation,
       filteredTerms = filteredTermsAggregation,
       filteredSelfTerms = filteredTermsSelfAggregation,
       unfilteredSelfTerms = unfilteredTermsSelfAggregation
     )
   }
-
 
   describe("aggregation-level filtering") {
     it("applies to aggregations with a paired filter") {
@@ -68,39 +74,40 @@ class AggregationsBuilderTest
         List(WorkAggregationRequest.Format, WorkAggregationRequest.Languages)
       )
 
-      aggregations should have length 2
+      aggregations should have length 4
 
-      val firstAggregation = decomposeRootAggregation(aggregations.head)
+      val firstAggregation = decomposeRootAggregation(aggregations.head, aggregations(1))
 
       // The first aggregation is the Format one, filtered with the languages filter.
       firstAggregation.filtered should have(
-        filters(Seq(languagesFilterQuery)),
+        filters(Seq(languagesFilterQuery))
       )
       firstAggregation.filteredTerms should have(
-        aggregationField(s"${formatFieldName}.id")
+        aggregationField(s"$formatFieldName.id")
       )
 
       inside(firstAggregation.filteredSelfTerms.get) {
         case selfFilter: TermsAggregation =>
           selfFilter should have(
-            aggregationField(s"${formatFieldName}.id")
+            aggregationField(s"$formatFieldName.id")
           )
       }
 
-      val secondAggregation = decomposeRootAggregation(aggregations(1))
+      val secondAggregation = decomposeRootAggregation(aggregations(2), aggregations(3))
 
       // The second aggregation is the Languages one, filtered with the format filter.
       secondAggregation.filtered should have(
-        filters(Seq(formatFilterQuery)),
+        filters(Seq(formatFilterQuery))
       )
       secondAggregation.filteredTerms should have(
-        aggregationField(s"${languagesFieldName}.id")
+        aggregationField(s"$languagesFieldName.id")
       )
 
-      inside(secondAggregation.filteredSelfTerms.get) { case selfFilter: TermsAggregation =>
-        selfFilter should have(
-          aggregationField(s"${languagesFieldName}.id")
-        )
+      inside(secondAggregation.filteredSelfTerms.get) {
+        case selfFilter: TermsAggregation =>
+          selfFilter should have(
+            aggregationField(s"$languagesFieldName.id")
+          )
       }
     }
 
@@ -112,15 +119,17 @@ class AggregationsBuilderTest
         List(WorkAggregationRequest.Format)
       )
 
+      aggregations should have length 2
+
       // The aggregation list is just the requested aggregation
       // filtered by the requested (unpaired) filter.
-      val filterAggregation = decomposeRootAggregation(aggregations.loneElement)
+      val filterAggregation = decomposeRootAggregation(aggregations.head, aggregations(1))
 
       // This marks the absence of the "self" aggregation
       filterAggregation.filteredNestedSelf shouldBe None
       filterAggregation.unfilteredNestedSelf shouldBe None
 
-      filterAggregation.filteredTerms.field.get shouldBe s"${formatFieldName}.id"
+      filterAggregation.filteredTerms.field.get shouldBe s"$formatFieldName.id"
     }
 
     it("includes a label-based subaggregation") {
@@ -131,19 +140,22 @@ class AggregationsBuilderTest
         List(WorkAggregationRequest.Format)
       )
 
+      aggregations should have length 2
+
       // The aggregation list is just the requested aggregation
       // filtered by the requested (unpaired) filter.
-      val filterAggregation = decomposeRootAggregation(aggregations.loneElement)
+      val filterAggregation = decomposeRootAggregation(aggregations.head, aggregations(1))
 
       filterAggregation.filteredNestedSelf shouldBe None
       filterAggregation.unfilteredNestedSelf shouldBe None
 
-      val labelSubaggregation = filterAggregation.filteredTerms.subaggs.loneElement.asInstanceOf[TermsAggregation]
+      val labelSubaggregation =
+        filterAggregation.filteredTerms.subaggs.head
+          .asInstanceOf[TermsAggregation]
 
-      labelSubaggregation.field.get shouldBe s"${formatFieldName}.label"
+      labelSubaggregation.field.get shouldBe s"$formatFieldName.label"
       labelSubaggregation.size shouldBe Some(1)
     }
-
 
     it("applies paired filters to non-paired aggregations") {
       val formatFilter = FormatFilter(Seq("bananas"))
@@ -153,20 +165,21 @@ class AggregationsBuilderTest
         List(WorkAggregationRequest.Format, WorkAggregationRequest.Languages)
       )
 
-      aggregations should have length 2
+      aggregations should have length 4
+
       //The first aggregation is Format, which has a "self" subaggregation.
       // The details of the content of this aggregation are examined
       // in the "applies to aggregations with a paired filter" test.
-      val firstAggregation = decomposeRootAggregation(aggregations.head)
+      val firstAggregation = decomposeRootAggregation(aggregations.head, aggregations(1))
       firstAggregation.filtered.subaggs should have length 2
 
       firstAggregation.filteredTerms should have(
-        aggregationField(s"${formatFieldName}.id")
+        aggregationField(s"$formatFieldName.id")
       )
 
       //The second aggregation is Language, which has no corresponding
       // filter in this query, so does not have a "self" subaggregation
-      val secondAggregation = decomposeRootAggregation(aggregations(1))
+      val secondAggregation = decomposeRootAggregation(aggregations(2), aggregations(3))
       secondAggregation.filtered.subaggs should have length 1
 
       // But it should still be filtered using the format filter
@@ -175,7 +188,7 @@ class AggregationsBuilderTest
       )
 
       secondAggregation.filteredTerms should have(
-        aggregationField(s"${languagesFieldName}.id")
+        aggregationField(s"$languagesFieldName.id")
       )
     }
 
@@ -194,20 +207,13 @@ class AggregationsBuilderTest
         )
       )
 
-      aggregations should have length 3
+      aggregations should have length 6
 
-      forAll(
-        Table(
-          ("agg", "matchingFilter"),
-          // The aggregations and the filter list are expected to be
-          // in the same order, so zipping them should result in
-          // each aggregation being paired with its corresponding filter
-          aggregations.zip(
-            filters
-          ): _*
-        )
-      ) { (agg: FilterAggregation, thisFilter: WorkFilter) =>
-        val filteredAggregation = decomposeRootAggregation(agg).filtered
+      // The aggregations and the filter list are expected to be
+      // in the same order, so zipping them should result in
+      // each aggregation being paired with its corresponding filter
+      filters.zipWithIndex.foreach {case (thisFilter: WorkFilter, i: Int) => {
+        val filteredAggregation = decomposeRootAggregation(aggregations(2*i), aggregations(2*i+1)).filtered
         val filterQuery = filteredAggregation.query.asInstanceOf[BoolQuery]
 
         //Three filters are requested, each aggregation should
@@ -215,8 +221,9 @@ class AggregationsBuilderTest
         filterQuery.filters should have length 2
         // And this ensures that it is the correct two.
         filterQuery.filters should contain theSameElementsAs filters
-          .filterNot(_ == thisFilter).map(buildWorkFilterQuery)
-      }
+          .filterNot(_ == thisFilter)
+          .map(buildWorkFilterQuery)
+      }}
     }
   }
 }

--- a/search/src/test/scala/weco/api/search/services/AggregationsTest.scala
+++ b/search/src/test/scala/weco/api/search/services/AggregationsTest.scala
@@ -204,7 +204,6 @@ class AggregationsTest
             SubjectLabelFilter(Seq("fIbfVPkqaf"))
           )
         )
-        println(searchOptions.aggregations)
         whenReady(aggregationQuery(index, searchOptions)) { aggs =>
           val buckets = aggs.format.get.buckets
 


### PR DESCRIPTION
## What does this change?

Fixes a bug which causes a 'labelled id' filter to display an id instead of a label in the frontend. See [this thread](https://wellcome.slack.com/archives/C3TQSF63C/p1737477925864379) for more info.

This bug occurs when a query returning 0 results is combined with an active 'labelled id' filter (such as the languages filter or the format filter). Under these circumstances, the unfiltered `selfNested` aggregation works with 0 results and therefore cannot return label buckets for the active filter(s). 

The fix involves moving the unfiltered `selfNested` aggregation into a separate global aggregation to ignore the query and therefore always correctly return the label(s) for the filtered id(s). 

### Checklist

- [ ] Does this patch need a change to the documentation?
- [ ] Do you need to update the [Catalogue API Swagger][swagger]?

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml

## How to test

This can be tested by locally running the frontend and the catalogue-api and configuring the frontend to connect to the local catalogue-api. 

Additionally, a few new automated tests were added to cover the case of a query returning 0 results while a filter is applied to prevent regressions.

## How can we measure success?

Active filters should always surface the filter's label to the user instead of its id, regardless of how many results are returned or which other filters are active. 

## Have we considered potential risks?

With this fix, the number of aggregations and subaggregations remains the same but one of the subaggregations is moved into its own global aggregation, which might have performance implications. However, I have not observed noticeably slower response times in my testing.