### PR TITLE
Switch to new concepts index 2025-10-10

### DIFF
--- a/concepts/config.ts
+++ b/concepts/config.ts
@@ -11,7 +11,7 @@ const environment = environmentSchema.parse(process.env);
 
 const config = {
   pipelineDate: "2025-08-14",
-  conceptsIndex: "concepts-indexed-2025-08-21",
+  conceptsIndex: "concepts-indexed-2025-10-10",
   publicRootUrl: new URL(environment.PUBLIC_ROOT_URL),
 };
 


### PR DESCRIPTION
## What does this change?

This change points the Concepts API at concepts-indexed-2025-10-10.

Follows https://github.com/wellcomecollection/catalogue-pipeline/pull/3037

Part of https://github.com/wellcomecollection/wellcomecollection.org/milestone/73

## How to test

- [x] Run the automated tests!

## How can we measure success?

We're able to release the new collections landing pages.

## Have we considered potential risks?

If there is bad data in the index, we'll surface that to the public, mitigated by automated & smoke testing.