### PR TITLE
Enable cross zone load balancing to try and avoid outages

### DIFF
--- a/terraform/modules/stack/nlb.tf
+++ b/terraform/modules/stack/nlb.tf
@@ -3,4 +3,6 @@ resource "aws_lb" "catalogue_api" {
   internal           = true
   load_balancer_type = "network"
   subnets            = local.routable_private_subnets
+
+  enable_cross_zone_load_balancing = true
 }


### PR DESCRIPTION
## What does this change?

> [!Note] 
> This change has been applied.

This pull request makes a small but important change to the `aws_lb` resource in the `nlb.tf` Terraform module. The change enables cross-zone load balancing for the Network Load Balancer, which helps distribute traffic more evenly across availability zones.

* Enabled cross-zone load balancing for the `aws_lb.catalogue_api` resource by setting `enable_cross_zone_load_balancing = true` in `nlb.tf`.

## Why?

We are often seeing issues in Catalogue API deployment in the stage environment, but not in prod. The only apparent difference is that stage uses Fargate spot instances, which should not cause issues as there is not difference to the NLB or app how they are provisioned. However I have noticed that at least once when this issue has happened that the tasks are not places evenly across all 3 AZs, and that from experience this can cause issues with NLBs routing traffic to tasks properly.
NLBs can have issues when tasks are not evenly distributed across AZs. 

I have experienced this in the past, and it is specified in the NLB docs: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html

> Your load balancer serves as a single point of contact for clients and distributes incoming traffic across its healthy registered targets. Each target group must have at least one registered target in each Availability Zone that is enabled for the load balancer. You can register each target with one or more target groups.

Note also that NLBs have a "fail-open" behaviour that will route requests to "unhealthy" targets in certain situations: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html

> Network Load Balancers will also fail open when you have an empty target group. The effect of the fail open is to allow traffic to all targets in all enabled Availability Zones, regardless of their health status.

What's this got to do with spot instances that might distinguish the stage & prod environments? 

Fargate spot is far more subject to demand, so it's a lot more likely there won't be spot resource in a particular AZ so it might trigger an uneven AZ task placement and a resulting "fail-open" situation where we are routing to a target group in an AZ without a task.

See: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement.html

> Task placement strategies and constraints aren't supported for tasks using the Fargate. Fargate will try its best to spread tasks across accessible Availability Zones. If the capacity provider includes both Fargate and Fargate Spot, the spread behavior is independent for each capacity provider.

The solution to this problem is to enable cross-zone load balancing: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#cross-zone-load-balancing

> If you turn on cross-zone load balancing, each Network Load Balancer node distributes traffic across the registered targets in all enabled Availability Zones.

However, that has an associated cost: https://aws.amazon.com/blogs/networking-and-content-delivery/exploring-data-transfer-costs-for-aws-network-load-balancers/

> if the target is located in a different AZ than the NLB ENI (Figure 5), which can occur in cross-zone enabled load balancers, then a charge of $0.01 per GB

So how would this impact us if we switched it on in both stage and prod (we could distinguish, but it's better if the envs are the same to reason about them and it's possible this situation could occur in prod, less likely but we aren't guaranteed Fargate availability in a particular AZ even if not using Spot.

A glance at the network stats, we shift ~300GB a month (see the [CloudWatch metrics here](https://756629837203-eyycyuo4.eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metricsV2?graph=~(metrics~(~(~'AWS*2fNetworkELB~'ProcessedBytes~'LoadBalancer~'net*2fprod-catalogue-api*2f4949f952cd77782b))~sparkline~true~view~'singleValue~stacked~false~region~'eu-west-1~start~'-PT672H~end~'P0D~stat~'Sum~period~2592000)&query=~'*7bAWS*2fNetworkELB*2cLoadBalancer*7d)). So that would be $3, which is probably acceptable.

## How to test?

This change was applied in the stage environment while making requests to the stage api with the following command:

```
echo "GET https://api-stage.wellcomecollection.org/catalogue/v2/works/" | \
vegeta attack -rate 10 -duration 10m | vegeta encode | \
    jaggr @count=rps \
          hist\[100,200,300,400,500\]:code \
          p25,p50,p95:latency \
          sum:bytes_in \
          sum:bytes_out | \
    jplot rps+code.hist.100+code.hist.200+code.hist.300+code.hist.400+code.hist.500 \
          latency.p95+latency.p50+latency.p25 \
          bytes_in.sum+bytes_out.sum
```

No downtime was observed, so this was applied to prod with the same monitoring.

Also:

- [x] Is the prod API still serving requests?