### PR TITLE
Switch concepts / catalogue API to pipeline 2025-05-10

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
@@ -11,7 +11,7 @@ case class ElasticConfig(
 object ElasticConfig {
   // We use this to share config across Scala API applications
   // i.e. The API and the snapshot generator.
-  val pipelineDate = "2025-03-06"
+  val pipelineDate = "2025-05-01"
 }
 
 object PipelineClusterElasticConfig extends Logging {

--- a/concepts/config.ts
+++ b/concepts/config.ts
@@ -10,8 +10,8 @@ const environmentSchema = z.object({
 const environment = environmentSchema.parse(process.env);
 
 const config = {
-  pipelineDate: "2025-03-06",
-  conceptsIndex: "concepts-indexed-2025-04-24",
+  pipelineDate: "2025-05-01",
+  conceptsIndex: "concepts-indexed-2025-05-15",
   publicRootUrl: new URL(environment.PUBLIC_ROOT_URL),
 };
 

--- a/concepts/src/services/elasticsearch.ts
+++ b/concepts/src/services/elasticsearch.ts
@@ -10,12 +10,10 @@ const isProduction = process.env.NODE_ENV === "production";
 const getElasticClientConfig = async ({
   pipelineDate,
 }: ClientParameters): Promise<ClientOptions> => {
-  // TODO: The 'concepts_api_new' key is temporary. Switch back to 'concepts_api' once it has been updated with the
-  // necessary permissions!
   const secretPrefix = `elasticsearch/pipeline_storage_${pipelineDate}`;
   const [host, apiKey] = await Promise.all([
     getSecret(`${secretPrefix}/${isProduction ? "private" : "public"}_host`),
-    getSecret(`${secretPrefix}/concepts_api_new/api_key`),
+    getSecret(`${secretPrefix}/concepts_api/api_key`),
   ]);
 
   if (apiKey == null || host == null) {


### PR DESCRIPTION
## What does this change?

Move the APIs over to the new pipeline, releasing quite a few changes, including:

- https://github.com/wellcomecollection/platform/issues/5996
- https://github.com/wellcomecollection/catalogue-pipeline/pull/2892
- https://github.com/wellcomecollection/platform/issues/5987 

Follows: https://github.com/wellcomecollection/platform/issues/6027

## How to test

- [ ] Test the website locally pointed at the new pipeline, does it behave as expected?
- [ ] Push the change through stage and let all the lovely tests make sure it's not broken anything.

## How can we measure success?

Releasing the above changes, not breaking anything.

## Have we considered potential risks?

This change must be thoroughly tested as described above as it changes the pipeline for the in the public catalogue.
