### PR TITLE
Use new images index (2026-04-29)

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
@@ -34,7 +34,7 @@ object ElasticConfig {
   // i.e. The API and the snapshot generator.
   val defaultPipelineDate = "2025-10-02"
   val defaultWorksIndexDate = "2026-03-03"
-  val defaultImagesIndexDate = "2025-10-02"
+  val defaultImagesIndexDate = "2026-04-29"
 }
 
 sealed trait VectorType


### PR DESCRIPTION
## What does this change?

https://github.com/wellcomecollection/platform/issues/6331

Switch to a new images index (populated by the Python ingestor). Documents in this index use standard concept labels (bringing the index in line with the works index), but otherwise they should be identical to documents in the existing production index. 

## How to test

* Run the frontend locally connected to the new index and verify that images use standard concept labels and that other functionality is unchanged.

## How can we measure success?

Using standard concept labels makes the images index consistent with the works index and resolves a few known issues with filtering/aggregations.

## Have we considered potential risks?

The new index is populated using new code which hasn't been tested in production yet. It's possible that there are unknown issues with this code, leading to invalid or missing image documents. To mitigate this risk, the existing Scala ingestor will keep running in parallel, populating the old index (2025-10-02), so that we can switch back to it at any time. 

