### PR TITLE
Update local development docs

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -46,11 +46,16 @@ Currently only the search & items API can be run locally. It will use the config
 By default the apps run in dev mode (the default `api.public-root` in
 [`application.conf`](../search/src/main/resources/application.conf) points at `api-dev.wellcomecollection.org`),
 where they read Elasticsearch secrets using the `catalogue-developer` AWS profile.
-You will need an active SSO session for that profile:
+You will need valid credentials for that profile. If `catalogue-developer` is a
+role-assumption profile (`role_arn` with a `source_profile`), log in to SSO on its
+source profile, e.g.:
 
 ```bash
-aws sso login --profile catalogue-developer
+aws sso login
 ```
+
+If instead you have `catalogue-developer` configured as an SSO profile itself, use
+`aws sso login --profile catalogue-developer`.
 
 To run the search API from the root of the repository:
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -46,16 +46,12 @@ Currently only the search & items API can be run locally. It will use the config
 By default the apps run in dev mode (the default `api.public-root` in
 [`application.conf`](../search/src/main/resources/application.conf) points at `api-dev.wellcomecollection.org`),
 where they read Elasticsearch secrets using the `catalogue-developer` AWS profile.
-You will need valid credentials for that profile. If `catalogue-developer` is a
-role-assumption profile (`role_arn` with a `source_profile`), log in to SSO on its
-source profile, e.g.:
+The `catalogue-developer` profile assumes the role via a `source_profile`, so log in
+to SSO on the source profile first:
 
 ```bash
 aws sso login
 ```
-
-If instead you have `catalogue-developer` configured as an SSO profile itself, use
-`aws sso login --profile catalogue-developer`.
 
 To run the search API from the root of the repository:
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -14,7 +14,7 @@ The CI flow looks as follows:
 
 ## Dependencies
 
-- Java 1.8
+- Java 11
 - Scala 2.12
 - SBT
 - Terraform
@@ -43,9 +43,22 @@ At the root of the project you should be able to use `sbt` to run the project as
 Currently only the search & items API can be run locally. It will use the configured pipeline index in
 [`ElasticConfig.scala`](../common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala).
 
-You will need to have signed in to the AWS on the CLI to allow the application to assume the required role.
+By default the apps run in dev mode (the default `api.public-root` in
+[`application.conf`](../search/src/main/resources/application.conf) points at `api-dev.wellcomecollection.org`),
+where they read Elasticsearch secrets using the `catalogue-developer` AWS profile.
+You will need an active SSO session for that profile:
 
-To run with reloading of code changes using [`sbt-revolver`](https://github.com/spray/sbt-revolver) from the root of the repository:
+```bash
+aws sso login --profile catalogue-developer
+```
+
+To run the search API from the root of the repository:
+
+```bash
+sbt "project search" run
+```
+
+Or, to run with reloading of code changes using [`sbt-revolver`](https://github.com/spray/sbt-revolver):
 
 ```bash
 sbt "project search" "~reStart"
@@ -54,11 +67,28 @@ AWS_PROFILE=catalogue-developer sbt "project items" "~reStart"
 
 You should then be able to access the APIs at:
 
-- `http://localhost:8080/works`: Seach
+- `http://localhost:8080/works`: Search
 - `http://localhost:8081/items`: Items
+
+In dev mode the search API logs every request with its full query string, which is
+useful for checking exactly what the front-end sends.
+
+**Note:** `sbt` fails to load inside a git worktree (sbt-git/jgit throws
+"Bare Repository has neither a working tree, nor an index"), so run it from a normal checkout.
 
 To specify a different pipeline index, you can set the `pipelineDate` environment variable for the search API:
 
 ```bash
 pipelineDate=2021-01-01 sbt "project search" "~reStart"
+```
+
+### Running tests locally
+
+The search project's tests need an Elasticsearch instance on `localhost:9200`.
+You can start one with the [`docker-compose.yml`](../search/docker-compose.yml) in the `search` directory
+(this is the same Elasticsearch that CI starts via [`run_sbt_tests.sh`](../builds/run_sbt_tests.sh)):
+
+```bash
+(cd search && docker compose up -d)
+sbt "project search" test
 ```


### PR DESCRIPTION
## What does this change?

Updates `docs/developers.md` so it matches how the search and items APIs actually run locally, based on running them today. Changes:

- Corrects the Java dependency from `Java 1.8` to `Java 11`, matching the repo's own install instructions.
- Documents that the apps run in dev mode by default (the default `api.public-root` in `application.conf` points at `api-dev.wellcomecollection.org`) and read Elasticsearch secrets via the `catalogue-developer` AWS profile, so you need valid credentials for that profile: it assumes the role via a `source_profile`, so run `aws sso login` on the source profile first.
- Adds the plain `sbt "project search" run` invocation alongside the existing `~reStart` (sbt-revolver) one.
- Notes that in dev mode the search API logs every request with its full query string, which is handy for seeing exactly what the front-end sends.
- Notes that `sbt` fails to load inside a git worktree (sbt-git/jgit throws a "Bare Repository has neither a working tree, nor an index" error), so it needs a normal checkout.
- Adds a "Running tests locally" subsection: the search tests need Elasticsearch on `localhost:9200`, which you can start with `docker compose up -d` in `search/`, the same instance CI uses.
- Fixes a typo (`Seach` to `Search`).

### Checklist

- [x] Does this patch need a change to the documentation? This change is the documentation update.
- [x] Does this change the API surface? No. Docs only, so no OpenAPI spec change is needed.


Part of wellcomecollection/platform#6421: these docs cover the local setup used to verify the catalogue pipeline preview toggle.
## How to test

Read the rendered `docs/developers.md` on this branch and follow it from a clean checkout:

- `aws sso login` (on the source profile that `catalogue-developer` assumes its role from), then `sbt "project search" run` (or the `~reStart` variant), and confirm the API comes up at `http://localhost:8080/works`.
- Confirm the search API logs each request with its full query string in dev mode.
- From `search/`, run `docker compose up -d` and then `sbt "project search" test` and confirm the tests find Elasticsearch on `localhost:9200`.

## How can we measure success?

No runtime behaviour changes, so there is nothing to measure in logs or analytics. Success is that a developer can follow these docs and get search and items running locally without hitting the gaps the previous version left out.

## Have we considered potential risks?

Low risk. This is a documentation-only change with no code, config, or infrastructure impact.