### PR TITLE
Query concepts API with multiple IDs

### DIFF
--- a/concepts/test/concepts.test.ts
+++ b/concepts/test/concepts.test.ts
@@ -12,4 +12,21 @@ describe("GET /concepts", () => {
     expect(response.statusCode).toBe(200);
     expect(response.body.results).toStrictEqual(testConcepts);
   });
+
+  it("returns only requested ids when id query param supplied, preserving order and duplicates", async () => {
+    const testConcepts = [
+      concept({ id: "a" }),
+      concept({ id: "b" }),
+      concept({ id: "c" }),
+    ];
+    const api = mockedApi(testConcepts);
+
+    const response = await api.get("/concepts?id=b,a,b,missing");
+    expect(response.statusCode).toBe(200);
+    // Should include b, a, b (duplicate) but not missing
+    // @ts-ignore - test helper, dynamic typing acceptable here
+    const resultIds = response.body.results.map((c) => c.id);
+    expect(resultIds).toStrictEqual(["b", "a", "b"]);
+    expect(response.body.totalResults).toBe(3);
+  });
 });

--- a/concepts/test/fixtures/elasticsearch.ts
+++ b/concepts/test/fixtures/elasticsearch.ts
@@ -74,6 +74,29 @@ export const mockedElasticsearchClient = <T extends Identifiable>({
     })
   );
 
+  // _mget support for batch id retrieval
+  mock.add(
+    {
+      method: ["GET", "POST"],
+      path: `/${index}/_mget`,
+    },
+    ({ body }) => {
+      const ids: string[] = (body as any)?.ids || [];
+      return {
+        docs: ids.map((id) =>
+          docsMap.has(id)
+            ? {
+                _index: index,
+                _id: id,
+                found: true,
+                _source: { display: docsMap.get(id) },
+              }
+            : { _index: index, _id: id, found: false }
+        ),
+      };
+    }
+  );
+
   return new Client({
     node: "http://test:9200",
     Connection: mock.getConnection(),


### PR DESCRIPTION
### What is this?
Adds support to the Concepts API for batch lookup of specific concept IDs using a single request:

```
GET /concepts?id=id1,id2,id3
```

Resolves wellcomecollection/platform#6131.

### Why?
Previously, clients needing a handful of specific concepts had to either:
- Issue multiple sequential `GET /concepts/:id` requests, or
- Perform a broader search and filter client-side.

This introduces an efficient server-side path using a single Elasticsearch `_mget` call.

### What does it do?
- New optional query param: `id` (comma‑separated list of concept IDs).
- Short‑circuits the normal text search flow when `id` is present and performs a single `_mget`.
- Returns concepts in the exact order requested, preserving duplicates; silently skips IDs not found.
- Extends the test Elasticsearch mock with `_mget` support.
- Adds a test covering ordering, duplicate preservation, and missing IDs handling.

### Behaviour
- Response shape remains a `ResultList`.
- For batch lookups: `pageSize == totalResults == number of returned concepts`; `totalPages = 1`.
- Pagination & free‑text `query` are ignored when `id` is supplied (can be revisited if needed).

### Local testing
From repo root (ensure deps installed):

```
yarn install
# Option A: run within the workspace
cd concepts && yarn dev
# Option B: from root using workspaces
yarn workspace @weco/concepts-api dev
```
Then request (adjust port if you set `PORT`):
```
http://localhost:3001/concepts\?id\=ID1,ID2,ID3
```
You should see a `ResultList` ordered as requested, with duplicates retained, and missing IDs omitted.

### Deployed example (dev)
Placeholder (will be replaced with screenshot):
`https://api-dev.wellcomecollection.org/catalogue/v2/concepts?id=a22auf32,a2233f9d`

<img width="714" height="985" alt="Screenshot 2025-09-04 at 09 47 41" src="https://github.com/user-attachments/assets/4246416c-28a8-45d5-b6c7-8d4828536ffb" />

### Implementation summary
```
concepts/src/controllers/concepts.ts          # Add ?id= handling & _mget logic
concepts/test/fixtures/elasticsearch.ts       # Add mock _mget route
concepts/test/concepts.test.ts                # New test for batch ID query
```

### Tests
All existing and new tests pass:
```
yarn workspace @weco/concepts-api test
```

### Risk & rollout
Low risk: behavior gated behind explicit `id` param; existing search & pagination untouched.

### Follow‑ups (optional)
- Expose list of missing IDs (e.g. `missing: []`).
- Emit a metric/count for `?id=` usage vs standard searches.

---
Resolves #6131
