### PR TITLE
Concepts resilient es client

### DIFF
--- a/concepts/server.ts
+++ b/concepts/server.ts
@@ -2,16 +2,18 @@
 import "./src/services/init-apm";
 
 import createApp from "./src/app";
-import { getElasticClient } from "./src/services/elasticsearch";
+import { ResilientElasticClient } from "./src/services/elasticsearch";
 import { getConfig } from "./config";
 import log from "./src/services/logging";
 
 const config = getConfig();
 
-getElasticClient({ pipelineDate: config.pipelineDate }).then((elastic) => {
-  const app = createApp({ elastic }, config);
-  const port = process.env.PORT ?? 3000;
-  app.listen(port, () => {
-    log.info(`Concepts API listening on port ${port}`);
-  });
-});
+ResilientElasticClient.create({ pipelineDate: config.pipelineDate }).then(
+  (elastic) => {
+    const app = createApp({ elastic }, config);
+    const port = process.env.PORT ?? 3000;
+    app.listen(port, () => {
+      log.info(`Concepts API listening on port ${port}`);
+    });
+  }
+);

--- a/concepts/src/controllers/concept.ts
+++ b/concepts/src/controllers/concept.ts
@@ -14,16 +14,18 @@ const conceptController = (
   config: Config
 ): ConceptHandler => {
   const index = config.conceptsIndex;
-  const elasticClient = clients.elastic;
+  const elastic = clients.elastic;
 
   return asyncHandler(async (req, res) => {
     const id = req.params.id;
     try {
-      const getResponse = await elasticClient.get<Displayable<Concept>>({
-        index,
-        id,
-        _source: ["display"],
-      });
+      const getResponse = await elastic.execute((client) =>
+        client.get<Displayable<Concept>>({
+          index,
+          id,
+          _source: ["display"],
+        })
+      );
 
       res.status(200).json(getResponse._source!.display);
     } catch (error) {

--- a/concepts/src/controllers/concepts.ts
+++ b/concepts/src/controllers/concepts.ts
@@ -26,7 +26,7 @@ const conceptsController = (
   config: Config
 ): ConceptHandler => {
   const index = config.conceptsIndex;
-  const elasticClient = clients.elastic;
+  const elastic = clients.elastic;
   const getPaginationResponse = paginationResponseGetter(config.publicRootUrl);
 
   return asyncHandler(async (req, res) => {
@@ -49,11 +49,13 @@ const conceptsController = (
         return;
       }
 
-      const mgetResponse = await elasticClient.mget<Displayable<Concept>>({
-        index,
-        body: { ids: uniqueIds },
-        _source: ["display"],
-      } as any); // typing gap in elastic client generics for mget
+      const mgetResponse = await elastic.execute((client) =>
+        client.mget<Displayable<Concept>>({
+          index,
+          body: { ids: uniqueIds },
+          _source: ["display"],
+        } as any)
+      ); // typing gap in elastic client generics for mget
 
       // Map id -> concept for quick lookup
       const docsMap = new Map<string, Concept>();
@@ -81,49 +83,52 @@ const conceptsController = (
 
     const queryString = req.query.query;
     const identifierTypeFilter = req.query["identifiers.identifierType"];
-    const searchResponse = await elasticClient.search<Displayable<Concept>>({
-      index,
-      body: {
-        ...paginationElasticBody(req.query),
-        _source: ["display"],
-        track_total_hits: true,
-        query: {
-          bool: {
-            should: queryString
-              ? [
-                  {
-                    match: {
-                      "query.identifiers.value": {
-                        query: queryString,
-                        analyzer: "whitespace",
-                        operator: "OR",
-                        boost: 1000,
+    const searchResponse = await elastic.execute((client) =>
+      client.search<Displayable<Concept>>({
+        index,
+        body: {
+          ...paginationElasticBody(req.query),
+          _source: ["display"],
+          track_total_hits: true,
+          query: {
+            bool: {
+              should: queryString
+                ? [
+                    {
+                      match: {
+                        "query.identifiers.value": {
+                          query: queryString,
+                          analyzer: "whitespace",
+                          operator: "OR",
+                          boost: 1000,
+                        },
                       },
                     },
-                  },
-                  {
-                    multi_match: {
-                      query: queryString,
-                      fields: ["query.label", "query.alternativeLabels"],
-                      type: "cross_fields",
+                    {
+                      multi_match: {
+                        query: queryString,
+                        fields: ["query.label", "query.alternativeLabels"],
+                        type: "cross_fields",
+                      },
                     },
-                  },
-                ]
-              : [],
-            filter: identifierTypeFilter
-              ? [
-                  {
-                    term: {
-                      "query.identifiers.identifierType": identifierTypeFilter,
+                  ]
+                : [],
+              filter: identifierTypeFilter
+                ? [
+                    {
+                      term: {
+                        "query.identifiers.identifierType":
+                          identifierTypeFilter,
+                      },
                     },
-                  },
-                ]
-              : [],
+                  ]
+                : [],
+            },
           },
+          sort: queryString ? ["_score"] : ["query.id"],
         },
-        sort: queryString ? ["_score"] : ["query.id"],
-      },
-    });
+      })
+    );
 
     const results = searchResponse.hits.hits.flatMap((hit) =>
       hit._source ? [hit._source.display] : []

--- a/concepts/src/services/elasticsearch.ts
+++ b/concepts/src/services/elasticsearch.ts
@@ -1,5 +1,10 @@
-import { Client, ClientOptions } from "@elastic/elasticsearch";
+import {
+  Client,
+  ClientOptions,
+  errors as elasticErrors,
+} from "@elastic/elasticsearch";
 import { getSecret } from "./aws";
+import log from "./logging";
 
 type ClientParameters = {
   pipelineDate: string;
@@ -28,9 +33,54 @@ const getElasticClientConfig = async ({
   };
 };
 
-export const getElasticClient = async (
-  params: ClientParameters
-): Promise<Client> => {
-  const config = await getElasticClientConfig(params);
-  return new Client(config);
+const isAuthError = (error: unknown): boolean => {
+  if (error instanceof elasticErrors.ResponseError) {
+    return error.statusCode === 401 || error.statusCode === 403;
+  }
+  return false;
 };
+
+export class ResilientElasticClient {
+  private client: Client;
+  private readonly params: ClientParameters;
+  private readonly MAX_RETRIES = 3;
+
+  public constructor(client: Client, params: ClientParameters) {
+    this.client = client;
+    this.params = params;
+  }
+
+  static async create(
+    params: ClientParameters
+  ): Promise<ResilientElasticClient> {
+    const config = await getElasticClientConfig(params);
+    const client = new Client(config);
+    return new ResilientElasticClient(client, params);
+  }
+
+  private async refreshClient(): Promise<void> {
+    log.info("Refreshing Elasticsearch client due to auth error");
+    const config = await getElasticClientConfig(this.params);
+    this.client = new Client(config);
+  }
+
+  async execute<T>(operation: (client: Client) => Promise<T>): Promise<T> {
+    for (let attempt = 0; attempt < this.MAX_RETRIES; attempt++) {
+      try {
+        return await operation(this.client);
+      } catch (error) {
+        if (isAuthError(error) && attempt < this.MAX_RETRIES - 1) {
+          log.warn(
+            `Elasticsearch auth error on attempt ${attempt + 1}/${
+              this.MAX_RETRIES
+            }, refreshing client...`
+          );
+          await this.refreshClient();
+          continue;
+        }
+        throw error;
+      }
+    }
+    throw new Error("Unexpected: max retries exceeded");
+  }
+}

--- a/concepts/src/services/elasticsearch.ts
+++ b/concepts/src/services/elasticsearch.ts
@@ -44,6 +44,7 @@ export class ResilientElasticClient {
   private client: Client;
   private readonly params: ClientParameters;
   private readonly MAX_RETRIES = 3;
+  private pendingRefresh: Promise<void> | null = null;
 
   public constructor(client: Client, params: ClientParameters) {
     this.client = client;
@@ -59,9 +60,23 @@ export class ResilientElasticClient {
   }
 
   private async refreshClient(): Promise<void> {
-    log.info("Refreshing Elasticsearch client due to auth error");
-    const config = await getElasticClientConfig(this.params);
-    this.client = new Client(config);
+    if (this.pendingRefresh) {
+      return this.pendingRefresh;
+    }
+
+    const createNewClient = async () => {
+      log.info("Refreshing Elasticsearch client due to auth error");
+      const config = await getElasticClientConfig(this.params);
+      this.client = new Client(config);
+    };
+
+    this.pendingRefresh = createNewClient();
+
+    try {
+      await this.pendingRefresh;
+    } finally {
+      this.pendingRefresh = null;
+    }
   }
 
   async execute<T>(operation: (client: Client) => Promise<T>): Promise<T> {

--- a/concepts/src/types.ts
+++ b/concepts/src/types.ts
@@ -1,8 +1,8 @@
 import { PaginationResponse } from "./controllers/pagination";
-import { Client as ElasticClient } from "@elastic/elasticsearch";
+import { ResilientElasticClient } from "./services/elasticsearch";
 
 export type Clients = {
-  elastic: ElasticClient;
+  elastic: ResilientElasticClient;
 };
 
 export type Displayable<T = any> = {

--- a/concepts/test/fixtures/elasticsearch.ts
+++ b/concepts/test/fixtures/elasticsearch.ts
@@ -102,5 +102,5 @@ export const mockedElasticsearchClient = <T extends Identifiable>({
     node: "http://test:9200",
     Connection: mock.getConnection(),
   });
-  return new ResilientElasticClient(client, { pipelineDate: "" });
+  return new ResilientElasticClient(client, { pipelineDate: "2020-01-01" });
 };

--- a/concepts/test/fixtures/elasticsearch.ts
+++ b/concepts/test/fixtures/elasticsearch.ts
@@ -1,5 +1,6 @@
 import { Client, errors } from "@elastic/elasticsearch";
 import Mock from "@elastic/elasticsearch-mock";
+import { ResilientElasticClient } from "../../src/services/elasticsearch";
 
 type Identifiable = {
   id: string;
@@ -97,8 +98,9 @@ export const mockedElasticsearchClient = <T extends Identifiable>({
     }
   );
 
-  return new Client({
+  const client = new Client({
     node: "http://test:9200",
     Connection: mock.getConnection(),
   });
+  return new ResilientElasticClient(client, { pipelineDate: "" });
 };

--- a/concepts/test/resilientElasticClient.test.ts
+++ b/concepts/test/resilientElasticClient.test.ts
@@ -1,4 +1,4 @@
-import { errors } from "@elastic/elasticsearch";
+import { Client, errors } from "@elastic/elasticsearch";
 import { ResilientElasticClient } from "../src/services/elasticsearch";
 
 // Mock Client constructor so neither initial nor refreshed clients are real
@@ -15,10 +15,16 @@ jest.mock("../src/services/aws", () => ({
   getSecret: jest.fn().mockResolvedValue("mocked-value"),
 }));
 
+const MockedClient = Client as jest.Mock;
+
 const getResilient = () =>
   ResilientElasticClient.create({ pipelineDate: "2025-01-01" });
 
 describe("ResilientElasticClient", () => {
+  beforeEach(() => {
+    MockedClient.mockClear();
+  });
+
   it("returns the result of a successful operation", async () => {
     const resilient = await getResilient();
     const operation = jest.fn().mockResolvedValue("ok");
@@ -26,6 +32,7 @@ describe("ResilientElasticClient", () => {
     const result = await resilient.execute(operation);
     expect(result).toBe("ok");
     expect(operation).toHaveBeenCalledTimes(1);
+    expect(MockedClient).toHaveBeenCalledTimes(1);
   });
 
   it("throws non-auth errors immediately without retrying", async () => {
@@ -36,6 +43,7 @@ describe("ResilientElasticClient", () => {
       "network failure"
     );
     expect(operation).toHaveBeenCalledTimes(1);
+    expect(MockedClient).toHaveBeenCalledTimes(1);
   });
 
   it.each([401, 403])(
@@ -58,6 +66,7 @@ describe("ResilientElasticClient", () => {
       const result = await resilient.execute(operation);
       expect(result).toBe("success");
       expect(operation).toHaveBeenCalledTimes(2);
+      expect(MockedClient).toHaveBeenCalledTimes(2);
     }
   );
 
@@ -78,6 +87,7 @@ describe("ResilientElasticClient", () => {
     );
     // 3 attempts total (initial + 2 retries)
     expect(operation).toHaveBeenCalledTimes(3);
+    expect(MockedClient).toHaveBeenCalledTimes(3);
   });
 
   it("recovers on the last possible attempt", async () => {
@@ -99,5 +109,6 @@ describe("ResilientElasticClient", () => {
     const result = await resilient.execute(operation);
     expect(result).toBe("recovered");
     expect(operation).toHaveBeenCalledTimes(3);
+    expect(MockedClient).toHaveBeenCalledTimes(3);
   });
 });

--- a/concepts/test/resilientElasticClient.test.ts
+++ b/concepts/test/resilientElasticClient.test.ts
@@ -1,0 +1,103 @@
+import { errors } from "@elastic/elasticsearch";
+import { ResilientElasticClient } from "../src/services/elasticsearch";
+
+// Mock Client constructor so neither initial nor refreshed clients are real
+jest.mock("@elastic/elasticsearch", () => {
+  const actual = jest.requireActual("@elastic/elasticsearch");
+  return {
+    ...actual,
+    Client: jest.fn().mockImplementation(() => ({})),
+  };
+});
+
+// Mock getSecret so refreshClient() -> getElasticClientConfig() can resolve
+jest.mock("../src/services/aws", () => ({
+  getSecret: jest.fn().mockResolvedValue("mocked-value"),
+}));
+
+const getResilient = () =>
+  ResilientElasticClient.create({ pipelineDate: "2025-01-01" });
+
+describe("ResilientElasticClient", () => {
+  it("returns the result of a successful operation", async () => {
+    const resilient = await getResilient();
+    const operation = jest.fn().mockResolvedValue("ok");
+
+    const result = await resilient.execute(operation);
+    expect(result).toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws non-auth errors immediately without retrying", async () => {
+    const resilient = await getResilient();
+    const operation = jest.fn().mockRejectedValue(new Error("network failure"));
+
+    await expect(resilient.execute(operation)).rejects.toThrow(
+      "network failure"
+    );
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([401, 403])(
+    "retries on %i auth errors and succeeds on subsequent attempt",
+    async (statusCode) => {
+      const resilient = await getResilient();
+
+      const authError = new errors.ResponseError({
+        statusCode,
+        warnings: null,
+        meta: {} as any,
+        body: { error: "security_exception" },
+      });
+
+      const operation = jest
+        .fn()
+        .mockRejectedValueOnce(authError)
+        .mockResolvedValueOnce("success");
+
+      const result = await resilient.execute(operation);
+      expect(result).toBe("success");
+      expect(operation).toHaveBeenCalledTimes(2);
+    }
+  );
+
+  it("gives up after MAX_RETRIES auth failures and throws the last error", async () => {
+    const resilient = await getResilient();
+
+    const authError = new errors.ResponseError({
+      statusCode: 401,
+      warnings: null,
+      meta: {} as any,
+      body: { error: "security_exception" },
+    });
+
+    const operation = jest.fn().mockRejectedValue(authError);
+
+    await expect(resilient.execute(operation)).rejects.toThrow(
+      errors.ResponseError
+    );
+    // 3 attempts total (initial + 2 retries)
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+
+  it("recovers on the last possible attempt", async () => {
+    const resilient = await getResilient();
+
+    const authError = new errors.ResponseError({
+      statusCode: 401,
+      warnings: null,
+      meta: {} as any,
+      body: { error: "security_exception" },
+    });
+
+    const operation = jest
+      .fn()
+      .mockRejectedValueOnce(authError)
+      .mockRejectedValueOnce(authError)
+      .mockResolvedValueOnce("recovered");
+
+    const result = await resilient.execute(operation);
+    expect(result).toBe("recovered");
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## What does this change?

Make the concept API resilient to API key changes in the same way as the Scala works API.

### Checklist

- [ ] Does this patch need a change to the documentation?
- [ ] Do you need to update the [Catalogue API Swagger][swagger]?

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml

## How to test

I tested this change by simulating an API key change in Secrets Manager and verified that the API successfully picked up the new key.

## How can we measure success?

The concepts API can pick up new Elasticsearch API keys from Secrets Manager at runtime.

## Have we considered potential risks?

This change is relatively low-risk and will be tested in staging.