### PR TITLE
Hardcode rank test pipeline dates

### DIFF
--- a/.buildkite/pipeline.deploy-prod.yml
+++ b/.buildkite/pipeline.deploy-prod.yml
@@ -120,6 +120,7 @@ steps:
             - "--content-type={{matrix}}"
             - "--cluster=pipeline-prod"
             - "--query=https://api.wellcomecollection.org/catalogue/v2"
+            - "--pipeline-date=2025-10-02"
           mount-checkout: false
           always-pull: true
           propagate-environment: true

--- a/.buildkite/pipeline.deploy-stage.yml
+++ b/.buildkite/pipeline.deploy-stage.yml
@@ -78,6 +78,7 @@ steps:
             - "--content-type={{matrix}}"
             - "--cluster=pipeline-stage"
             - "--query=https://api-stage.wellcomecollection.org/catalogue/v2"
+            - "--pipeline-date=2025-10-02"
           mount-checkout: false
           always-pull: true
           propagate-environment: true

--- a/.buildkite/pipeline.rank.yml
+++ b/.buildkite/pipeline.rank.yml
@@ -15,6 +15,7 @@ steps:
             - "--content-type={{matrix}}"
             - "--cluster=pipeline-prod"
             - "--query=https://api.wellcomecollection.org/catalogue/v2"
+            - "--pipeline-date=2025-10-02"
           mount-checkout: false
           always-pull: true
           propagate-environment: true


### PR DESCRIPTION
## What does this change?

At the moment, the rank test code assumes that pipeline dates and index dates always match. However, this won't always be the case going forward, since we decoupled the two dates in the pipeline Terraform stack.

This PR introduces a temporary fix, hard-coding the current pipeline dates in all rank test runs. A permanent fix will be implemented later as part of [this ticket](https://github.com/wellcomecollection/platform/issues/6220).
