### PR TITLE
Add an axiell-collections-testing multiCluster entry for per-request pipeline routing

### DIFF
--- a/docs/multi-cluster-setup.md
+++ b/docs/multi-cluster-setup.md
@@ -58,7 +58,7 @@ because a secret doesn't exist), the cluster is logged and dropped, and requests
 
 Note for local development: the entry uses the cluster's `private_host` secret, which is only reachable from
 inside the VPC. When running the API outside the VPC (e.g. locally), swap `hostSecretPath` to the corresponding
-`public_host` secret (`elasticsearch/es_cluster_2026-07-03/public_host`).
+`public_host` secret (`elasticsearch/es-cluster-2026-07-03/public_host`).
 
 ### Eventually flipping the default
 

--- a/docs/multi-cluster-setup.md
+++ b/docs/multi-cluster-setup.md
@@ -47,3 +47,26 @@ multiCluster {
   }
 }
 ```
+
+## The `new-pipeline` cluster
+
+The `new-pipeline` entry points at the output of the new (Axiell/FOLIO) pipeline, so that its works and images
+indexes can be previewed with `?elasticCluster=new-pipeline` before the default cluster is flipped over.
+
+Like any other additional cluster, if its config fails to parse or its client fails to build at startup (e.g.
+because a secret doesn't exist), the cluster is logged and dropped, and requests selecting it return 404.
+
+Note for local development: the entry uses the cluster's `private_host` secret, which is only reachable from
+inside the VPC. When running the API outside the VPC (e.g. locally), swap `hostSecretPath` to the corresponding
+`public_host` secret (`elasticsearch/es_cluster_2026-07-03/public_host`).
+
+### Eventually flipping the default
+
+The environment default stays on the old pipeline until we're ready to cut over. To flip the default:
+
+1. Update `defaultPipelineDate`, `defaultWorksIndexDate` and `defaultImagesIndexDate` in
+   `common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala`.
+2. Deploy to stage, verify, then deploy to prod.
+
+To roll back, revert the `ElasticConfig` change and redeploy. To remove the `new-pipeline` cluster entirely,
+delete its `multiCluster` entry from `application.conf` and redeploy; requests selecting it will then return 404.

--- a/docs/multi-cluster-setup.md
+++ b/docs/multi-cluster-setup.md
@@ -48,17 +48,19 @@ multiCluster {
 }
 ```
 
-## The `new-pipeline` cluster
+## The `axiell-collections-testing` cluster
 
