### PR TITLE
Use pipeline 2025-08-14

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
@@ -11,7 +11,7 @@ case class ElasticConfig(
 object ElasticConfig {
   // We use this to share config across Scala API applications
   // i.e. The API and the snapshot generator.
-  val pipelineDate = "2025-05-01"
+  val pipelineDate = "2025-08-14"
 }
 
 object PipelineClusterElasticConfig extends Logging {

--- a/concepts/config.ts
+++ b/concepts/config.ts
@@ -10,8 +10,8 @@ const environmentSchema = z.object({
 const environment = environmentSchema.parse(process.env);
 
 const config = {
-  pipelineDate: "2025-05-01",
-  conceptsIndex: "concepts-indexed-2025-07-21",
+  pipelineDate: "2025-08-14",
+  conceptsIndex: "concepts-indexed-2025-08-21",
   publicRootUrl: new URL(environment.PUBLIC_ROOT_URL),
 };
 


### PR DESCRIPTION
## What does this change?

Follows https://github.com/wellcomecollection/catalogue-pipeline/pull/2987

Updates config to point at the new pipeline 2025-08-14 (including the concepts index using index 2025-08-21).

## How to test

- [ ] Test locally, does the api & front-end run locally behave as expected?

## How can we measure success?

We are able to switch to the new pipeline that carries a number of new improvements.

## Have we considered potential risks?

This should be thoroughly tested by the build pipeline!