### PR TITLE
Increase stage resources

### DIFF
--- a/terraform/modules/stack/services.tf
+++ b/terraform/modules/stack/services.tf
@@ -36,8 +36,8 @@ module "search_api" {
     metrics_namespace = "search-api"
   }
 
-  app_cpu    = var.environment_name == "prod" ? 1024 : 512
-  app_memory = var.environment_name == "prod" ? 2048 : 1024
+  app_cpu    = 1024
+  app_memory = 2048
 
   secrets = var.apm_secret_config
 


### PR DESCRIPTION
## What does this change?

This change gives the stage search service the same resources as prod.

We've been having issues with consistently failing e2e tests on stage, previously we tried to fix [this with this change](https://github.com/wellcomecollection/catalogue-api/pull/750/files).

It appears that isn't the _only_ cause. Looking at the metrics on resource usage in stage vs prod:

<img width="679" alt="Screenshot 2025-03-26 at 09 33 16" src="https://github.com/user-attachments/assets/fb0f817f-6e23-42e2-8106-67be8f91377c" />
<img width="679" alt="Screenshot 2025-03-26 at 09 33 20" src="https://github.com/user-attachments/assets/7765d1ec-8f53-44c6-89f9-b9becee5a8eb" />

Stage seems to cap out at 100% usage on deployment which may be the cause of the initial failures, we make it the same as prod here so that there is no difference in resources.

> [!Note] 
> This change will increase costs slightly, but as we already turn stage off overnight and use spot priced instances in stage it's unlikely to be a significant increase.

## How to test

- [ ] Deploy this change, does it impact e2e tests when run?

## How can we measure success?

Not having to re-run e2e tests in stage.

## Have we considered potential risks?

This should not be impactful to users, it may slightly increase costs.
