### PR TITLE
Bump pinned Python dependencies flagged by Dependabot

### DIFF
--- a/diff_tool/requirements.txt
+++ b/diff_tool/requirements.txt
@@ -6,7 +6,7 @@
 #
 anyio==3.5.0
     # via httpx
-certifi==2021.10.8
+certifi==2024.7.4
     # via
     #   httpcore
     #   httpx

--- a/snapshots/snapshot_recorder/requirements.txt
+++ b/snapshots/snapshot_recorder/requirements.txt
@@ -10,7 +10,7 @@ elasticsearch==7.9.1
     # via -r requirements.in
 humanize==3.0.1
     # via -r requirements.in
-urllib3==2.3.0
+urllib3==2.7.0
     # via elasticsearch
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/snapshots/snapshot_scheduler/requirements.txt
+++ b/snapshots/snapshot_scheduler/requirements.txt
@@ -68,7 +68,7 @@ urllib3==1.26.17
     # via
     #   botocore
     #   responses
-werkzeug==3.0.1
+werkzeug==3.1.4
     # via moto
 xmltodict==0.13.0
     # via moto


### PR DESCRIPTION
## What does this change?

Batches up three Dependabot updates to pinned Python requirements:

- urllib3 2.3.0 → 2.7.0 in `snapshots/snapshot_recorder` (closes #919)
- werkzeug 3.0.1 → 3.1.4 in `snapshots/snapshot_scheduler` (closes #879)
- certifi 2021.10.8 → 2024.7.4 in `diff_tool` (closes #870)

These mirror exactly what the Dependabot PRs proposed (pin bumps in the pip-compile output files; the `requirements.in` files are unchanged).

### Checklist

- [x] Does this patch need a change to the documentation? — No
- [x] Do you need to update the [Catalogue API Swagger][swagger]? — No

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml

## How to test

All three requirement sets `pip install` cleanly into fresh virtualenvs with the new pins.

Note: `snapshot_scheduler`'s `test_writes_messages_to_sqs` fails with `TypeError: main() got an unexpected keyword argument 'indices'` — this failure is pre-existing on `main` with the old pins (verified by running the same test against an env built from `main`'s requirements) and is unrelated to this change.

## How can we measure success?

The three Dependabot PRs listed above can be closed, and the associated security alerts clear.

## Have we considered potential risks?

Low risk: werkzeug is a test-only dependency (via moto); urllib3 and certifi are patch/CA-bundle updates to internal snapshot/diff tooling. Nothing requires redeployment to take effect until the tools are next built.

🤖 Generated with Claude Code