-The `new-pipeline` entry points at the output of the new (Axiell/FOLIO) pipeline, so that its works and images
-indexes can be previewed with `?elasticCluster=new-pipeline` before the default cluster is flipped over.
+The `axiell-collections-testing` entry points at the output of the new (Axiell/FOLIO) pipeline, so that its works
+and images indexes can be previewed with `?elasticCluster=axiell-collections-testing` before the default cluster is
+flipped over. Its connection secrets live under the pipeline's `elasticsearch/pipeline_storage_2026-07-03/` prefix,
+as created by the `pipeline_new` stack in the catalogue-pipeline repo.
 
 Like any other additional cluster, if its config fails to parse or its client fails to build at startup (e.g.
 because a secret doesn't exist), the cluster is logged and dropped, and requests selecting it return 404.
 
 Note for local development: the entry uses the cluster's `private_host` secret, which is only reachable from
 inside the VPC. When running the API outside the VPC (e.g. locally), swap `hostSecretPath` to the corresponding
-`public_host` secret (`elasticsearch/es-cluster-2026-07-03/public_host`).
+`public_host` secret (`elasticsearch/pipeline_storage_2026-07-03/public_host`).
 
 ### Eventually flipping the default
 
@@ -68,5 +70,5 @@ The environment default stays on the old pipeline until we're ready to cut over.
    `common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala`.
 2. Deploy to stage, verify, then deploy to prod.
 
-To roll back, revert the `ElasticConfig` change and redeploy. To remove the `new-pipeline` cluster entirely,
+To roll back, revert the `ElasticConfig` change and redeploy. To remove the `axiell-collections-testing` cluster entirely,
 delete its `multiCluster` entry from `application.conf` and redeploy; requests selecting it will then return 404.

--- a/search/src/main/resources/application.conf
+++ b/search/src/main/resources/application.conf
@@ -40,11 +40,11 @@ multiCluster.openai {
 }
 
 # The new (Axiell/FOLIO) pipeline; see docs/multi-cluster-setup.md
-multiCluster.new-pipeline {
-  hostSecretPath = "elasticsearch/es-cluster-2026-07-03/private_host"
-  portSecretPath = "elasticsearch/es-cluster-2026-07-03/port"
-  protocolSecretPath = "elasticsearch/es-cluster-2026-07-03/protocol"
-  apiKeySecretPath = "elasticsearch/es-cluster-2026-07-03/catalogue_api/api_key"
+multiCluster.axiell-collections-testing {
+  hostSecretPath = "elasticsearch/pipeline_storage_2026-07-03/private_host"
+  portSecretPath = "elasticsearch/pipeline_storage_2026-07-03/port"
+  protocolSecretPath = "elasticsearch/pipeline_storage_2026-07-03/protocol"
+  apiKeySecretPath = "elasticsearch/pipeline_storage_2026-07-03/catalogue_api/api_key"
   worksIndex = "works-indexed-2026-07-03"
   imagesIndex = "images-indexed-2026-07-03"
 }

--- a/search/src/main/resources/application.conf
+++ b/search/src/main/resources/application.conf
@@ -38,3 +38,13 @@ multiCluster.openai {
     numCandidates = 500
   }
 }
+
+# The new (Axiell/FOLIO) pipeline; see docs/multi-cluster-setup.md
+multiCluster.new-pipeline {
+  hostSecretPath = "elasticsearch/es_cluster_2026-07-03/private_host"
+  portSecretPath = "elasticsearch/es_cluster_2026-07-03/port"
+  protocolSecretPath = "elasticsearch/es_cluster_2026-07-03/protocol"
+  apiKeySecretPath = "elasticsearch/pipeline_storage_2026-07-03/catalogue_api/api_key"
+  worksIndex = "works-indexed-2026-07-03"
+  imagesIndex = "images-indexed-2026-07-03"
+}

--- a/search/src/main/resources/application.conf
+++ b/search/src/main/resources/application.conf
@@ -41,10 +41,10 @@ multiCluster.openai {
 
 # The new (Axiell/FOLIO) pipeline; see docs/multi-cluster-setup.md
 multiCluster.new-pipeline {
-  hostSecretPath = "elasticsearch/es_cluster_2026-07-03/private_host"
-  portSecretPath = "elasticsearch/es_cluster_2026-07-03/port"
-  protocolSecretPath = "elasticsearch/es_cluster_2026-07-03/protocol"
-  apiKeySecretPath = "elasticsearch/pipeline_storage_2026-07-03/catalogue_api/api_key"
+  hostSecretPath = "elasticsearch/es-cluster-2026-07-03/private_host"
+  portSecretPath = "elasticsearch/es-cluster-2026-07-03/port"
+  protocolSecretPath = "elasticsearch/es-cluster-2026-07-03/protocol"
+  apiKeySecretPath = "elasticsearch/es-cluster-2026-07-03/catalogue_api/api_key"
   worksIndex = "works-indexed-2026-07-03"
   imagesIndex = "images-indexed-2026-07-03"
 }

--- a/search/src/test/scala/weco/api/search/ElasticClusterParamTest.scala
+++ b/search/src/test/scala/weco/api/search/ElasticClusterParamTest.scala
@@ -153,8 +153,8 @@ class ElasticClusterParamTest
     it("routes works and images requests to a cluster configured with both indexes") {
       withLocalWorksIndex { defaultWorksIndex =>
         withLocalImagesIndex { defaultImagesIndex =>
-          withLocalWorksIndex { newPipelineWorksIndex =>
-            withLocalImagesIndex { newPipelineImagesIndex =>
+          withLocalWorksIndex { axiellTestingWorksIndex =>
+            withLocalImagesIndex { axiellTestingImagesIndex =>
               val router = new SearchApi(
                 elasticClient = resilientElasticClient,
                 elasticConfig = ElasticConfig(
@@ -162,14 +162,14 @@ class ElasticClusterParamTest
                   worksIndex = Some(defaultWorksIndex.name),
                   imagesIndex = Some(defaultImagesIndex.name)
                 ),
-                additionalElasticClients = Map("new-pipeline" -> resilientElasticClient),
+                additionalElasticClients = Map("axiell-collections-testing" -> resilientElasticClient),
                 additionalElasticConfigs = Map(
-                  "new-pipeline" -> ElasticConfig(
-                    name = "new-pipeline",
-                    hostSecretPath = Some("new-pipeline/host"),
-                    apiKeySecretPath = Some("new-pipeline/key"),
-                    worksIndex = Some(newPipelineWorksIndex.name),
-                    imagesIndex = Some(newPipelineImagesIndex.name)
+                  "axiell-collections-testing" -> ElasticConfig(
+                    name = "axiell-collections-testing",
+                    hostSecretPath = Some("axiell-collections-testing/host"),
+                    apiKeySecretPath = Some("axiell-collections-testing/key"),
+                    worksIndex = Some(axiellTestingWorksIndex.name),
+                    imagesIndex = Some(axiellTestingImagesIndex.name)
                   )
                 ),
                 apiConfig = apiConfig
@@ -177,42 +177,42 @@ class ElasticClusterParamTest
               val routes = router.routes
 
               val defaultWorkId = getKey(getVisibleWork(visibleWorks(0)).display, "id").get.asString.get
-              val newPipelineWorkId = getKey(getVisibleWork(visibleWorks(3)).display, "id").get.asString.get
+              val axiellTestingWorkId = getKey(getVisibleWork(visibleWorks(3)).display, "id").get.asString.get
               val defaultImageId = getTestImageId("images.different-licenses.0")
-              val newPipelineImageId = getTestImageId("images.different-licenses.1")
+              val axiellTestingImageId = getTestImageId("images.different-licenses.1")
 
               indexTestDocuments(defaultWorksIndex, visibleWorks(0))
-              indexTestDocuments(newPipelineWorksIndex, visibleWorks(3))
+              indexTestDocuments(axiellTestingWorksIndex, visibleWorks(3))
               indexTestDocuments(defaultImagesIndex, "images.different-licenses.0")
-              indexTestDocuments(newPipelineImagesIndex, "images.different-licenses.1")
+              indexTestDocuments(axiellTestingImagesIndex, "images.different-licenses.1")
 
               // Works search
-              assertJsonResponseLike(routes, s"$rootPath/works?elasticCluster=new-pipeline") { json =>
+              assertJsonResponseLike(routes, s"$rootPath/works?elasticCluster=axiell-collections-testing") { json =>
                 val jsonStr = json.toString()
-                jsonStr should include(newPipelineWorkId)
+                jsonStr should include(axiellTestingWorkId)
                 jsonStr should not include defaultWorkId
               }
 
               // Single work
-              assertJsonResponseLike(routes, s"$rootPath/works/$newPipelineWorkId?elasticCluster=new-pipeline") { json =>
-                getKey(json, "id").get.asString.get shouldBe newPipelineWorkId
+              assertJsonResponseLike(routes, s"$rootPath/works/$axiellTestingWorkId?elasticCluster=axiell-collections-testing") { json =>
+                getKey(json, "id").get.asString.get shouldBe axiellTestingWorkId
               }
-              Get(s"$rootPath/works/$newPipelineWorkId") ~> routes ~> check {
+              Get(s"$rootPath/works/$axiellTestingWorkId") ~> routes ~> check {
                 status shouldEqual Status.NotFound
               }
 
               // Images search
-              assertJsonResponseLike(routes, s"$rootPath/images?elasticCluster=new-pipeline") { json =>
+              assertJsonResponseLike(routes, s"$rootPath/images?elasticCluster=axiell-collections-testing") { json =>
                 val jsonStr = json.toString()
-                jsonStr should include(newPipelineImageId)
+                jsonStr should include(axiellTestingImageId)
                 jsonStr should not include defaultImageId
               }
 
               // Single image
-              assertJsonResponseLike(routes, s"$rootPath/images/$newPipelineImageId?elasticCluster=new-pipeline") { json =>
-                getKey(json, "id").get.asString.get shouldBe newPipelineImageId
+              assertJsonResponseLike(routes, s"$rootPath/images/$axiellTestingImageId?elasticCluster=axiell-collections-testing") { json =>
+                getKey(json, "id").get.asString.get shouldBe axiellTestingImageId
               }
-              Get(s"$rootPath/images/$newPipelineImageId") ~> routes ~> check {
+              Get(s"$rootPath/images/$axiellTestingImageId") ~> routes ~> check {
                 status shouldEqual Status.NotFound
               }
             }

--- a/search/src/test/scala/weco/api/search/ElasticClusterParamTest.scala
+++ b/search/src/test/scala/weco/api/search/ElasticClusterParamTest.scala
@@ -149,5 +149,76 @@ class ElasticClusterParamTest
           }
       }
     }
+
+    it("routes works and images requests to a cluster configured with both indexes") {
+      withLocalWorksIndex { defaultWorksIndex =>
+        withLocalImagesIndex { defaultImagesIndex =>
+          withLocalWorksIndex { newPipelineWorksIndex =>
+            withLocalImagesIndex { newPipelineImagesIndex =>
+              val router = new SearchApi(
+                elasticClient = resilientElasticClient,
+                elasticConfig = ElasticConfig(
+                  name = "default",
+                  worksIndex = Some(defaultWorksIndex.name),
+                  imagesIndex = Some(defaultImagesIndex.name)
+                ),
+                additionalElasticClients = Map("new-pipeline" -> resilientElasticClient),
+                additionalElasticConfigs = Map(
+                  "new-pipeline" -> ElasticConfig(
+                    name = "new-pipeline",
+                    hostSecretPath = Some("new-pipeline/host"),
+                    apiKeySecretPath = Some("new-pipeline/key"),
+                    worksIndex = Some(newPipelineWorksIndex.name),
+                    imagesIndex = Some(newPipelineImagesIndex.name)
+                  )
+                ),
+                apiConfig = apiConfig
+              )
+              val routes = router.routes
+
+              val defaultWorkId = getKey(getVisibleWork(visibleWorks(0)).display, "id").get.asString.get
+              val newPipelineWorkId = getKey(getVisibleWork(visibleWorks(3)).display, "id").get.asString.get
+              val defaultImageId = getTestImageId("images.different-licenses.0")
+              val newPipelineImageId = getTestImageId("images.different-licenses.1")
+
+              indexTestDocuments(defaultWorksIndex, visibleWorks(0))
+              indexTestDocuments(newPipelineWorksIndex, visibleWorks(3))
+              indexTestDocuments(defaultImagesIndex, "images.different-licenses.0")
+              indexTestDocuments(newPipelineImagesIndex, "images.different-licenses.1")
+
+              // Works search
+              assertJsonResponseLike(routes, s"$rootPath/works?elasticCluster=new-pipeline") { json =>
+                val jsonStr = json.toString()
+                jsonStr should include(newPipelineWorkId)
+                jsonStr should not include defaultWorkId
+              }
+
+              // Single work
+              assertJsonResponseLike(routes, s"$rootPath/works/$newPipelineWorkId?elasticCluster=new-pipeline") { json =>
+                getKey(json, "id").get.asString.get shouldBe newPipelineWorkId
+              }
+              Get(s"$rootPath/works/$newPipelineWorkId") ~> routes ~> check {
+                status shouldEqual Status.NotFound
+              }
+
+              // Images search
+              assertJsonResponseLike(routes, s"$rootPath/images?elasticCluster=new-pipeline") { json =>
+                val jsonStr = json.toString()
+                jsonStr should include(newPipelineImageId)
+                jsonStr should not include defaultImageId
+              }
+
+              // Single image
+              assertJsonResponseLike(routes, s"$rootPath/images/$newPipelineImageId?elasticCluster=new-pipeline") { json =>
+                getKey(json, "id").get.asString.get shouldBe newPipelineImageId
+              }
+              Get(s"$rootPath/images/$newPipelineImageId") ~> routes ~> check {
+                status shouldEqual Status.NotFound
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## What does this change?

Registers the new (Axiell/FOLIO) pipeline's shared ES cluster as a `multiCluster` entry labelled `axiell-collections-testing`, so any works/images request (list and detail) can be routed to the new pipeline with `?elasticCluster=axiell-collections-testing`. This lets staff preview and compare the new pipeline's output before we flip the default, using the existing multi-cluster mechanism. The change is config, tests, and docs only, with no production code changes.

The entry reads its connection secrets from the `elasticsearch/pipeline_storage_2026-07-03/` prefix, written to the catalogue account by the `pipeline_new` stack in the catalogue-pipeline repo.

As with the other additional clusters, the entry is non-essential: if it fails to build at startup it is logged and dropped, and requests selecting it get an explicit 404 rather than falling back to the old pipeline.

The paired front-end change is wellcomecollection/wellcomecollection.org#13253, which adds the staff toggle that sends the param.

Part of wellcomecollection/platform#6421

### Checklist

- [x] Does this patch need a change to the documentation? `docs/multi-cluster-setup.md` updated (new entry, `pipeline_storage_2026-07-03` secret paths, local-dev note, default-flip and rollback steps)
- [ ] Do you need to update the [Catalogue API Swagger][swagger]? No, `elasticCluster` is an existing internal-use param

[swagger]: https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/reference/catalogue.yaml

## How to test

`ElasticClusterParamTest` (5 tests) covers routing for `/works`, `/works/{id}`, `/images`, `/images/{id}` on a cluster with both indexes configured.

Verified end-to-end locally (2026-07-21) with the paired front-end PR driving the param through the local nginx `api-dev` setup:

- With the committed config the cluster builds at startup and toggled requests return 200 with results from the `2026-07-03` indexes, which are empty until the new pipeline populates them. When running the API outside the VPC (e.g. locally), swap the entry's `hostSecretPath` to the `public_host` secret per `docs/multi-cluster-setup.md`.
- If the secrets or cluster are ever missing, the cluster is dropped at startup and `?elasticCluster=axiell-collections-testing` returns an explicit `404 "Cluster 'axiell-collections-testing' is not configured"`, while default traffic is unaffected.

Once the new pipeline populates the indexes, `GET /catalogue/v2/works?query=medicine&elasticCluster=axiell-collections-testing` returns results from `works-indexed-2026-07-03`.

## How can we measure success?

Staff can compare old and new pipeline results on the same environment by adding or removing the param (or using the front-end toggle), supporting sign-off of the Axiell/FOLIO migration without a deploy.

## Have we considered potential risks?

- Requests without the param are untouched; the default cluster wiring is unchanged.
- A misconfigured or unavailable cluster can't crash the API (non-essential build) and can't silently serve old data (explicit 404).
- If the secrets are ever missing, deploying is still safe: the cluster is dropped with a logged error.
