### PR TITLE
Add API Gateway 5xx and latency alarms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .idea
 *.iml
 .lambda_hashes.json
-terraform.plan
+*.plan
 .terraform
 **/.terraform
 shared_infra/.releases

--- a/terraform/catalogue_api/locals.tf
+++ b/terraform/catalogue_api/locals.tf
@@ -10,15 +10,8 @@ locals {
   items_repository    = data.terraform_remote_state.catalogue_api_shared.outputs["ecr_items_repository_url"]
   concepts_repository = data.terraform_remote_state.catalogue_api_shared.outputs["ecr_concepts_repository_url"]
 
-  // The monitoring stack has had a Slack alert lambda listening on this
-  // topic since it was created, but nothing ever published to it: no
-  // CloudWatch alarm existed for the catalogue API, which is why the
-  // July 2026 search outage (5xx rate above 90%) alerted nobody.
   api_gateway_alerts_topic_arn = data.terraform_remote_state.monitoring.outputs["catalogue_api_gateway_alerts_topic_arn"]
 
-  // Raw CloudWatch alarm notifications rendered in Slack by AWS Chatbot,
-  // used for alarms (eg latency) that the 5xx Slack lambda would describe
-  // misleadingly as "errors in the API".
   chatbot_topic_arn = data.terraform_remote_state.monitoring.outputs["chatbot_topic_arn"]
 
   apm_secret_config = {

--- a/terraform/catalogue_api/locals.tf
+++ b/terraform/catalogue_api/locals.tf
@@ -10,6 +10,17 @@ locals {
   items_repository    = data.terraform_remote_state.catalogue_api_shared.outputs["ecr_items_repository_url"]
   concepts_repository = data.terraform_remote_state.catalogue_api_shared.outputs["ecr_concepts_repository_url"]
 
+  // The monitoring stack has had a Slack alert lambda listening on this
+  // topic since it was created, but nothing ever published to it: no
+  // CloudWatch alarm existed for the catalogue API, which is why the
+  // July 2026 search outage (5xx rate above 90%) alerted nobody.
+  api_gateway_alerts_topic_arn = data.terraform_remote_state.monitoring.outputs["catalogue_api_gateway_alerts_topic_arn"]
+
+  // Raw CloudWatch alarm notifications rendered in Slack by AWS Chatbot,
+  // used for alarms (eg latency) that the 5xx Slack lambda would describe
+  // misleadingly as "errors in the API".
+  chatbot_topic_arn = data.terraform_remote_state.monitoring.outputs["chatbot_topic_arn"]
+
   apm_secret_config = {
     apm_server_url = "catalogue/api/apm_server_url"
     apm_secret     = "catalogue/api/apm_secret"

--- a/terraform/catalogue_api/main.tf
+++ b/terraform/catalogue_api/main.tf
@@ -3,6 +3,7 @@ module "catalogue_api_prod" {
 
   environment_name  = "prod"
   external_hostname = "api.wellcomecollection.org"
+  enable_api_alarms = true
 
   container_images = {
     search   = "${local.search_repository}:env.prod"

--- a/terraform/catalogue_api/main.tf
+++ b/terraform/catalogue_api/main.tf
@@ -24,6 +24,9 @@ module "catalogue_api_prod" {
   apm_secret_config    = local.apm_secret_config
   sierra_secret_config = local.sierra_secret_config
 
+  api_gateway_alerts_topic_arn = local.api_gateway_alerts_topic_arn
+  chatbot_topic_arn            = local.chatbot_topic_arn
+
   providers = {
     aws.dns        = aws.dns
     aws.experience = aws.experience
@@ -55,6 +58,9 @@ module "catalogue_api_stage" {
 
   apm_secret_config    = local.apm_secret_config
   sierra_secret_config = local.sierra_secret_config
+
+  api_gateway_alerts_topic_arn = local.api_gateway_alerts_topic_arn
+  chatbot_topic_arn            = local.chatbot_topic_arn
 
   providers = {
     aws.dns        = aws.dns

--- a/terraform/catalogue_api/terraform.tf
+++ b/terraform/catalogue_api/terraform.tf
@@ -52,3 +52,17 @@ data "terraform_remote_state" "catalogue_api_shared" {
     region = "eu-west-1"
   }
 }
+
+data "terraform_remote_state" "monitoring" {
+  backend = "s3"
+
+  config = {
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
+
+    bucket = "wellcomecollection-platform-infra"
+    key    = "terraform/monitoring.tfstate"
+    region = "eu-west-1"
+  }
+}

--- a/terraform/modules/stack/alarms.tf
+++ b/terraform/modules/stack/alarms.tf
@@ -1,0 +1,47 @@
+# During the July 2026 search outage the API Gateway 5xx rate exceeded 90%
+# and nobody was alerted: the monitoring stack's Slack lambda had been
+# listening on the catalogue_api_gateway_5xx_alarm topic since it was
+# created, but no alarm had ever been defined to publish to it. These are
+# those alarms. The 5xx alarm follows the identity account's convention
+# (any 5xx in a minute alerts); the latency alarm is a slower-burn signal
+# that would have fired within a few minutes of the outage starting.
+
+resource "aws_cloudwatch_metric_alarm" "api_gateway_5xx" {
+  alarm_name          = "catalogue-api-${var.environment_name}-5xx-alarm"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "5XXError"
+  namespace           = "AWS/ApiGateway"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ApiName = aws_api_gateway_rest_api.catalogue.name
+  }
+
+  alarm_actions = [var.api_gateway_alerts_topic_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_gateway_latency" {
+  alarm_name          = "catalogue-api-${var.environment_name}-latency-alarm"
+  alarm_description   = "p95 latency for ${aws_api_gateway_rest_api.catalogue.name} has been over 10s for 3 minutes"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "Latency"
+  namespace           = "AWS/ApiGateway"
+  period              = 60
+  extended_statistic  = "p95"
+  threshold           = 10000
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ApiName = aws_api_gateway_rest_api.catalogue.name
+  }
+
+  # This goes to the Chatbot topic rather than the 5xx Slack lambda,
+  # because that lambda's message template describes every alarm as
+  # "{n} errors in the API", which would be misleading for latency.
+  alarm_actions = [var.chatbot_topic_arn]
+}

--- a/terraform/modules/stack/alarms.tf
+++ b/terraform/modules/stack/alarms.tf
@@ -1,12 +1,6 @@
-# During the July 2026 search outage the API Gateway 5xx rate exceeded 90%
-# and nobody was alerted: the monitoring stack's Slack lambda had been
-# listening on the catalogue_api_gateway_5xx_alarm topic since it was
-# created, but no alarm had ever been defined to publish to it. These are
-# those alarms. The 5xx alarm follows the identity account's convention
-# (any 5xx in a minute alerts); the latency alarm is a slower-burn signal
-# that would have fired within a few minutes of the outage starting.
-
 resource "aws_cloudwatch_metric_alarm" "api_gateway_5xx" {
+  count = var.enable_api_alarms ? 1 : 0
+
   alarm_name          = "catalogue-api-${var.environment_name}-5xx-alarm"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
@@ -25,6 +19,8 @@ resource "aws_cloudwatch_metric_alarm" "api_gateway_5xx" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "api_gateway_latency" {
+  count = var.enable_api_alarms ? 1 : 0
+
   alarm_name          = "catalogue-api-${var.environment_name}-latency-alarm"
   alarm_description   = "p95 latency for ${aws_api_gateway_rest_api.catalogue.name} has been over 10s for 3 minutes"
   comparison_operator = "GreaterThanThreshold"
@@ -40,8 +36,7 @@ resource "aws_cloudwatch_metric_alarm" "api_gateway_latency" {
     ApiName = aws_api_gateway_rest_api.catalogue.name
   }
 
-  # This goes to the Chatbot topic rather than the 5xx Slack lambda,
-  # because that lambda's message template describes every alarm as
-  # "{n} errors in the API", which would be misleading for latency.
+  # Chatbot rather than the 5xx Slack lambda, whose message template
+  # only describes error counts.
   alarm_actions = [var.chatbot_topic_arn]
 }

--- a/terraform/modules/stack/alarms.tf
+++ b/terraform/modules/stack/alarms.tf
@@ -8,8 +8,10 @@ resource "aws_cloudwatch_metric_alarm" "api_gateway_5xx" {
   namespace           = "AWS/ApiGateway"
   period              = 60
   statistic           = "Sum"
-  threshold           = 0
-  treat_missing_data  = "notBreaching"
+  # Normal operation produces short bursts of up to ~50 5xxs a minute;
+  # only alert well above that background.
+  threshold          = 100
+  treat_missing_data = "notBreaching"
 
   dimensions = {
     ApiName = aws_api_gateway_rest_api.catalogue.name

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -51,3 +51,13 @@ variable "sierra_secret_config" {
     sierra_api_secret = string
   })
 }
+
+variable "api_gateway_alerts_topic_arn" {
+  type        = string
+  description = "SNS topic that routes API Gateway 5xx alarms to Slack via the monitoring stack"
+}
+
+variable "chatbot_topic_arn" {
+  type        = string
+  description = "SNS topic rendered in Slack by AWS Chatbot, for alarms without a bespoke Slack lambda"
+}

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -61,3 +61,9 @@ variable "chatbot_topic_arn" {
   type        = string
   description = "SNS topic rendered in Slack by AWS Chatbot, for alarms without a bespoke Slack lambda"
 }
+
+variable "enable_api_alarms" {
+  type        = bool
+  default     = false
+  description = "Off for stage, whose backend is stopped overnight and 5xxs steadily out of hours"
+}


### PR DESCRIPTION
## What does this change?

During the wellcomecollection.org outage on 2026-07-06 the catalogue API's 5xx rate went above 90% at API Gateway and no alert fired. When we looked into it we found that the monitoring stack's Slack alert lambda has been subscribed to the `catalogue_api_gateway_5xx_alarm` SNS topic ever since that topic was created, but no CloudWatch alarm has ever existed to publish to it. The plumbing was in place, there was just nothing at the other end of the pipe.

This adds the missing alarms.

- `terraform/modules/stack/alarms.tf` (new) defines two API Gateway alarms, both gated behind a new `enable_api_alarms` variable:
  - A `5XXError` alarm (`Sum > 100` over 60s) routed to the existing `catalogue_api_gateway_5xx_alarm` topic and its Slack lambda. This started at `> 0` to match the identity account's convention, but 14 days of per-minute data showed 68 minutes with at least one 5xx (about five a day, bursts peaking at 54 in a minute), so `> 0` would have paged daily. 100 clears that background with headroom and still fires in the first minute of a real incident, which opened at over 1,100 a minute. Slower burns are covered by the latency alarm below and the CloudFront 5xx-rate alarm.
  - A p95 `Latency` alarm (over 10s for 3 consecutive minutes) routed to the platform Chatbot topic instead of the Slack lambda. The 5xx Slack lambda's message template only describes error counts, so a latency breach would render misleadingly through it.
- Alarms are enabled for prod only. Stage deliberately has no alarms: its backend is stopped outside office hours, and the stage gateway returned 5xxs in 117 of the last 177 hours, so a `> 0` threshold would alert every night. `enable_api_alarms` defaults to `false` and is only set to `true` on the prod module.
- `terraform/catalogue_api/{terraform,locals,main}.tf` add a `monitoring` remote state data source and wire the two topic ARNs (`catalogue_api_gateway_alerts_topic_arn` and `chatbot_topic_arn`) into the stack modules.
- `.gitignore` widens the ignored `terraform.plan` to `*.plan`.

## How to test

The alarm resources have already been applied to prod via a targeted `terraform apply` (alarm resources only). Both prod alarms are currently in OK state.

The full delivery pipeline was tested end to end by forcing the alarms into ALARM state:

- The 5xx route delivered "There were 7 errors in the API" to Slack via the monitoring lambda.
- The latency route delivered to Slack via Chatbot.

The cross-account publish to the platform Chatbot topic is permitted by that topic's existing policy, whose allowed source accounts already include `756629837203`.

Two things worth flagging for a reviewer:

- The full plan also shows pre-existing, unrelated drift on `aws_api_gateway_gateway_response` formatting (jsonencode vs string) in both environments. This was left untouched for the repo owners to decide on, which is why the apply here was targeted at the alarm resources only.
- Forcing the alarms exposed a latent bug in the shared `metric_to_slack_alert` lambda (in platform-infrastructure): it raises a `TypeError` rather than degrading gracefully when an alarm's `NewStateReason` does not match its "Threshold Crossed" regex. That will be fixed separately in platform-infrastructure and does not block this change.

## How can we measure success?

The next time the catalogue API's 5xx rate or p95 latency crosses these thresholds, an alert should reach Slack. The immediate marker of success is that the `catalogue_api_gateway_5xx_alarm` topic now has an alarm publishing to it rather than sitting idle. Both prod alarms sitting in OK state under normal conditions, and firing correctly under the forced test above, is the evidence that the pipeline works end to end.

## Have we considered potential risks?

- Stage is intentionally left without alarms to avoid nightly noise from its out-of-hours 5xxs. If that noise were routed to the same channel it would quickly train people to ignore the alarm.
- Latency alarms go via Chatbot rather than the 5xx Slack lambda on purpose, because that lambda's message template would misrepresent a latency breach as an error count.
- The changes are additive and gated behind `enable_api_alarms` (default `false`), so there is no change to stage. The prod alarm resources were applied with a targeted apply to avoid touching the unrelated pre-existing gateway_response drift.

