### PR TITLE
Update ports and config to use local nginx for dev

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/ApiConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ApiConfig.scala
@@ -12,9 +12,9 @@ case class ApiConfig(
 ) {
   // Used to determine whether we're running in a dev environment
   def environment: ApiEnvironment = publicHost match {
-    case "localhost"                       => ApiEnvironment.Dev
-    case _ if publicHost.contains("stage") => ApiEnvironment.Stage
-    case _                                 => ApiEnvironment.Prod
+    case _ if publicHost.contains("api-dev")   => ApiEnvironment.Dev
+    case _ if publicHost.contains("api-stage") => ApiEnvironment.Stage
+    case _                                     => ApiEnvironment.Prod
   }
 }
 

--- a/common/search/src/test/scala/weco/api/search/models/ApiConfigTest.scala
+++ b/common/search/src/test/scala/weco/api/search/models/ApiConfigTest.scala
@@ -39,7 +39,7 @@ class ApiConfigTest extends AnyFunSpec with Matchers with Inside {
   }
 
   it("correctly identifies a dev environment") {
-    val publicRoot = "https://localhost:8080/catalogue/v2"
+    val publicRoot = "https://api-dev.wellcomecollection.org/catalogue/v2"
     inside(
       ApiConfig(
         publicRootUri = Uri(publicRoot),
@@ -48,7 +48,7 @@ class ApiConfigTest extends AnyFunSpec with Matchers with Inside {
     ) {
       case apiConfig@ApiConfig(publicScheme, publicHost, publicRootPath, _) =>
         publicScheme shouldBe "https"
-        publicHost shouldBe "localhost"
+        publicHost shouldBe "api-dev.wellcomecollection.org"
         publicRootPath shouldBe "/catalogue/v2"
         apiConfig.environment shouldBe ApiEnvironment.Dev
     }

--- a/concepts/package.json
+++ b/concepts/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "start": "NODE_ENV=production ts-node-transpile-only ./server.ts",
-    "dev": "NODE_ENV=development nodemon ./server.ts",
+    "dev": "AWS_PROFILE=catalogue-developer PORT=3001 NODE_ENV=development nodemon ./server.ts",
     "test": "jest"
   },
   "dependencies": {

--- a/items/src/main/resources/application.conf
+++ b/items/src/main/resources/application.conf
@@ -14,9 +14,9 @@ content.api.publicRoot="https://api.wellcomecollection.org/content/v0"
 content.api.publicRoot=${?content_api_public_root}
 
 http.host="0.0.0.0"
-http.port=8080
+http.port=8081
 http.port=${?app_port}
-http.externalBaseURL="http://localhost:8080/"
+http.externalBaseURL="http://localhost:8081/"
 http.externalBaseURL=${?app_base_url}
 
 aws.metrics.namespace=${?metrics_namespace}

--- a/search/src/main/resources/application.conf
+++ b/search/src/main/resources/application.conf
@@ -1,4 +1,4 @@
-api.public-root="http://localhost"
+api.public-root="https://api-dev.wellcomecollection.org/catalogue/v2"
 api.public-root=${?api_public_root}
 apm.server.url=${?apm_server_url}
 apm.secret=${?apm_secret}


### PR DESCRIPTION
## What does this change?

Part of https://github.com/wellcomecollection/wellcomecollection.org/pull/11551

This change updates the ports that concepts and items APIs use when run locally in order that they can run at the same time locally to enable a more complete local development experience when working with https://github.com/wellcomecollection/wellcomecollection.org

## How to test

- In the root of the repository run:
  - `sbt "project search" "~reStart"`: Starts the Search API
  - `sbt "project items" "~reStart"`: Starts the Items API
- In `./concepts` run `yarn && yarn dev`: Starts the Concepts API 

Concepts should be available on `localhost:3001` search on `localhost:8080` and items at `localhost:8081`.

This change can be more thoroughly tested by reviewing https://github.com/wellcomecollection/wellcomecollection.org/pull/11551 and following the relevant steps described running this branch.

## How can we measure success?

Easier development!

## Have we considered potential risks?

This change includes changing some base config, that if not overridden may have impact when deployed. This configuration (public-root) is overridden when deployed mitigating risk.