### PR TITLE
Document the automated test-document sync from the pipeline

### DIFF
--- a/copy_test_documents.py
+++ b/copy_test_documents.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 """
-This script copies test documents from the pipeline repo into this repo.
+This script copies test documents from a local clone of the pipeline repo.
 
-For now, it's using a local clone, but eventually this script will be
-extended to fetch from a remote repo on GitHub.
+The routine path is automated: the pipeline's sync-test-documents.yml
+workflow opens a PR here when the documents change on its main branch.
+Use this script for a local refresh from an unmerged pipeline branch.
 """
 
 import glob

--- a/reference/README.md
+++ b/reference/README.md
@@ -50,16 +50,20 @@ the concepts test compares both directions.
 ### The response schemas
 
 The pipeline generates the documents in
-`common/search/src/test/resources/test_documents/`, and `copy_test_documents.py` copies
-them here from a local clone of the pipeline repo. Each one's `document.display` object
+`common/search/src/test/resources/test_documents/`. When they change on the pipeline's
+`main`, its `sync-test-documents.yml` workflow opens a pull request here updating our
+copy; `copy_test_documents.py` still does the same from a local clone if you need a
+refresh without waiting for a merge. Each one's `document.display` object
 is exactly what the API returns for that record, so `OpenApiSpecResponseTest` validates
 all of them against the `Work` and `Image` schemas.
 
 Two limits to that. The fixtures are a sample, not every field the pipeline can emit,
 so the test proves the schemas accept what we have rather than everything that exists.
 The schemas were missing `Genre`-typed concepts for a while because no fixture contained
-one. And because `copy_test_documents.py` runs by hand, a change to the pipeline's
-display model is only caught once someone refreshes the fixtures.
+one. And a display model change is only caught when the fixtures are refreshed: the
+sync workflow does that on merge, so expect its pull request to arrive with failing
+tests whenever the pipeline changes the display shape. That failure is the mechanism
+working; update this spec on that branch before merging it.
 
 ## Checking your changes
 


### PR DESCRIPTION
## What does this change?

Documentation only. `reference/README.md` and the `copy_test_documents.py` docstring described a manual fixture refresh as the only path; once wellcomecollection/catalogue-pipeline#3565 lands, the routine path is the pipeline's `sync-test-documents.yml` workflow opening auto-PRs here, with the script kept for local refreshes from unmerged pipeline branches. The README now also says what a red auto-sync PR means (the spec needs updating on that branch) rather than describing the drift window the automation removes.

Draft until catalogue-pipeline#3565 is merged and its GitHub App secrets are configured, since until then these docs would describe a workflow that doesn't run.

Part of wellcomecollection/platform#6514.

## How to test

Read the two files; there is no behaviour change.

## How can we measure success?

Nobody follows the README to a manual process that no longer needs running.

## Have we considered potential risks?

Only that this merges before the pipeline workflow is live, which the draft status guards.
