### PR TITLE
Switch API (including concepts) to new index, run works snapshot locally

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
@@ -11,7 +11,7 @@ case class ElasticConfig(
 object ElasticConfig {
   // We use this to share config across Scala API applications
   // i.e. The API and the snapshot generator.
-  val pipelineDate = "2024-11-18"
+  val pipelineDate = "2025-03-06"
 }
 
 object PipelineClusterElasticConfig extends Logging {

--- a/concepts/config.ts
+++ b/concepts/config.ts
@@ -10,8 +10,8 @@ const environmentSchema = z.object({
 const environment = environmentSchema.parse(process.env);
 
 const config = {
-  pipelineDate: "2024-10-28",
-  conceptsIndex: "concepts-store",
+  pipelineDate: "2025-03-06",
+  conceptsIndex: "concepts-indexed-2025-03-06",
   publicRootUrl: new URL(environment.PUBLIC_ROOT_URL),
 };
 

--- a/concepts/package.json
+++ b/concepts/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "start": "NODE_ENV=production ts-node-transpile-only ./server.ts",
-    "dev": "AWS_PROFILE=catalogue-developer PORT=3001 NODE_ENV=development nodemon ./server.ts",
+    "dev": "AWS_PROFILE=platform-developer PORT=3001 NODE_ENV=development nodemon ./server.ts",
     "test": "jest"
   },
   "dependencies": {

--- a/concepts/src/services/elasticsearch.ts
+++ b/concepts/src/services/elasticsearch.ts
@@ -10,16 +10,20 @@ const isProduction = process.env.NODE_ENV === "production";
 const getElasticClientConfig = async ({
   pipelineDate,
 }: ClientParameters): Promise<ClientOptions> => {
-  const secretPrefix = `elasticsearch/concepts-${pipelineDate}`;
-  const [host, password] = await Promise.all([
+  const secretPrefix = `elasticsearch/pipeline_storage_${pipelineDate}`;
+  const [host, apiKey] = await Promise.all([
     getSecret(`${secretPrefix}/${isProduction ? "private" : "public"}_host`),
-    getSecret(`${secretPrefix}/api/password`),
+    getSecret(`${secretPrefix}/concepts_api/api_key`),
   ]);
+
+  if (apiKey == null || host == null) {
+    throw Error("Could not retrieve values from Secrets Manager.");
+  }
+
   return {
     node: `https://${host}:9243`,
     auth: {
-      username: "api",
-      password: password!,
+      apiKey: apiKey,
     },
   };
 };

--- a/snapshots/README.md
+++ b/snapshots/README.md
@@ -22,3 +22,15 @@ Contains:
 The snapshot_generator is deployed alongside the catalogue API using Buildkite.
 
 New Lambda deployment packages are published to S3 by Buildkite; you need to run a `terraform apply` to use the new versions.
+
+## Running locally
+
+To run the snapshot generator locally:
+
+SNAPSHOT_QUERY='{"term": {"type": "Visible"}}'
+SNAPSHOT_BUCKET_NAME="wellcomecollection-data-public-delta"
+SNAPSHOT_BUCKET_KEY="catalogue_dev/v2/works.json.gz"
+SNAPSHOT_INDEX="works-indexed-\*"
+PIPELINE_DATE="2025-03-06"
+AWS_PROFILE=catalogue-developer
+AWS_REGION=eu-west-1

--- a/snapshots/README.md
+++ b/snapshots/README.md
@@ -25,12 +25,18 @@ New Lambda deployment packages are published to S3 by Buildkite; you need to run
 
 ## Running locally
 
-To run the snapshot generator locally:
+To create a snapshot of a non-production index and save it to a separate S3 location, it is possible to run the
+snapshot generator locally.
 
-SNAPSHOT_QUERY='{"term": {"type": "Visible"}}'
+For example, to create a works snapshot and save it to `s3://wellcomecollection-data-public-delta/catalogue_dev/v2/works.json.gz`,
+run the snapshot generator with the following environment variables:
+
+```
 SNAPSHOT_BUCKET_NAME="wellcomecollection-data-public-delta"
 SNAPSHOT_BUCKET_KEY="catalogue_dev/v2/works.json.gz"
-SNAPSHOT_INDEX="works-indexed-\*"
-PIPELINE_DATE="2025-03-06"
+SNAPSHOT_INDEX="works-indexed-<SOME_PIPELINE_DATE>"
+PIPELINE_DATE=<SOME_PIPELINE_DATE>
+SNAPSHOT_QUERY='{"term": {"type": "Visible"}}'
 AWS_PROFILE=catalogue-developer
 AWS_REGION=eu-west-1
+```

--- a/snapshots/snapshot_generator/src/main/resources/application.conf
+++ b/snapshots/snapshot_generator/src/main/resources/application.conf
@@ -2,7 +2,6 @@ aws.sns.topic.arn=${?topic_arn}
 aws.sqs.queue.url=${?queue_url}
 aws.metrics.namespace=${?metrics_namespace}
 
-; Local config
 pipelineDate=${?PIPELINE_DATE}
 snapshotIndex=${?SNAPSHOT_INDEX}
 snapshotBucketName=${?SNAPSHOT_BUCKET_KEY}

--- a/snapshots/snapshot_generator/src/main/resources/application.conf
+++ b/snapshots/snapshot_generator/src/main/resources/application.conf
@@ -1,3 +1,10 @@
 aws.sns.topic.arn=${?topic_arn}
 aws.sqs.queue.url=${?queue_url}
 aws.metrics.namespace=${?metrics_namespace}
+
+; Local config
+pipelineDate=${?PIPELINE_DATE}
+snapshotIndex=${?SNAPSHOT_INDEX}
+snapshotBucketName=${?SNAPSHOT_BUCKET_KEY}
+snapshotBucketKey=${?SNAPSHOT_BUCKET_NAME}
+snapshotQuery=${?SNAPSHOT_QUERY}

--- a/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/MainLocal.scala
+++ b/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/MainLocal.scala
@@ -6,7 +6,6 @@ import weco.api.search.models.ApiEnvironment
 import weco.api.snapshot_generator.models.SnapshotJob
 import weco.api.snapshot_generator.services.SnapshotService
 import weco.storage.providers.s3.S3ObjectLocation
-import com.sksamuel.elastic4s.Index
 import com.typesafe.config.{Config, ConfigFactory}
 
 import java.time.Instant
@@ -17,24 +16,24 @@ object MainLocal {
 
     val snapshotService =
       new SnapshotService(
-        PipelineElasticClientBuilder("snapshot_generator", _, ApiEnvironment.Dev),
+        PipelineElasticClientBuilder(
+          "snapshot_generator",
+          _,
+          ApiEnvironment.Dev),
         S3Client.builder().build()
       )
 
-
     val snapshotJob = SnapshotJob(
-      s3Location=S3ObjectLocation(
-        bucket=config.getString("snapshotBucketName"),
-        key=config.getString("snapshotBucketKey")
+      s3Location = S3ObjectLocation(
+        bucket = config.getString("snapshotBucketName"),
+        key = config.getString("snapshotBucketKey")
       ),
-      requestedAt=Instant.now(),
-      pipelineDate=config.getString("pipelineDate"),
-      index=config.getString("snapshotIndex"),
-      bulkSize=150,
-      query=Option(config.getString("snapshotQuery"))
-    );
-    val completedSnapshotJob = snapshotService.generateSnapshot(snapshotJob);
-
-    println(completedSnapshotJob);
+      requestedAt = Instant.now(),
+      pipelineDate = config.getString("pipelineDate"),
+      index = config.getString("snapshotIndex"),
+      bulkSize = 150,
+      query = Option(config.getString("snapshotQuery"))
+    )
+    snapshotService.generateSnapshot(snapshotJob);
   }
 }

--- a/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/MainLocal.scala
+++ b/snapshots/snapshot_generator/src/main/scala/weco/api/snapshot_generator/MainLocal.scala
@@ -1,0 +1,40 @@
+package weco.api.snapshot_generator
+
+import software.amazon.awssdk.services.s3.S3Client
+import weco.api.search.config.builders.PipelineElasticClientBuilder
+import weco.api.search.models.ApiEnvironment
+import weco.api.snapshot_generator.models.SnapshotJob
+import weco.api.snapshot_generator.services.SnapshotService
+import weco.storage.providers.s3.S3ObjectLocation
+import com.sksamuel.elastic4s.Index
+import com.typesafe.config.{Config, ConfigFactory}
+
+import java.time.Instant
+
+object MainLocal {
+  def main(): Unit = {
+    val config: Config = ConfigFactory.load()
+
+    val snapshotService =
+      new SnapshotService(
+        PipelineElasticClientBuilder("snapshot_generator", _, ApiEnvironment.Dev),
+        S3Client.builder().build()
+      )
+
+
+    val snapshotJob = SnapshotJob(
+      s3Location=S3ObjectLocation(
+        bucket=config.getString("snapshotBucketName"),
+        key=config.getString("snapshotBucketKey")
+      ),
+      requestedAt=Instant.now(),
+      pipelineDate=config.getString("pipelineDate"),
+      index=config.getString("snapshotIndex"),
+      bulkSize=150,
+      query=Option(config.getString("snapshotQuery"))
+    );
+    val completedSnapshotJob = snapshotService.generateSnapshot(snapshotJob);
+
+    println(completedSnapshotJob);
+  }
+}


### PR DESCRIPTION
## What does this change?

Related to https://github.com/wellcomecollection/catalogue-pipeline/pull/2850 and https://github.com/wellcomecollection/wellcomecollection.org/pull/11697.

* Adds support for running the snapshot generator service locally. This is useful in cases where we want to take a snapshot of a non-production index, so that we can use the snapshot to populate the catalogue graph.
* Switches the concepts API to the new concepts index (populated from the catalogue graph).

### Checklist

- [ ] Does this patch need a change to the documentation?
- [ ] Do you need to update the [Catalogue API Swagger][swagger]?

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml

## How to test

* Follow the instructions in the README to run the snapshot generator locally. Does it work?
* Pull this PR and the corresponding [frontend PR](https://github.com/wellcomecollection/wellcomecollection.org/pull/11697). Then run the concepts API and the Wellcome Collection frontend locally. Does it work?

## How can we measure success?

* Catalogue snapshots can be generated locally and saved to an arbitrary S3 location.

## Have we considered potential risks?

We should not merge this PR until we are ready to switch to the new concepts index.