### PR TITLE
Ignore Claude Code worktree checkouts and local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 ### Project Specific ###
 
+# Claude Code local state: worktree checkouts and personal settings.
+# .claude itself stays trackable in case shared settings are added later.
+.claude/worktrees/
+.claude/settings.local.json
+
 .idea
 *.iml
 .lambda_hashes.json


### PR DESCRIPTION
Claude Code creates git worktrees under `.claude/worktrees/`, but `.claude/` was untracked rather than ignored here. Because each worktree contains a `.git` file, a stray `git add -A` would write gitlink entries for them.

This ignores the two local-state paths specifically rather than all of `.claude/`, so a shared `.claude/settings.json` stays trackable if we ever want one. Verified with `git check-ignore` that `.claude/settings.json`, `.claude/agents/`, `.claude/skills/` and `.claude/CLAUDE.md` all remain visible to git.

Nothing under `.claude/` was already tracked, so no `git rm --cached` is needed.