### PR TITLE
Switch concepts / catalogue API to pipeline 2025-10-02

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
@@ -11,7 +11,7 @@ case class ElasticConfig(
 object ElasticConfig {
   // We use this to share config across Scala API applications
   // i.e. The API and the snapshot generator.
-  val pipelineDate = "2025-08-14"
+  val pipelineDate = "2025-10-02"
 }
 
 object PipelineClusterElasticConfig extends Logging {

--- a/concepts/config.ts
+++ b/concepts/config.ts
@@ -10,8 +10,8 @@ const environmentSchema = z.object({
 const environment = environmentSchema.parse(process.env);
 
 const config = {
-  pipelineDate: "2025-08-14",
-  conceptsIndex: "concepts-indexed-2025-10-14",
+  pipelineDate: "2025-10-02",
+  conceptsIndex: "concepts-indexed-2025-10-09",
   publicRootUrl: new URL(environment.PUBLIC_ROOT_URL),
 };
 


### PR DESCRIPTION
## What does this change?

Move the APIs over to the new pipeline (2025-10-02), releasing changes that include:

- [EBSCO Adapter Iceberg implementation platform#6046](https://github.com/wellcomecollection/platform/issues/6046)
- [Upgrade pipeline-2025-08-14 ES deployment to 9.1.3 platform#6130](https://github.com/wellcomecollection/platform/issues/6130)

Follows: [wellcomecollection/platform#6141](https://github.com/wellcomecollection/platform/issues/6141)

## How to test

Test the website locally pointed at the new pipeline, does it behave as expected?
Push the change through stage and let all the lovely tests make sure it's not broken anything.

## How can we measure success?

Releasing the above changes, not breaking anything.

## Have we considered potential risks?

This change must be thoroughly tested as described above as it changes the pipeline for the in the public catalogue.
