### PR TITLE
Switch to new works index

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
@@ -12,7 +12,7 @@ object ElasticConfig {
   // We use this to share config across Scala API applications
   // i.e. The API and the snapshot generator.
   val pipelineDate = "2025-10-02"
-  val indexDateWorks = "2025-11-20"
+  val indexDateWorks = "2025-10-09"
   val indexDateImages = "2025-10-02"
 }
 


### PR DESCRIPTION
## What does this change?

Switch to a new works index (2025-10-09) within the production cluster. This index is populated using the graph pipeline.

### Checklist

- [ ] Does this patch need a change to the documentation?
- [ ] Do you need to update the [Catalogue API Swagger][swagger]?

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml

## How to test

Run the frontend locally connected to the index. Do work pages look as expected?

## How can we measure success?

The new graph pipeline is used to populate the production works index. There should be no differences in the contents of the new index and the current production index (except for a few deliberate changes, including the removal of the `succeededBy` and `preceededBy` fields in work hierarchies, and some data quality improvements).

## Have we considered potential risks?

This is a major change which involves switching to a new set of services for populating the final works index (retiring the Scala relation embedder and works ingestor).

However, risks are relatively small, since we did a full comparison of the two indexes (see [here](https://wellcome.slack.com/archives/C02ANCYL90E/p1763554599296169)) and did not find any unexpected differences. 

If issues do appear, we have the option of switching back to the old index (2025-10-02).