### PR TITLE
Improve run local experience for requests & items API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ lazy val search_common = setupProject(
 lazy val stacks = setupProject(
   project,
   "common/stacks",
-  localDependencies = Seq(display),
+  localDependencies = Seq(display, search_common),
   externalDependencies = CatalogueDependencies.stacksDependencies
 )
 

--- a/common/stacks/src/main/scala/weco/sierra/typesafe/builders/SierraOauthHttpClientBuilder.scala
+++ b/common/stacks/src/main/scala/weco/sierra/typesafe/builders/SierraOauthHttpClientBuilder.scala
@@ -24,9 +24,8 @@ object SierraOauthHttpClientBuilder {
     implicit
     as: ActorSystem,
     ec: ExecutionContext
-  ): SierraOauthHttpClient = {
+  ): SierraOauthHttpClient =
     build(config, ApiEnvironment.Prod)
-  }
 
   def build(config: Config, environment: ApiEnvironment = ApiEnvironment.Prod)(
     implicit
@@ -52,22 +51,24 @@ object SierraOauthHttpClientBuilder {
     // Note: At present, we only use the secrets manager to get the items
     // service key and secret, the requests service uses a different key
     // and secret, which is in the identity account and stored in JSON
-    // format, in a single secret. 
+    // format, in a single secret.
     //
     // We should probably refactor this so they both use the same approach!
 
     val username = config.getStringOption("sierra.api.key") match {
       case Some(key) => key
-      case None => getSecretString(
-        s"stacks/prod/sierra_api_key"
-      )
+      case None =>
+        getSecretString(
+          s"stacks/prod/sierra_api_key"
+        )
     }
 
     val password = config.getStringOption("sierra.api.secret") match {
       case Some(secret) => secret
-      case None => getSecretString(
-        s"stacks/prod/sierra_api_secret"
-      )
+      case None =>
+        getSecretString(
+          s"stacks/prod/sierra_api_secret"
+        )
     }
 
     val client = new PekkoHttpClient() with HttpGet with HttpPost {

--- a/common/stacks/src/main/scala/weco/sierra/typesafe/builders/SierraOauthHttpClientBuilder.scala
+++ b/common/stacks/src/main/scala/weco/sierra/typesafe/builders/SierraOauthHttpClientBuilder.scala
@@ -1,4 +1,4 @@
-package weco.api.items.config.builders
+package weco.sierra.typesafe.builders
 
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.model.Uri
@@ -20,6 +20,14 @@ import scala.concurrent.ExecutionContext
 // remove this from scala-libs, after removing any other usages (
 // currently the requests service).
 object SierraOauthHttpClientBuilder {
+  def build(config: Config)(
+    implicit
+    as: ActorSystem,
+    ec: ExecutionContext
+  ): SierraOauthHttpClient = {
+    build(config, ApiEnvironment.Prod)
+  }
+
   def build(config: Config, environment: ApiEnvironment = ApiEnvironment.Prod)(
     implicit
     as: ActorSystem,
@@ -41,13 +49,26 @@ object SierraOauthHttpClientBuilder {
 
     implicit val secretsClient: SecretsManagerClient = secretsClientForEnv
 
-    val username = getSecretString(
-      s"stacks/prod/sierra_api_key"
-    )
+    // Note: At present, we only use the secrets manager to get the items
+    // service key and secret, the requests service uses a different key
+    // and secret, which is in the identity account and stored in JSON
+    // format, in a single secret. 
+    //
+    // We should probably refactor this so they both use the same approach!
 
-    val password = getSecretString(
-      s"stacks/prod/sierra_api_secret"
-    )
+    val username = config.getStringOption("sierra.api.key") match {
+      case Some(key) => key
+      case None => getSecretString(
+        s"stacks/prod/sierra_api_key"
+      )
+    }
+
+    val password = config.getStringOption("sierra.api.secret") match {
+      case Some(secret) => secret
+      case None => getSecretString(
+        s"stacks/prod/sierra_api_secret"
+      )
+    }
 
     val client = new PekkoHttpClient() with HttpGet with HttpPost {
       override val baseUri: Uri = Uri(

--- a/items/src/main/resources/application.conf
+++ b/items/src/main/resources/application.conf
@@ -10,7 +10,7 @@ api.public-root=${?catalogue_api_public_root}
 
 catalogue.api.publicRoot="https://api.wellcomecollection.org/catalogue/v2"
 # If running on the same host as the API (like when running locally), uncomment the line below:
-catalogue.api.publicRoot="http://localhost:8080"
+# catalogue.api.publicRoot="http://localhost:8080"
 catalogue.api.publicRoot=${?catalogue_api_public_root}
 
 content.api.publicRoot="https://api.wellcomecollection.org/content/v0"

--- a/items/src/main/resources/application.conf
+++ b/items/src/main/resources/application.conf
@@ -1,4 +1,5 @@
 api.host=${?api_host}
+
 apm.server.url=${?apm_server_url}
 apm.secret=${?apm_secret}
 apm.service.name=${?apm_service_name}
@@ -8,6 +9,8 @@ api.public-root="http://localhost"
 api.public-root=${?catalogue_api_public_root}
 
 catalogue.api.publicRoot="https://api.wellcomecollection.org/catalogue/v2"
+# If running on the same host as the API (like when running locally), uncomment the line below:
+catalogue.api.publicRoot="http://localhost:8080"
 catalogue.api.publicRoot=${?catalogue_api_public_root}
 
 content.api.publicRoot="https://api.wellcomecollection.org/content/v0"
@@ -20,5 +23,8 @@ http.externalBaseURL="http://localhost:8081/"
 http.externalBaseURL=${?app_base_url}
 
 aws.metrics.namespace=${?metrics_namespace}
-sierra.api.baseUrl="libsys.wellcomelibrary.org"
+
+sierra.api.baseUrl="https://libsys.wellcomelibrary.org/iii/sierra-api"
+# Uncomment to use the testing Sierra service:
+# sierra.api.baseUrl="https://welli-tr.iii.com/iii/sierra-api"
 sierra.api.baseUrl=${?sierra_base_url}

--- a/items/src/main/scala/weco/api/items/Main.scala
+++ b/items/src/main/scala/weco/api/items/Main.scala
@@ -4,7 +4,7 @@ import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.model.Uri
 import com.typesafe.config.Config
 import weco.Tracing
-import weco.api.items.config.builders.SierraOauthHttpClientBuilder
+import weco.sierra.typesafe.builders.SierraOauthHttpClientBuilder
 import weco.api.items.services.{
   ItemUpdateService,
   SierraItemUpdater,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -155,7 +155,8 @@ object CatalogueDependencies {
 
   val stacksDependencies: Seq[ModuleID] =
     ExternalDependencies.scalatestDependencies ++
-      WellcomeDependencies.sierraLibrary
+      WellcomeDependencies.sierraLibrary ++
+      ExternalDependencies.secretsDependencies
 
   val snapshotGeneratorDependencies: Seq[ModuleID] =
     WellcomeDependencies.messagingTypesafeLibrary ++

--- a/requests/src/main/resources/application.conf
+++ b/requests/src/main/resources/application.conf
@@ -1,17 +1,30 @@
-http.externalBaseURL=${?app_base_url}
-http.host="0.0.0.0"
-http.port=9001
-
 apm.server.url=${?apm_server_url}
 apm.secret=${?apm_secret}
 apm.service.name=${?apm_service_name}
 apm.environment=${?apm_environment}
 
+http.host="0.0.0.0"
+http.port=9001
+http.port=${?app_port}
+http.externalBaseURL="http://localhost:9001/"
+http.externalBaseURL=${?app_base_url}
+
+catalogue.api.publicRoot="https://api.wellcomecollection.org/catalogue/v2"
+# If running on the same host as the API (like when running locally), uncomment the line below:
+catalogue.api.publicRoot="http://localhost:8080"
 catalogue.api.publicRoot=${?catalogue_api_public_root}
 
 aws.metrics.namespace=${?metrics_namespace}
+
+# If you want to test the requesting service locally, you will need to set these
+# environment variables to the values for the correct machine user (see the identity account).
 sierra.api.key=${?sierra_api_key}
 sierra.api.secret=${?sierra_api_secret}
+
+sierra.api.baseUrl="https://libsys.wellcomelibrary.org/iii/sierra-api"
+# Uncomment to use the testing Sierra service:
+# sierra.api.baseUrl="https://welli-tr.iii.com/iii/sierra-api"
 sierra.api.baseUrl=${?sierra_base_url}
 
+sierra.holdLimit=15
 sierra.holdLimit=${?user_hold_limit}

--- a/requests/src/main/resources/application.conf
+++ b/requests/src/main/resources/application.conf
@@ -11,7 +11,7 @@ http.externalBaseURL=${?app_base_url}
 
 catalogue.api.publicRoot="https://api.wellcomecollection.org/catalogue/v2"
 # If running on the same host as the API (like when running locally), uncomment the line below:
-catalogue.api.publicRoot="http://localhost:8080"
+# catalogue.api.publicRoot="http://localhost:8080"
 catalogue.api.publicRoot=${?catalogue_api_public_root}
 
 aws.metrics.namespace=${?metrics_namespace}

--- a/requests/src/main/scala/weco/api/requests/Main.scala
+++ b/requests/src/main/scala/weco/api/requests/Main.scala
@@ -15,7 +15,7 @@ import weco.http.client.{HttpGet, PekkoHttpClient}
 import weco.http.monitoring.HttpMetrics
 import weco.http.typesafe.HTTPServerBuilder
 import weco.monitoring.typesafe.CloudWatchBuilder
-import weco.sierra.typesafe.SierraOauthHttpClientBuilder
+import weco.sierra.typesafe.builders.SierraOauthHttpClientBuilder
 import weco.typesafe.WellcomeTypesafeApp
 import weco.typesafe.config.builders.EnrichConfig._
 
@@ -39,6 +39,7 @@ object Main extends WellcomeTypesafeApp {
 
     val holdLimit = config.requireInt("sierra.holdLimit")
     val client = SierraOauthHttpClientBuilder.build(config)
+
     val sierraService = SierraRequestsService(client, holdLimit = holdLimit)
     val itemLookup = new ItemLookup(httpClient)
 


### PR DESCRIPTION
## What does this change?

This pull request introduces updates to configuration files and refactors the `SierraOauthHttpClientBuilder` to be shared between the items and requesting service, as per the code note to do so. 

We have also tried to make the application.conf more consistent between thes services.

This change is intended to allow it to be easier to run the requests & items APIs more easily locally, however there are still some outstanding difficulties as the services in production run in different AWS accounts and consume secrets in different ways. The requests service uses a JSON value with one secret, and the ECS task definition references an attribute from the supplied object, the items service uses 2 secrets.

### Refactoring and File Reorganization:
* Renamed `items/src/main/scala/weco/api/items/config/builders/SierraOauthHttpClientBuilder.scala` to `common/stacks/src/main/scala/weco/sierra/typesafe/builders/SierraOauthHttpClientBuilder.scala` and updated the package declaration to reflect the new location.
* Updated imports in `items/src/main/scala/weco/api/items/Main.scala` and `requests/src/main/scala/weco/api/requests/Main.scala` to reflect the new location of `SierraOauthHttpClientBuilder`. [[1]](diffhunk://#diff-7e7704ff8b1fb40ad114682dbe6ac017a8c9ffef37e55a88093170fa76f1d60bL7-R7) [[2]](diffhunk://#diff-c925b5e5652299a48ad332a4f65f8f715a95e48ba7bbadfdc0cd5ff721a49c04L18-R18)

### Configuration Updates:
* Enhanced `items/src/main/resources/application.conf` and `requests/src/main/resources/application.conf` to support multiple environments, including local testing. Added options for Sierra API base URLs and clarified environment variable usage for Sierra API credentials. [[1]](diffhunk://#diff-2ed914df9ba1c1c00cfc507bbde66cff097be58b868ba7739925ab61685cbfa6L23-R29) [[2]](diffhunk://#diff-c538b1f6437593c2b9b303094aff673aaeee1cf7092ad9c4ddbca1f7fda0cc9eL1-R29)
* Added a new `sierra.holdLimit` configuration in `requests/src/main/resources/application.conf` with support for environment variable overrides.

### Sierra API Credential Handling:
* Refactored `SierraOauthHttpClientBuilder` to allow credentials (`sierra.api.key` and `sierra.api.secret`) to be sourced from configuration files or secrets manager, improving flexibility for different environments.

### Dependency Updates:
* Updated `project/Dependencies.scala` to add `ExternalDependencies.secretsDependencies` to `stacksDependencies`, ensuring proper support for secrets management.

## How to test

- [ ] Run the items API and requests API locally, do they work as expected?
- [ ] Run the tests, do they pass?

## How can we measure success?

Easier for developers to run and test things locally, easier next time we want to test a Sierra upgrade.

## Have we considered potential risks?

This should only change the local environment, but it does re-order things in a way that could break a production release if incorrect. This change should be tested in stage before release!