### PR TITLE
Switch the default works index to works-indexed-2026-07-30

### DIFF
--- a/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
+++ b/common/search/src/main/scala/weco/api/search/models/ElasticConfig.scala
@@ -33,7 +33,7 @@ object ElasticConfig {
   // We use this to share config across Scala API applications
   // i.e. The API and the snapshot generator.
   val defaultPipelineDate = "2025-10-02"
-  val defaultWorksIndexDate = "2026-03-03"
+  val defaultWorksIndexDate = "2026-07-30"
   val defaultImagesIndexDate = "2026-04-29"
 }
 


### PR DESCRIPTION
## What does this change?

Flips `defaultWorksIndexDate` from `2026-03-03` to `2026-07-30`, so the works API, items API and snapshot generator read the new archive-browsing index by default. Part of wellcomecollection/platform#6509.

The new index has been verified: full re-ingest completed 2026-08-10, kept current by the incremental pipeline, counts in line with the old index, and an 800-document sampled diff showed parity apart from the new archive/collection fields and live catalogue edits the frozen old index can no longer receive.

## How to test

On stage after deploy, the new filters/aggregations/sort should work without the `elasticCluster` parameter, and the deploy-prod diff tool output is the final stage-on-new vs prod-on-old parity report to review at the prod gate.

## Have we considered potential risks?

The old index stays in place; rollback is reverting this one line and redeploying. The next public snapshot will include the additive archive/collection display fields.