### PR TITLE
Link to the rank repository from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,30 +14,31 @@ It combines our different source catalogues and presents them through a single s
 We have two services for searching the museum and library collections.
 These APIs are freely available, and allow anybody to use our data.
 
--	The **search API** is for running ad hoc searches, and it powers the collections search at [wellcomecollection.org/collections][search].
-	We have [documentation][search_docs] for external developers who want to use this API.
+- The **search API** is for running ad hoc searches, and it powers the collections search at [wellcomecollection.org/collections][search].
+  We have [documentation][search_docs] for external developers who want to use this API.
 
-	To help us develop the search API, we have a tool called **rank**.
-	This helps us measure the quality of our search ranking, by checking that certain queries return known-relevant results.
+  To help us develop the search API, we have a tool called [**rank**][rank], which lives in its own repository.
+  This helps us measure the quality of our search ranking, by checking that certain queries return known-relevant results.
 
--	The **catalogue datasets** provide a daily snapshot of all the works in the search API.
-	It's useful for batch queries or analysis that doesn't work with the search API.
-	These snapshots are [freely available to download][snapshots].
+- The **catalogue datasets** provide a daily snapshot of all the works in the search API.
+  It's useful for batch queries or analysis that doesn't work with the search API.
+  These snapshots are [freely available to download][snapshots].
 
 Both of these services read the data populated by the [catalogue pipeline][pipeline].
 
 We also have two services for dealing with items in the library stores.
 These APIs are used on the Wellcome Collection website, but they require authentication and aren't publicly available:
 
--	The **items API** gets the status of an item: for example, whether it's on hold, or available for requesting, or temporarily unavailable.
-	It queries source systems directly, so it always has the most up-to-date information.
+- The **items API** gets the status of an item: for example, whether it's on hold, or available for requesting, or temporarily unavailable.
+  It queries source systems directly, so it always has the most up-to-date information.
 
--	Library members can [request items from the library stores][requests].
-	The **requests API** allows them to manage their requests on the Wellcome Collection website: either placing requests, or checking the status of their outstanding requests.
-	It forward requests to our library management systems, so that library staff know which items to retrieve from the stores.
+- Library members can [request items from the library stores][requests].
+  The **requests API** allows them to manage their requests on the Wellcome Collection website: either placing requests, or checking the status of their outstanding requests.
+  It forward requests to our library management systems, so that library staff know which items to retrieve from the stores.
 
 See [notes on the requesting flow](docs/requesting_flow.md) for more information.
 
+[rank]: https://github.com/wellcomecollection/rank
 [search]: https://wellcomecollection.org/collections
 [search_docs]: https://developers.wellcomecollection.org/api/catalogue
 [pipeline]: https://github.com/wellcomecollection/catalogue-pipeline


### PR DESCRIPTION
## What does this change?

The **rank** search-relevance tool no longer lives in this repository, so the README's mention of it was misleading. This updates the README so **rank** links out to its current home at https://github.com/wellcomecollection/rank, and adds the matching link reference at the bottom of the file.

Most of the diff is prettier reformatting. The README hadn't been run through the repo's prettier config before, so the list markers changed from tabs to spaces across the block. The substantive change is just two lines: the sentence that now links **rank** to its repository, and the `[rank]:` link definition.

The pre-commit hook normally handles the formatting, but the generated husky shim was missing in this worktree, so prettier was run by hand.

### Checklist

- [x] Does this patch need a change to the documentation? This is a documentation-only change (README).
- [x] Does this change the API surface? No, so no OpenAPI spec update is needed.

## How to test

Read the updated README and confirm the **rank** paragraph links to https://github.com/wellcomecollection/rank and that the `[rank]:` reference resolves. The rest of the diff is whitespace and list-marker formatting only, so the rendered prose should be unchanged apart from the new link.

## How can we measure success?

No measurable success criteria. This is a small documentation fix so a reader following the README ends up at the right place for the rank tool.

## Have we considered potential risks?

Minimal risk. The change touches only the README, with no code, config, or API surface affected.
