### PR TITLE
Use new works and concepts indexes

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
@@ -33,7 +33,7 @@ object ElasticConfig {
   // We use this to share config across Scala API applications
   // i.e. The API and the snapshot generator.
   val defaultPipelineDate = "2025-10-02"
-  val defaultWorksIndexDate = "2025-11-20"
+  val defaultWorksIndexDate = "2026-03-03"
   val defaultImagesIndexDate = "2025-10-02"
 }
 

--- a/concepts/config.ts
+++ b/concepts/config.ts
@@ -11,7 +11,7 @@ const environment = environmentSchema.parse(process.env);
 
 const config = {
   pipelineDate: "2025-10-02",
-  conceptsIndex: "concepts-indexed-2025-10-09",
+  conceptsIndex: "concepts-indexed-2026-03-03",
   publicRootUrl: new URL(environment.PUBLIC_ROOT_URL),
 };
 


### PR DESCRIPTION
## What does this change?

Switch to new indexes following https://github.com/wellcomecollection/catalogue-pipeline/pull/3255

### Checklist

- [ ] Does this patch need a change to the documentation?
- [ ] Do you need to update the [Catalogue API Swagger][swagger]?

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml

## How to test

Run catalogue API locally connected to the new indexes. Verify that changes listed in https://github.com/wellcomecollection/catalogue-pipeline/pull/3255 are in place by visiting theme pages synonymous with one of [these](https://github.com/wellcomecollection/catalogue-pipeline/blob/811fffd40447c3fb66fc53a3efb027e866231f7a/catalogue_graph/src/sources/weco_concepts/wellcome_collection_authority.csv) WeCo authority concepts.


## Have we considered potential risks?

This is a low-risk change but if we do discover an issue, we can temporarily switch to the old indexes.