### PR TITLE
Switch to new concepts index

### DIFF
--- a/concepts/config.ts
+++ b/concepts/config.ts
@@ -11,7 +11,7 @@ const environment = environmentSchema.parse(process.env);
 
 const config = {
   pipelineDate: "2025-05-01",
-  conceptsIndex: "concepts-indexed-2025-05-15",
+  conceptsIndex: "concepts-indexed-2025-06-17",
   publicRootUrl: new URL(environment.PUBLIC_ROOT_URL),
 };
 


### PR DESCRIPTION
## What does this change?

Switch the concepts API to the latest concepts index. Follow-up on [this PR](https://github.com/wellcomecollection/catalogue-pipeline/pull/2927).