### PR TITLE
Make sync-openapi-spec fail loudly when PR creation fails

### DIFF
--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.changes == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           cd developers.wellcomecollection.org
 
@@ -81,21 +83,19 @@ jobs:
           git commit -m "Update OpenAPI spec from catalogue-api"
           git push origin $BRANCH_NAME
 
-          # Open PR
-          PR_NUMBER=$(curl -s -X POST \
-            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/wellcomecollection/developers.wellcomecollection.org/pulls \
-            -d '{
-              "title": "🤖 Auto-sync: Update OpenAPI spec",
-              "head": "'"$BRANCH_NAME"'",
-              "base": "main",
-              "body": "This PR updates `reference/catalogue.yaml` from the spec in `wellcomecollection/catalogue-api`, which is its source of truth.\n\n**Triggered by commit:** ${{ github.sha }}\n\nPlease review and merge if the changes look correct."
-            }' | jq -r '.number')
+          # gh, unlike curl -s, fails the step on API errors
+          cat > "$RUNNER_TEMP/pr-body.md" <<'EOF'
+          This PR updates `reference/catalogue.yaml` from the spec in `wellcomecollection/catalogue-api`, which is its source of truth.
 
-          # Request review from digital-platform team
-          curl -s -X POST \
-            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/wellcomecollection/developers.wellcomecollection.org/pulls/$PR_NUMBER/requested_reviewers \
-            -d '{"team_reviewers": ["digital-platform"]}'
+          **Triggered by commit:** ${{ github.sha }}
+
+          Please review and merge if the changes look correct.
+          EOF
+
+          gh pr create \
+            --repo wellcomecollection/developers.wellcomecollection.org \
+            --head "$BRANCH_NAME" \
+            --base main \
+            --title "🤖 Auto-sync: Update OpenAPI spec" \
+            --body-file "$RUNNER_TEMP/pr-body.md" \
+            --reviewer wellcomecollection/digital-platform


### PR DESCRIPTION
## What does this change?

The "Create Pull Request" step in `sync-openapi-spec.yml` used `curl -s`, which exits 0 on 4xx/5xx responses. If the PR creation failed (for example through missing app permissions), `jq` extracted `null`, the reviewer request posted to `/pulls/null/requested_reviewers`, and the run stayed green with no PR opened. For unattended automation a green run that did nothing is the worst failure mode.

Both calls are now a single `gh pr create` (with `GH_TOKEN` from the app token and the reviewer requested in the same command), which fails the step on API errors. The PR title, body and reviewer are unchanged.

This mirrors the same fix Copilot prompted on the new sync workflow in wellcomecollection/catalogue-pipeline#3565, which had copied the curl pattern from here.

### Checklist

- [x] Does this patch need a change to the documentation? No, behaviour on success is identical.
- [x] Does this change the API surface? No.

## How to test

The change only runs on pushes to `main` touching `reference/catalogue.yaml`, so it can't be exercised from this branch. After merge, the next spec change (or a `workflow_dispatch` run while the spec differs from the developers-site copy) should open the auto-sync PR exactly as before; a deliberate way to see the new failure mode is revoking the app's access, which previously went green.

## How can we measure success?

A sync failure now shows as a red run in Actions instead of a silent no-op, so spec changes can't quietly fail to reach developers.wellcomecollection.org.

## Have we considered potential risks?

`gh` is preinstalled on ubuntu-latest runners and authenticates via `GH_TOKEN`, the same app token the curl calls used; no new permissions are involved.
