### PR TITLE
Items.locations.created date filter

### DIFF
--- a/search/src/main/scala/weco/api/search/models/DocumentFilter.scala
+++ b/search/src/main/scala/weco/api/search/models/DocumentFilter.scala
@@ -23,6 +23,11 @@ case class DateRangeFilter(
 ) extends WorkFilter
     with ImageFilter
 
+case class ItemsLocationsCreatedDateFilter(
+  fromDate: Option[LocalDate],
+  toDate: Option[LocalDate]
+) extends WorkFilter
+
 case object VisibleWorkFilter extends WorkFilter
 
 case class LanguagesFilter(languageIds: Seq[String])

--- a/search/src/main/scala/weco/api/search/rest/WorksParams.scala
+++ b/search/src/main/scala/weco/api/search/rest/WorksParams.scala
@@ -60,7 +60,9 @@ case class ItemsParams(
   `items.identifiers`: Option[ItemsIdentifiersFilter],
   `items.locations.license`: Option[LicenseFilter],
   `items.locations.locationType`: Option[ItemLocationTypeIdFilter],
-  `items.locations.accessConditions.status`: Option[AccessStatusFilter]
+  `items.locations.accessConditions.status`: Option[AccessStatusFilter],
+  `items.locations.createdDate.from`: Option[LocalDate],
+  `items.locations.createdDate.to`: Option[LocalDate]
 )
 
 case class PaginationParams(
@@ -118,6 +120,7 @@ case class MultipleWorksParams(
     List(
       filterParams.workType,
       dateFilter,
+      createdDateFilter,
       filterParams.languages,
       filterParams.`genres.label`,
       filterParams.`genres`,
@@ -145,6 +148,15 @@ case class MultipleWorksParams(
       case (None, None)       => None
       case (dateFrom, dateTo) => Some(DateRangeFilter(dateFrom, dateTo))
     }
+
+  private def createdDateFilter: Option[ItemsLocationsCreatedDateFilter] =
+    (
+      itemsParams.`items.locations.createdDate.from`,
+      itemsParams.`items.locations.createdDate.to`
+    ) match {
+      case (None, None)       => None
+      case (dateFrom, dateTo) => Some(ItemsLocationsCreatedDateFilter(dateFrom, dateTo))
+    }
 }
 
 object MultipleWorksParams extends QueryParamsUtils {
@@ -166,6 +178,8 @@ object MultipleWorksParams extends QueryParamsUtils {
       "items.identifiers".as[ItemsIdentifiersFilter].?,
       "items.locations.locationType".as[ItemLocationTypeIdFilter].?,
       "items.locations.accessConditions.status".as[AccessStatusFilter].?,
+      "items.locations.createdDate.from".as[LocalDate].?,
+      "items.locations.createdDate.to".as[LocalDate].?,
       "page".as[Int].?,
       "pageSize".as[Int].?,
       "sort".as[List[SortRequest]].?,
@@ -180,6 +194,8 @@ object MultipleWorksParams extends QueryParamsUtils {
           identifiers,
           locationType,
           accessStatus,
+          createdDateFrom,
+          createdDateTo,
           page,
           pageSize,
           sort,
@@ -193,7 +209,9 @@ object MultipleWorksParams extends QueryParamsUtils {
           identifiers,
           license,
           locationType,
-          accessStatus
+          accessStatus,
+          createdDateFrom,
+          createdDateTo
         )
 
         val paginationParams = PaginationParams(page, pageSize, sort, sortOrder)

--- a/search/src/main/scala/weco/api/search/rest/WorksParams.scala
+++ b/search/src/main/scala/weco/api/search/rest/WorksParams.scala
@@ -154,8 +154,9 @@ case class MultipleWorksParams(
       itemsParams.`items.locations.createdDate.from`,
       itemsParams.`items.locations.createdDate.to`
     ) match {
-      case (None, None)       => None
-      case (dateFrom, dateTo) => Some(ItemsLocationsCreatedDateFilter(dateFrom, dateTo))
+      case (None, None) => None
+      case (dateFrom, dateTo) =>
+        Some(ItemsLocationsCreatedDateFilter(dateFrom, dateTo))
     }
 }
 

--- a/search/src/main/scala/weco/api/search/services/WorksRequestBuilder.scala
+++ b/search/src/main/scala/weco/api/search/services/WorksRequestBuilder.scala
@@ -91,6 +91,14 @@ object WorksRequestBuilder
         lte = lte,
         gte = gte
       )
+    case ItemsLocationsCreatedDateFilter(fromDate, toDate) =>
+      val (gte, lte) =
+        (fromDate map ElasticDate.apply, toDate map ElasticDate.apply)
+      RangeQuery(
+        "filterableValues.items.locations.createdDate",
+        lte = lte,
+        gte = gte
+      )
     case LanguagesFilter(languageIds) =>
       termsQuery(
         "filterableValues.languages.id",

--- a/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala
@@ -135,6 +135,83 @@ class WorksFiltersTest
     }
   }
 
+  describe("filtering works by items.locations.createdDate") {
+    val digitalLocationWorks = Seq(
+      "work-digital-location.2020",
+      "work-digital-location.2021",
+      "work-digital-location.2022"
+    )
+
+    it("filters by date range") {
+      withWorksApi {
+        case (worksIndex, routes) =>
+          indexTestDocuments(worksIndex, digitalLocationWorks: _*)
+
+          assertJsonResponse(
+            routes,
+            path =
+              s"$rootPath/works?items.locations.createdDate.from=2020-01-01&items.locations.createdDate.to=2021-12-31"
+          ) {
+            Status.OK -> worksListResponse(
+              ids = Seq("work-digital-location.2020", "work-digital-location.2021")
+            )
+          }
+      }
+    }
+
+    it("filters by from date") {
+      withWorksApi {
+        case (worksIndex, routes) =>
+          indexTestDocuments(worksIndex, digitalLocationWorks: _*)
+
+          assertJsonResponse(
+            routes,
+            path = s"$rootPath/works?items.locations.createdDate.from=2021-01-01"
+          ) {
+            Status.OK -> worksListResponse(
+              ids = Seq(
+                "work-digital-location.2021",
+                "work-digital-location.2022"
+              )
+            )
+          }
+      }
+    }
+
+    it("filters by to date") {
+      withWorksApi {
+        case (worksIndex, routes) =>
+          indexTestDocuments(worksIndex, digitalLocationWorks: _*)
+
+          assertJsonResponse(
+            routes,
+            path = s"$rootPath/works?items.locations.createdDate.to=2021-12-31"
+          ) {
+            Status.OK -> worksListResponse(
+              ids = Seq(
+                "work-digital-location.2020",
+                "work-digital-location.2021"
+              )
+            )
+          }
+      }
+    }
+
+    it("errors on invalid date") {
+      withApi { routes =>
+        assertJsonResponse(
+          routes,
+          path = s"$rootPath/works?items.locations.createdDate.from=INVALID"
+        ) {
+          Status.BadRequest ->
+            badRequest(
+              "items.locations.createdDate.from: Invalid date encoding. Expected YYYY-MM-DD"
+            )
+        }
+      }
+    }
+  }
+
   describe("filtering by genre concept ids") {
 
     // This work has a single compound Genre.


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/wellcomecollection.org/issues/12766

Adding a filter on `items.locations.createdDate` so as to exclude works that have been too recently digitised. This aims to allow time for the thumbnails to be generated and prevent failing e2e test when the thumbnail URLs return 404

### Checklist

- [ ] Does this patch need a change to the documentation?
- [x] Do you need to update the [Catalogue API Swagger][swagger]?

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml

## How to test

Run tests

Run `sbt "project search" "~reStart"` from the root of the project
http://localhost:8080/works?sortOrder=desc&sort=items.locations.createdDate
-> first result is `u3epmef4` from "2026-02-18T08:57:26Z"
http://localhost:8080/works?sortOrder=desc&sort=items.locations.createdDate&items.locations.createdDate.to=2025-12-31
-> first result is `u2rpht4h` from "2025-12-18T20:17:16Z"

## How can we measure success?

No works are displayed on the new online page that do not have a thumbnail 

## Have we considered potential risks?

This filter will only be used behind the scenes to fetch content for the new online page, it will not be user facing
