### PR TITLE
Remove the archive-browse-testing multiCluster entry

### DIFF
--- a/search/src/main/resources/application.conf
+++ b/search/src/main/resources/application.conf
@@ -48,12 +48,3 @@ multiCluster.axiell-collections-testing {
   worksIndex = "works-indexed-2026-07-03"
   imagesIndex = "images-indexed-2026-07-03"
 }
-
-multiCluster.archive-browse-testing {
-  hostSecretPath = "elasticsearch/pipeline_storage_2025-10-02/private_host"
-  portSecretPath = "elasticsearch/pipeline_storage_2025-10-02/port"
-  protocolSecretPath = "elasticsearch/pipeline_storage_2025-10-02/protocol"
-  apiKeySecretPath = "elasticsearch/pipeline_storage_2025-10-02/catalogue_api/api_key"
-  worksIndex = "works-indexed-2026-07-30"
-  imagesIndex = "images-indexed-2026-04-29"
-}


### PR DESCRIPTION
## What does this change?

Removes the `archive-browse-testing` multiCluster entry from `search/src/main/resources/application.conf`. Since the default works index flipped to `works-indexed-2026-07-30` (wellcomecollection/platform#6509), that entry has pointed at exactly what the default cluster already serves.

Do not merge before wellcomecollection/wellcomecollection.org#13367 has deployed. Requests selecting a removed cluster return 404, so the frontend toggle option has to disappear first.

Part of wellcomecollection/platform#6511.

## Have we considered potential risks?

Once the frontend change is live, nothing sends `elasticCluster=archive-browse-testing`, and any straggler gets a 404 rather than data from the wrong index. Rollback is reverting this commit.
