### PR TITLE
Assert every documented response field appears in a fixture

### DIFF
--- a/common/search/src/test/resources/test_documents/work.visible.rare-fields.json
+++ b/common/search/src/test/resources/test_documents/work.visible.rare-fields.json
@@ -1,0 +1,241 @@
+{
+  "description": "a work with every rarely-populated display field",
+  "id": "4cbgoe8p",
+  "document": {
+    "type": "Visible",
+    "debug": {
+      "source": {
+        "id": "4cbgoe8p",
+        "identifier": {
+          "identifierType": {
+            "id": "sierra-system-number"
+          },
+          "ontologyType": "Work",
+          "value": "3QF59FdNQJ"
+        },
+        "version": 1,
+        "modifiedTime": "2025-01-01T00:00:00Z"
+      },
+      "mergedTime": "2025-01-01T00:00:00Z",
+      "indexedTime": "2001-01-01T01:01:01Z",
+      "mergeCandidates": [],
+      "redirectSources": []
+    },
+    "query": {
+      "id": "4cbgoe8p",
+      "title": "A work with every rarely-populated display field",
+      "referenceNumber": "WA/HMM/BU/1",
+      "physicalDescription": "1 volume ; 23 cm",
+      "alternativeTitles": [],
+      "languages.label": [],
+      "sourceIdentifier.value": "3QF59FdNQJ",
+      "identifiers.value": ["4cbgoe8p", "3QF59FdNQJ"],
+      "images.id": [],
+      "images.identifiers.value": [],
+      "items.identifiers.value": ["Y14y2h0Rzl"],
+      "items.id": ["l5mem3bu"],
+      "items.shelfmark.value": ["Shelfmark: NaTDHzrYbX"],
+      "notes.contents": [],
+      "partOf.title": [],
+      "production.label": ["London", "Printed for the author", "1897"],
+      "subjects.concepts.label": [],
+      "contributors.agent.label": ["Wellcome, Henry Solomon, Sir"],
+      "genres.concepts.label": []
+    },
+    "display": {
+      "id": "4cbgoe8p",
+      "title": "A work with every rarely-populated display field",
+      "alternativeTitles": [],
+      "referenceNumber": "WA/HMM/BU/1",
+      "physicalDescription": "1 volume ; 23 cm",
+      "createdDate": {
+        "label": "1897",
+        "type": "Period"
+      },
+      "contributors": [
+        {
+          "agent": {
+            "id": "xoptq11r",
+            "label": "Wellcome, Henry Solomon, Sir",
+            "identifiers": [
+              {
+                "value": "sibpiNFnJJ",
+                "type": "Identifier",
+                "identifierType": {
+                  "id": "sierra-system-number",
+                  "type": "IdentifierType",
+                  "label": "Sierra system number"
+                }
+              }
+            ],
+            "type": "Person"
+          },
+          "roles": [
+            {
+              "label": "author",
+              "type": "ContributionRole"
+            }
+          ],
+          "primary": true,
+          "type": "Contributor"
+        }
+      ],
+      "identifiers": [
+        {
+          "value": "3QF59FdNQJ",
+          "type": "Identifier",
+          "identifierType": {
+            "id": "sierra-system-number",
+            "type": "IdentifierType",
+            "label": "Sierra system number"
+          }
+        }
+      ],
+      "subjects": [],
+      "genres": [],
+      "items": [
+        {
+          "id": "l5mem3bu",
+          "identifiers": [
+            {
+              "value": "Y14y2h0Rzl",
+              "type": "Identifier",
+              "identifierType": {
+                "id": "sierra-system-number",
+                "type": "IdentifierType",
+                "label": "Sierra system number"
+              }
+            }
+          ],
+          "title": "Copy 1, with manuscript annotations",
+          "note": "In poor condition; handle with care",
+          "locations": [
+            {
+              "locationType": {
+                "id": "closed-stores",
+                "type": "LocationType",
+                "label": "Closed stores"
+              },
+              "license": {
+                "id": "pdm",
+                "type": "License",
+                "label": "Public Domain Mark",
+                "url": "https://creativecommons.org/share-your-work/public-domain/pdm/"
+              },
+              "accessConditions": [
+                {
+                  "method": {
+                    "id": "manual-request",
+                    "type": "AccessMethod",
+                    "label": "Manual request"
+                  },
+                  "status": {
+                    "id": "restricted",
+                    "type": "AccessStatus",
+                    "label": "Restricted"
+                  },
+                  "terms": "Permission must be obtained from the depositor",
+                  "note": "This file is closed for data protection reasons",
+                  "type": "AccessCondition"
+                }
+              ],
+              "label": "locationLabel",
+              "shelfmark": "Shelfmark: NaTDHzrYbX",
+              "type": "PhysicalLocation"
+            }
+          ],
+          "type": "Item"
+        }
+      ],
+      "holdings": [],
+      "availabilities": [],
+      "production": [
+        {
+          "label": "London : Printed for the author, 1897",
+          "places": [
+            {
+              "label": "London",
+              "type": "Place"
+            }
+          ],
+          "agents": [
+            {
+              "label": "Printed for the author",
+              "type": "Agent"
+            }
+          ],
+          "dates": [
+            {
+              "label": "1897",
+              "type": "Period"
+            }
+          ],
+          "function": {
+            "label": "Printing",
+            "type": "Concept"
+          },
+          "type": "ProductionEvent"
+        }
+      ],
+      "languages": [],
+      "notes": [],
+      "currentFrequency": "Quarterly, 1897-1902",
+      "formerFrequency": [],
+      "designation": [],
+      "images": [],
+      "parts": [],
+      "partOf": [],
+      "type": "Work"
+    },
+    "aggregatableValues": {
+      "workType": [],
+      "genres": [],
+      "subjects": [],
+      "languages": [],
+      "production.dates": [
+        {
+          "id": "1897",
+          "label": "1897"
+        }
+      ],
+      "contributors.agent": [
+        {
+          "id": "xoptq11r",
+          "label": "Wellcome, Henry Solomon, Sir"
+        }
+      ],
+      "items.locations.license": [
+        {
+          "id": "pdm",
+          "label": "Public Domain Mark"
+        }
+      ],
+      "availabilities": []
+    },
+    "filterableValues": {
+      "workType": "Standard",
+      "production.dates.range.from": [-2303596800000],
+      "languages.id": [],
+      "genres.label": [],
+      "genres.concepts.id": [],
+      "genres.concepts.sourceIdentifier": [],
+      "subjects.label": [],
+      "subjects.concepts.id": [],
+      "subjects.concepts.sourceIdentifier": [],
+      "contributors.agent.label": ["Wellcome, Henry Solomon, Sir"],
+      "contributors.agent.id": ["xoptq11r"],
+      "contributors.agent.sourceIdentifier": ["sibpiNFnJJ"],
+      "identifiers.value": ["4cbgoe8p", "3QF59FdNQJ"],
+      "items.locations.license.id": ["pdm"],
+      "items.locations.accessConditions.status.id": ["restricted"],
+      "items.id": ["l5mem3bu"],
+      "items.identifiers.value": ["Y14y2h0Rzl"],
+      "items.locations.locationType.id": ["closed-stores"],
+      "items.locations.createdDate": [],
+      "partOf.id": [],
+      "partOf.title": [],
+      "availabilities.id": []
+    }
+  },
+  "createdAt": "2026-08-12T10:26:31.357044+00:00"
+}

--- a/copy_test_documents.py
+++ b/copy_test_documents.py
@@ -21,12 +21,13 @@ prefixes = [
     "catalogue_graph/document_generators/test_documents",
 ]
 
+TARGET = "common/search/src/test/resources/test_documents"
+
+# Mirror deletions too: a fixture removed upstream must not linger here as
+# stale evidence for the OpenAPI response tests.
+for stale in glob.glob(f"{TARGET}/*.json"):
+    os.remove(stale)
+
 for prefix in prefixes:
     for path in glob.glob(f"{PIPELINE_ROOT}/{prefix}/*.json"):
-        shutil.copyfile(
-            path,
-            os.path.join(
-                "common/search/src/test/resources/test_documents",
-                os.path.basename(path),
-            ),
-        )
+        shutil.copyfile(path, os.path.join(TARGET, os.path.basename(path)))

--- a/diff_tool/routes.json
+++ b/diff_tool/routes.json
@@ -79,28 +79,28 @@
   {
     "path": "/works/japtptkk",
     "params": {
-      "include": "identifiers,items,subjects,genres,contributors,production,languages,notes,images,succeededBy,precededBy,partOf,parts"
+      "include": "identifiers,items,subjects,genres,contributors,production,languages,notes,images,partOf,parts"
     },
     "comment": "A Sierra <> Miro merged work"
   },
   {
     "path": "/works/nbsqzbba",
     "params": {
-      "include": "identifiers,items,subjects,genres,contributors,production,languages,notes,images,succeededBy,precededBy,partOf,parts"
+      "include": "identifiers,items,subjects,genres,contributors,production,languages,notes,images,partOf,parts"
     },
     "comment": "A Sierra <> METS merged work"
   },
   {
     "path": "/works/tuzsytuh",
     "params": {
-      "include": "identifiers,items,subjects,genres,contributors,production,languages,notes,images,succeededBy,precededBy,partOf,parts"
+      "include": "identifiers,items,subjects,genres,contributors,production,languages,notes,images,partOf,parts"
     },
     "comment": "A Sierra physical <> digital <> METS merged work"
   },
   {
     "path": "/works/ugmmch83",
     "params": {
-      "include": "identifiers,items,subjects,genres,contributors,production,languages,notes,images,succeededBy,precededBy,partOf,parts"
+      "include": "identifiers,items,subjects,genres,contributors,production,languages,notes,images,partOf,parts"
     },
     "comment": "A Sierra work with lots of items"
   },

--- a/reference/README.md
+++ b/reference/README.md
@@ -35,12 +35,12 @@ ignored.
 Four tests now check this file against the code. Change one without the other and the
 build fails.
 
-| Test                                             | Asserts                                                                                                                                                                                 |
-| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `search/…/openapi/OpenApiSpecEnumTest.scala`     | The closed enums (`include`, `aggregations`, `sort`, `sortOrder`, the access status filter) match the decoders in `search/…/rest/`, and the pagination bounds match `PaginationLimits`. |
-| `search/…/openapi/OpenApiSpecEndpointTest.scala` | Every works and images endpoint documented here is routable, and the internal endpoints stay undocumented.                                                                              |
-| `search/…/openapi/OpenApiSpecResponseTest.scala` | The `Work` and `Image` schemas accept every display document in `test_documents/`, and document every field those documents contain.                                                    |
-| `concepts/test/openapi.test.ts`                  | The concepts endpoints served match those documented here exactly, and the pagination limits agree with the search API's.                                                               |
+| Test                                             | Asserts                                                                                                                                                                                                                     |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `search/…/openapi/OpenApiSpecEnumTest.scala`     | The closed enums (`include`, `aggregations`, `sort`, `sortOrder`, the access status filter) match the decoders in `search/…/rest/`, and the pagination bounds match `PaginationLimits`.                                     |
+| `search/…/openapi/OpenApiSpecEndpointTest.scala` | Every works and images endpoint documented here is routable, and the internal endpoints stay undocumented.                                                                                                                  |
+| `search/…/openapi/OpenApiSpecResponseTest.scala` | The `Work` and `Image` schemas accept every display document in `test_documents/`, document every field those documents contain, and document nothing the fixtures don't exhibit (a named allowlist covers the exceptions). |
+| `concepts/test/openapi.test.ts`                  | The concepts endpoints served match those documented here exactly, and the pagination limits agree with the search API's.                                                                                                   |
 
 The two services support different checks. A Pekko route is an opaque function, so the
 search test can only ask whether a documented path exists. A new public route added to

--- a/reference/catalogue.yaml
+++ b/reference/catalogue.yaml
@@ -1281,14 +1281,8 @@ components:
       title: Period
       type: object
       properties:
-        id:
-          type: string
         label:
           type: string
-        identifiers:
-          type: array
-          items:
-            $ref: "#/components/schemas/Identifier"
         type:
           type: string
       description: A period of time
@@ -1319,14 +1313,8 @@ components:
       title: Place
       type: object
       properties:
-        id:
-          type: string
         label:
           type: string
-        identifiers:
-          type: array
-          items:
-            $ref: "#/components/schemas/Identifier"
         type:
           type: string
       description: A place

--- a/reference/catalogue.yaml
+++ b/reference/catalogue.yaml
@@ -457,8 +457,6 @@ components:
             - images
             - parts
             - partOf
-            - precededBy
-            - succeededBy
     WorksAggregations:
       name: aggregations
       in: query
@@ -1380,10 +1378,6 @@ components:
         referenceNumber:
           type: string
           description: The identifier used by researchers to cite or refer to a work.
-        partOf:
-          type: array
-          items:
-            $ref: "#/components/schemas/RelatedWork"
         totalParts:
           type: integer
           description: Number of child works.
@@ -1539,16 +1533,6 @@ components:
         partOf:
           type: array
           description: Ancestor works.
-          items:
-            $ref: "#/components/schemas/RelatedWork"
-        precededBy:
-          type: array
-          description: Sibling works earlier in a series.
-          items:
-            $ref: "#/components/schemas/RelatedWork"
-        succeededBy:
-          type: array
-          description: Sibling works later in a series.
           items:
             $ref: "#/components/schemas/RelatedWork"
         type:

--- a/search/src/main/scala/weco/api/search/json/CatalogueJsonUtil.scala
+++ b/search/src/main/scala/weco/api/search/json/CatalogueJsonUtil.scala
@@ -39,8 +39,6 @@ trait CatalogueJsonUtil {
         .removeKeyIf(!includes.images, "images")
         .removeKeyIf(!includes.parts, "parts")
         .removeKeyIf(!includes.partOf, "partOf")
-        .removeKeyIf(!includes.precededBy, "precededBy")
-        .removeKeyIf(!includes.succeededBy, "succeededBy")
   }
 
   implicit class ImageJsonOps(json: Json) {

--- a/search/src/main/scala/weco/api/search/json/CatalogueJsonUtil.scala
+++ b/search/src/main/scala/weco/api/search/json/CatalogueJsonUtil.scala
@@ -39,6 +39,11 @@ trait CatalogueJsonUtil {
         .removeKeyIf(!includes.images, "images")
         .removeKeyIf(!includes.parts, "parts")
         .removeKeyIf(!includes.partOf, "partOf")
+        // Pre-catalogue_graph indices still hold these, so strip them
+        // unconditionally: a rollback or elasticCluster override must not
+        // leak fields the spec no longer documents.
+        .removeKey("precededBy")
+        .removeKey("succeededBy")
   }
 
   implicit class ImageJsonOps(json: Json) {

--- a/search/src/main/scala/weco/api/search/models/request/WorksIncludes.scala
+++ b/search/src/main/scala/weco/api/search/models/request/WorksIncludes.scala
@@ -19,8 +19,6 @@ object WorkInclude {
   case object Images extends WorkInclude
   case object Parts extends WorkInclude
   case object PartOf extends WorkInclude
-  case object PrecededBy extends WorkInclude
-  case object SucceededBy extends WorkInclude
 }
 
 case class WorksIncludes(
@@ -39,9 +37,7 @@ case class WorksIncludes(
   designation: Boolean,
   images: Boolean,
   parts: Boolean,
-  partOf: Boolean,
-  precededBy: Boolean,
-  succeededBy: Boolean
+  partOf: Boolean
 )
 
 case object WorksIncludes {
@@ -62,9 +58,7 @@ case object WorksIncludes {
       designation = includes.contains(WorkInclude.Designation),
       images = includes.contains(WorkInclude.Images),
       parts = includes.contains(WorkInclude.Parts),
-      partOf = includes.contains(WorkInclude.PartOf),
-      precededBy = includes.contains(WorkInclude.PrecededBy),
-      succeededBy = includes.contains(WorkInclude.SucceededBy)
+      partOf = includes.contains(WorkInclude.PartOf)
     )
 
   def none: WorksIncludes = WorksIncludes()

--- a/search/src/main/scala/weco/api/search/rest/QueryParams.scala
+++ b/search/src/main/scala/weco/api/search/rest/QueryParams.scala
@@ -163,7 +163,7 @@ trait QueryParamsUtils extends Directives {
   def stringListFilter[T](applyFilter: Seq[String] => T): Decoder[T] =
     decodeCommaSeparated.emap(strs => Right(applyFilter(strs)))
 
-  private def invalidValuesMsg(
+  def invalidValuesMsg(
     values: List[String],
     validValues: List[String]
   ): String = {
@@ -187,7 +187,7 @@ trait QueryParamsUtils extends Directives {
           .toDirective[Tuple1[T]]
     }
 
-  private def mapStringsToValues[T](
+  def mapStringsToValues[T](
     strs: List[String],
     mapping: Map[String, T]
   ): Either[List[String], List[T]] = {

--- a/search/src/main/scala/weco/api/search/rest/WorksParams.scala
+++ b/search/src/main/scala/weco/api/search/rest/WorksParams.scala
@@ -48,9 +48,7 @@ object SingleWorkParams extends QueryParamsUtils {
     "designation" -> WorkInclude.Designation,
     "images" -> WorkInclude.Images,
     "parts" -> WorkInclude.Parts,
-    "partOf" -> WorkInclude.PartOf,
-    "precededBy" -> WorkInclude.PrecededBy,
-    "succeededBy" -> WorkInclude.SucceededBy
+    "partOf" -> WorkInclude.PartOf
   )
 
   implicit val includesDecoder: Decoder[WorksIncludes] =

--- a/search/src/main/scala/weco/api/search/rest/WorksParams.scala
+++ b/search/src/main/scala/weco/api/search/rest/WorksParams.scala
@@ -51,8 +51,21 @@ object SingleWorkParams extends QueryParamsUtils {
     "partOf" -> WorkInclude.PartOf
   )
 
+  /** Accepted and ignored, deliberately undocumented. The pipeline stopped
+    * emitting these fields in the move to catalogue_graph, but iiif-builder
+    * still sends them on every request, so a hard 400 would break IIIF
+    * manifest building. Remove once iiif-builder stops sending them.
+    */
+  val deprecatedIncludeValues: Seq[String] = Seq("precededBy", "succeededBy")
+
   implicit val includesDecoder: Decoder[WorksIncludes] =
-    decodeOneOfCommaSeparated(includeValues: _*)
+    decodeCommaSeparated
+      .map(_.filterNot(deprecatedIncludeValues.contains))
+      .emap { strs =>
+        mapStringsToValues(strs, includeValues.toMap).left.map { invalidStrs =>
+          invalidValuesMsg(invalidStrs, includeValues.map(_._1).toList)
+        }
+      }
       .emap(values => Right(WorksIncludes(values: _*)))
 }
 

--- a/search/src/test/scala/weco/api/search/json/CatalogueJsonUtilTest.scala
+++ b/search/src/test/scala/weco/api/search/json/CatalogueJsonUtilTest.scala
@@ -99,9 +99,7 @@ class CatalogueJsonUtilTest
     ("notes", WorkInclude.Notes),
     ("images", WorkInclude.Images),
     ("parts", WorkInclude.Parts),
-    ("partOf", WorkInclude.PartOf),
-    ("precededBy", WorkInclude.PrecededBy),
-    ("succeededBy", WorkInclude.SucceededBy)
+    ("partOf", WorkInclude.PartOf)
   )
 
   describe("WorkJsonOps") {

--- a/search/src/test/scala/weco/api/search/openapi/OpenApiSpecEnumTest.scala
+++ b/search/src/test/scala/weco/api/search/openapi/OpenApiSpecEnumTest.scala
@@ -77,6 +77,13 @@ class OpenApiSpecEnumTest extends AnyFunSpec with Matchers {
       checkEnum("WorksInclude", names(SingleWorkParams.includeValues))
     }
 
+    it("keeps the deprecated includes undocumented") {
+      // Tolerated for iiif-builder, but they do nothing, so the spec must not
+      // advertise them.
+      specEnum("WorksInclude")
+        .intersect(SingleWorkParams.deprecatedIncludeValues.toSet) shouldBe empty
+    }
+
     it("documents every aggregation the API accepts") {
       checkEnum(
         "WorksAggregations",

--- a/search/src/test/scala/weco/api/search/openapi/OpenApiSpecResponseTest.scala
+++ b/search/src/test/scala/weco/api/search/openapi/OpenApiSpecResponseTest.scala
@@ -318,14 +318,7 @@ class OpenApiSpecResponseTest extends AnyFunSpec with Matchers {
     "Work.createdDate",
     "Work.currentFrequency",
     "Work.physicalDescription",
-    "Work.referenceNumber",
-    // The current ingestor's display model has no such fields at all (see
-    // catalogue_graph/src/ingestor/models/display/{work,relation}.py in the
-    // pipeline repo, confirmed against the live API). The spec documents them
-    // until we decide whether to drop them or restore them in the pipeline.
-    "RelatedWork.partOf",
-    "Work.precededBy",
-    "Work.succeededBy"
+    "Work.referenceNumber"
   )
 
   /** Every property of every component reachable from the Work and Image schemas, as

--- a/search/src/test/scala/weco/api/search/openapi/OpenApiSpecResponseTest.scala
+++ b/search/src/test/scala/weco/api/search/openapi/OpenApiSpecResponseTest.scala
@@ -220,21 +220,7 @@ class OpenApiSpecResponseTest extends AnyFunSpec with Matchers {
     */
   describe("the fixture coverage") {
     it("exhibits every field the spec documents") {
-      val observed = testDocuments.flatMap { file =>
-        val doc = circeOf(file)
-
-        for {
-          display <- doc.hcursor
-            .downField("document")
-            .downField("display")
-            .focus
-            .toSeq
-          name <- schemaNameOf(display).toSeq
-          path <- observedFields(schemaRef(name), display, name)
-        } yield path
-      }.toSet
-
-      val missing = documentedFields -- observed -- allowedUnexercised
+      val missing = documentedFields -- observedInFixtures -- allowedUnexercised
 
       withClue(
         s"""|The spec documents these fields, but no fixture contains them. Either the
@@ -250,50 +236,61 @@ class OpenApiSpecResponseTest extends AnyFunSpec with Matchers {
 
     it("does not allow fields the fixtures exercise") {
       // Entries here would mask a regression the assertion above exists to catch.
-      val observed = testDocuments.flatMap { file =>
-        val doc = circeOf(file)
-
-        for {
-          display <- doc.hcursor
-            .downField("document")
-            .downField("display")
-            .focus
-            .toSeq
-          name <- schemaNameOf(display).toSeq
-          path <- observedFields(schemaRef(name), display, name)
-        } yield path
-      }.toSet
-
-      allowedUnexercised.intersect(observed) shouldBe empty
+      allowedUnexercised.intersect(observedInFixtures) shouldBe empty
     }
 
     it("notices a documented field that no fixture contains") {
       // A control: an invented property must show up in the documented set.
+      val withExtra = schemaRef("Work").deepMerge(
+        Json.obj(
+          "properties" -> Json.obj(
+            "neverEmitted" -> Json.obj("type" -> Json.fromString("string"))
+          )
+        )
+      )
+
       documentedFieldsFrom(
         "Work",
-        name =>
-          if (name != "Work") schemaRef(name)
-          else {
-            val work = schemaRef("Work")
-            work.hcursor
-              .downField("properties")
-              .focus
-              .flatMap(_.asObject)
-              .map(
-                _.add(
-                  "neverEmitted",
-                  Json.obj("type" -> Json.fromString("string"))))
-              .map(Json.fromJsonObject)
-              .flatMap(
-                props =>
-                  work.hcursor
-                    .downField("properties")
-                    .set(props)
-                    .top
-              )
-              .get
-          }
+        name => if (name == "Work") withExtra else schemaRef(name)
       ) should contain("Work.neverEmitted")
+    }
+
+    /** The walks above understand `$ref`, `oneOf`, `properties` and `items`, and
+      * treat anything else as opaque. That is fine while the spec sticks to those,
+      * but an `allOf` refactor would silently exempt its subtree from every check
+      * in this file, so hold the line here.
+      */
+    it("only meets schema keywords the walks understand") {
+      def offences(json: Json, path: String): Seq[String] =
+        json.asObject match {
+          case Some(obj) =>
+            val here = Seq("allOf", "anyOf", "patternProperties")
+              .filter(obj.contains)
+              .map(k => s"$path uses $k")
+
+            val mixed =
+              if (obj.contains("oneOf") && (obj.contains("properties") || obj
+                    .contains("items")))
+                Seq(s"$path mixes oneOf with sibling properties/items")
+              else Seq.empty
+
+            here ++ mixed ++ obj.toIterable.flatMap {
+              case (key, value) => offences(value, s"$path/$key")
+            }
+
+          case None =>
+            json.asArray.toSeq.flatten.zipWithIndex.flatMap {
+              case (value, i) => offences(value, s"$path[$i]")
+            }
+        }
+
+      val schemas = specJson.hcursor
+        .downField("components")
+        .downField("schemas")
+        .focus
+        .get
+
+      offences(schemas, "components/schemas") shouldBe empty
     }
   }
 
@@ -302,18 +299,23 @@ class OpenApiSpecResponseTest extends AnyFunSpec with Matchers {
     */
   private lazy val allowedUnexercised: Set[String] = Set(
     // Spliced in by the API at request time, never part of an indexed document.
-    "Image.withSimilarFeatures",
-    // The spec reaches Period and Place only through production events and
-    // createdDate, where the ingestor's display transformer builds label-only
-    // concepts, dropping ids and identifiers even for identified concepts
-    // (work_display_transformer.py in the pipeline repo; the live API emits
-    // none either). Allowed rather than removed in case the transformer learns
-    // to keep them; the rare-fields fixture already carries identified inputs.
-    "Period.id",
-    "Period.identifiers",
-    "Place.id",
-    "Place.identifiers"
+    "Image.withSimilarFeatures"
   )
+
+  private lazy val observedInFixtures: Set[String] =
+    testDocuments.flatMap { file =>
+      val doc = circeOf(file)
+
+      for {
+        display <- doc.hcursor
+          .downField("document")
+          .downField("display")
+          .focus
+          .toSeq
+        name <- schemaNameOf(display).toSeq
+        path <- observedFields(schemaRef(name), display, name)
+      } yield path
+    }.toSet
 
   /** Every property of every component reachable from the Work and Image schemas, as
     * `Component.property` paths; inline sub-objects extend the dotted path instead.
@@ -379,8 +381,9 @@ class OpenApiSpecResponseTest extends AnyFunSpec with Matchers {
     * as [[documentedFields]]: paths restart at each named component, so a field
     * counts as observed wherever it appears.
     *
-    * Where `oneOf` branches share a property name, this follows all of them, so a
-    * field counts under every branch that could have produced it.
+    * A `oneOf` with a discriminator narrows to the branch the document names, so
+    * a field shared between branches is credited only to the one that produced
+    * it. Without a discriminator every branch holding the property counts.
     */
   private def observedFields(
     schema: Json,
@@ -389,7 +392,7 @@ class OpenApiSpecResponseTest extends AnyFunSpec with Matchers {
   ): Seq[String] =
     doc.asObject match {
       case Some(obj) =>
-        val alternatives = namedBranches(schema, path)
+        val alternatives = discriminate(namedBranches(schema, path), schema, doc)
 
         obj.toIterable.toSeq.flatMap {
           case (key, value) =>
@@ -443,6 +446,30 @@ class OpenApiSpecResponseTest extends AnyFunSpec with Matchers {
       .getOrElse(Vector((base, resolved)))
   }
 
+  /** Narrows `oneOf` alternatives to the branch the document's discriminator
+    * names, so a field shared between branches (a physical location's `license`)
+    * is not credited to the branch that didn't produce it. The spec declares
+    * `discriminator: propertyName: type` with the default mapping, so the
+    * document's `type` value is the component name.
+    */
+  private def discriminate(
+    alternatives: Seq[(String, Json)],
+    schema: Json,
+    doc: Json
+  ): Seq[(String, Json)] = {
+    val narrowed = for {
+      propertyName <- resolve(schema).hcursor
+        .downField("discriminator")
+        .get[String]("propertyName")
+        .toOption
+      value <- doc.hcursor.get[String](propertyName).toOption
+      matching = alternatives.filter { case (name, _) => name == value }
+      if matching.nonEmpty
+    } yield matching
+
+    narrowed.getOrElse(alternatives)
+  }
+
   private lazy val specJson: Json = OpenApiSpec.parsed
 
   private def circeOf(file: File): Json = {
@@ -468,10 +495,7 @@ class OpenApiSpecResponseTest extends AnyFunSpec with Matchers {
 
   /** Follows a `$ref` to the schema it names. */
   private def resolve(schema: Json): Json =
-    schema.hcursor.get[String]("$ref").toOption match {
-      case Some(ref) => schemaRef(ref.stripPrefix("#/components/schemas/"))
-      case None      => schema
-    }
+    refNameOf(schema).map(schemaRef).getOrElse(schema)
 
   private def branches(schema: Json): Vector[Json] = {
     val s = resolve(schema)

--- a/search/src/test/scala/weco/api/search/openapi/OpenApiSpecResponseTest.scala
+++ b/search/src/test/scala/weco/api/search/openapi/OpenApiSpecResponseTest.scala
@@ -207,6 +207,255 @@ class OpenApiSpecResponseTest extends AnyFunSpec with Matchers {
     }
   }
 
+  /** The walk above catches a field the pipeline added and we never documented. This
+    * is the reverse: a field the spec documents should appear in at least one fixture,
+    * or it is evidence of a removal the spec never caught up with (or a field that was
+    * never real).
+    *
+    * Fields are compared per component, not per position: `Identifier.value` counts
+    * as exercised wherever an identifier appears, so a fixture doesn't need to carry
+    * identifiers on every entity that can hold them. Some documented fields are
+    * genuinely rare and the generated sample doesn't reach them at all; those are
+    * allowed by name below, so a removal of anything else fails here.
+    */
+  describe("the fixture coverage") {
+    it("exhibits every field the spec documents") {
+      val observed = testDocuments.flatMap { file =>
+        val doc = circeOf(file)
+
+        for {
+          display <- doc.hcursor
+            .downField("document")
+            .downField("display")
+            .focus
+            .toSeq
+          name <- schemaNameOf(display).toSeq
+          path <- observedFields(schemaRef(name), display, name)
+        } yield path
+      }.toSet
+
+      val missing = documentedFields -- observed -- allowedUnexercised
+
+      withClue(
+        s"""|The spec documents these fields, but no fixture contains them. Either the
+            |pipeline no longer emits them and the spec should drop them, or they are
+            |rare and belong in allowedUnexercised with a note.
+            |
+            |${missing.toSeq.sorted.mkString("\n  ")}
+            |""".stripMargin
+      ) {
+        missing shouldBe empty
+      }
+    }
+
+    it("does not allow fields the fixtures exercise") {
+      // Entries here would mask a regression the assertion above exists to catch.
+      val observed = testDocuments.flatMap { file =>
+        val doc = circeOf(file)
+
+        for {
+          display <- doc.hcursor
+            .downField("document")
+            .downField("display")
+            .focus
+            .toSeq
+          name <- schemaNameOf(display).toSeq
+          path <- observedFields(schemaRef(name), display, name)
+        } yield path
+      }.toSet
+
+      allowedUnexercised.intersect(observed) shouldBe empty
+    }
+
+    it("notices a documented field that no fixture contains") {
+      // A control: an invented property must show up in the documented set.
+      documentedFieldsFrom(
+        "Work",
+        name =>
+          if (name != "Work") schemaRef(name)
+          else {
+            val work = schemaRef("Work")
+            work.hcursor
+              .downField("properties")
+              .focus
+              .flatMap(_.asObject)
+              .map(
+                _.add(
+                  "neverEmitted",
+                  Json.obj("type" -> Json.fromString("string"))))
+              .map(Json.fromJsonObject)
+              .flatMap(
+                props =>
+                  work.hcursor
+                    .downField("properties")
+                    .set(props)
+                    .top
+              )
+              .get
+          }
+      ) should contain("Work.neverEmitted")
+    }
+  }
+
+  /** Documented fields with no fixture yet. Each needs a reason; an entry the fixtures
+    * do exercise fails the guard test above, so this list cannot rot silently.
+    */
+  private lazy val allowedUnexercised: Set[String] = Set(
+    // Spliced in by the API at request time, never part of an indexed document.
+    "Image.withSimilarFeatures",
+    // Real fields the deterministic sample never populates. Teaching the pipeline's
+    // document generators about them would let these come off the list.
+    "AccessCondition.note",
+    "AccessCondition.terms",
+    "Agent.identifiers",
+    "Item.note",
+    "Item.title",
+    "Period.id",
+    "Period.identifiers",
+    "Place.id",
+    "Place.identifiers",
+    "ProductionEvent.function",
+    "Work.createdDate",
+    "Work.currentFrequency",
+    "Work.physicalDescription",
+    "Work.referenceNumber",
+    // The current ingestor's display model has no such fields at all (see
+    // catalogue_graph/src/ingestor/models/display/{work,relation}.py in the
+    // pipeline repo, confirmed against the live API). The spec documents them
+    // until we decide whether to drop them or restore them in the pipeline.
+    "RelatedWork.partOf",
+    "Work.precededBy",
+    "Work.succeededBy"
+  )
+
+  /** Every property of every component reachable from the Work and Image schemas, as
+    * `Component.property` paths; inline sub-objects extend the dotted path instead.
+    */
+  private lazy val documentedFields: Set[String] =
+    documentedFieldsFrom("Work", schemaRef) ++
+      documentedFieldsFrom("Image", schemaRef)
+
+  private def refNameOf(schema: Json): Option[String] =
+    schema.hcursor
+      .get[String]("$ref")
+      .toOption
+      .map(_.stripPrefix("#/components/schemas/"))
+
+  private def documentedFieldsFrom(
+    root: String,
+    componentSchema: String => Json
+  ): Set[String] = {
+    val visited = scala.collection.mutable.Set(root)
+    val queue = scala.collection.mutable.Queue(root)
+    val paths = scala.collection.mutable.Set.empty[String]
+
+    // A $ref starts its own component walk; everything inline extends the path.
+    def follow(schema: Json, path: String): Unit =
+      refNameOf(schema) match {
+        case Some(name) => if (visited.add(name)) queue += name
+        case None       => walkInline(schema, path)
+      }
+
+    def walkInline(schema: Json, path: String): Unit = {
+      schema.hcursor
+        .downField("oneOf")
+        .focus
+        .flatMap(_.asArray)
+        .getOrElse(Vector.empty)
+        .foreach(follow(_, path))
+
+      schema.hcursor
+        .downField("properties")
+        .focus
+        .flatMap(_.asObject)
+        .foreach(_.toIterable.foreach {
+          case (key, sub) =>
+            paths += s"$path.$key"
+            follow(sub, s"$path.$key")
+        })
+
+      schema.hcursor
+        .downField("items")
+        .focus
+        .foreach(follow(_, s"$path[]"))
+    }
+
+    while (queue.nonEmpty) {
+      val name = queue.dequeue()
+      walkInline(componentSchema(name), name)
+    }
+
+    paths.toSet
+  }
+
+  /** Reports every key in `doc` that the schema documents, in the same path grammar
+    * as [[documentedFields]]: paths restart at each named component, so a field
+    * counts as observed wherever it appears.
+    *
+    * Where `oneOf` branches share a property name, this follows all of them, so a
+    * field counts under every branch that could have produced it.
+    */
+  private def observedFields(
+    schema: Json,
+    doc: Json,
+    path: String
+  ): Seq[String] =
+    doc.asObject match {
+      case Some(obj) =>
+        val alternatives = namedBranches(schema, path)
+
+        obj.toIterable.toSeq.flatMap {
+          case (key, value) =>
+            alternatives.flatMap {
+              case (base, alt) =>
+                alt.hcursor
+                  .downField("properties")
+                  .downField(key)
+                  .focus
+                  .toSeq
+                  .flatMap { sub =>
+                    s"$base.$key" +: observedFields(sub, value, s"$base.$key")
+                  }
+            }
+        }
+
+      case None =>
+        doc.asArray match {
+          case Some(items) =>
+            namedBranches(schema, path).flatMap {
+              case (base, alt) =>
+                alt.hcursor.downField("items").focus.toSeq.flatMap { s =>
+                  items.flatMap(observedFields(s, _, s"$base[]"))
+                }
+            }
+
+          case None => Seq.empty
+        }
+    }
+
+  /** The `oneOf` alternatives of a schema, resolved, each with the path its fields
+    * belong under: the component name for a `$ref`, the inline path otherwise.
+    */
+  private def namedBranches(
+    schema: Json,
+    path: String
+  ): Seq[(String, Json)] = {
+    def named(s: Json): (String, Json) =
+      refNameOf(s) match {
+        case Some(name) => (name, schemaRef(name))
+        case None       => (path, s)
+      }
+
+    val (base, resolved) = named(schema)
+
+    resolved.hcursor
+      .downField("oneOf")
+      .focus
+      .flatMap(_.asArray)
+      .map(_.map(named))
+      .getOrElse(Vector((base, resolved)))
+  }
+
   private lazy val specJson: Json = OpenApiSpec.parsed
 
   private def circeOf(file: File): Json = {

--- a/search/src/test/scala/weco/api/search/openapi/OpenApiSpecResponseTest.scala
+++ b/search/src/test/scala/weco/api/search/openapi/OpenApiSpecResponseTest.scala
@@ -303,22 +303,16 @@ class OpenApiSpecResponseTest extends AnyFunSpec with Matchers {
   private lazy val allowedUnexercised: Set[String] = Set(
     // Spliced in by the API at request time, never part of an indexed document.
     "Image.withSimilarFeatures",
-    // Real fields the deterministic sample never populates. Teaching the pipeline's
-    // document generators about them would let these come off the list.
-    "AccessCondition.note",
-    "AccessCondition.terms",
-    "Agent.identifiers",
-    "Item.note",
-    "Item.title",
+    // The spec reaches Period and Place only through production events and
+    // createdDate, where the ingestor's display transformer builds label-only
+    // concepts, dropping ids and identifiers even for identified concepts
+    // (work_display_transformer.py in the pipeline repo; the live API emits
+    // none either). Allowed rather than removed in case the transformer learns
+    // to keep them; the rare-fields fixture already carries identified inputs.
     "Period.id",
     "Period.identifiers",
     "Place.id",
-    "Place.identifiers",
-    "ProductionEvent.function",
-    "Work.createdDate",
-    "Work.currentFrequency",
-    "Work.physicalDescription",
-    "Work.referenceNumber"
+    "Place.identifiers"
   )
 
   /** Every property of every component reachable from the Work and Image schemas, as

--- a/search/src/test/scala/weco/api/search/works/WorksErrorsTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksErrorsTest.scala
@@ -11,7 +11,7 @@ class WorksErrorsTest
     with TableDrivenPropertyChecks {
 
   val includesString =
-    "['identifiers', 'items', 'holdings', 'subjects', 'genres', 'contributors', 'production', 'languages', 'archive', 'collection', 'notes', 'formerFrequency', 'designation', 'images', 'parts', 'partOf', 'precededBy', 'succeededBy']"
+    "['identifiers', 'items', 'holdings', 'subjects', 'genres', 'contributors', 'production', 'languages', 'archive', 'collection', 'notes', 'formerFrequency', 'designation', 'images', 'parts', 'partOf']"
 
   describe("returns a 400 Bad Request for errors in the ?include parameter") {
     it("a single invalid include") {

--- a/search/src/test/scala/weco/api/search/works/WorksIncludesTest.scala
+++ b/search/src/test/scala/weco/api/search/works/WorksIncludesTest.scala
@@ -41,6 +41,30 @@ class WorksIncludesTest extends AnyFunSpec with ApiWorksTestBase {
     }
   }
 
+  it("accepts the deprecated includes and ignores them") {
+    // precededBy and succeededBy stopped existing with catalogue_graph, but
+    // iiif-builder still sends them, so they must not 400 yet.
+    withWorksApi {
+      case (worksIndex, routes) =>
+        indexTestDocuments(worksIndex, "works.visible.0")
+
+        assertJsonResponse(
+          routes,
+          path = s"$rootPath/works/afza5vpu?include=precededBy,succeededBy"
+        ) {
+          Status.OK -> s"""
+            {
+              "id" : "afza5vpu",
+              "title" : "52RvEJgwBuNO6n9",
+              "alternativeTitles": [],
+              "availabilities": [],
+              "type": "Work"
+            }
+          """
+        }
+    }
+  }
+
   it("renders the items if the items include is present") {
     withWorksApi {
       case (worksIndex, routes) =>

--- a/smoke_tests/stressTests.yml
+++ b/smoke_tests/stressTests.yml
@@ -41,7 +41,7 @@ scenarios:
   - name: "Normal usage"
     flow:
       - get:
-          url: "/catalogue/v2/works?query={{ query }}&includes=identifiers,production,contributors,subjects,partOf&aggregations=workType,availabilities,genres.label,languages,subjects.label,contributors.agent.label"
+          url: "/catalogue/v2/works?query={{ query }}&include=identifiers,production,contributors,subjects,partOf&aggregations=workType,availabilities,genres.label,languages,subjects.label,contributors.agent.label"
       - think: 0.5
       - get:
-          url: "/catalogue/v2/works/{{ id }}?includes=identifiers,images,items,subjects,genres,contributors,production,notes,parts,partOf,languages,holdings"
+          url: "/catalogue/v2/works/{{ id }}?include=identifiers,images,items,subjects,genres,contributors,production,notes,parts,partOf,languages,holdings"

--- a/smoke_tests/stressTests.yml
+++ b/smoke_tests/stressTests.yml
@@ -30,12 +30,10 @@ config:
         - duration: 10
           arrivalRate: 10
   payload:
-    -
-      path: "ids.csv"
+    - path: "ids.csv"
       fields:
         - "id"
-    -
-      path: "queries.csv"
+    - path: "queries.csv"
       fields:
         - "query"
 
@@ -46,4 +44,4 @@ scenarios:
           url: "/catalogue/v2/works?query={{ query }}&includes=identifiers,production,contributors,subjects,partOf&aggregations=workType,availabilities,genres.label,languages,subjects.label,contributors.agent.label"
       - think: 0.5
       - get:
-          url: "/catalogue/v2/works/{{ id }}?includes=identifiers,images,items,subjects,genres,contributors,production,notes,parts,partOf,precededBy,succeededBy,languages,holdings"
+          url: "/catalogue/v2/works/{{ id }}?includes=identifiers,images,items,subjects,genres,contributors,production,notes,parts,partOf,languages,holdings"


### PR DESCRIPTION
## What does this change?

`OpenApiSpecResponseTest` caught fields the pipeline emits that the spec misses, but nothing caught the reverse: a field removed from the display model stayed documented forever unless a schema happened to mark it required. This is step 2 of wellcomecollection/platform#6514.

The new assertion enumerates every property of every component reachable from the `Work` and `Image` schemas and requires each to appear in at least one fixture. Comparison is per component rather than per position, so `Identifier.value` counts as exercised wherever an identifier appears and a rarely-identified nested entity doesn't need its own fixture. A `oneOf` with a discriminator credits a field only to the branch the document names, so a field shared between location types can't be masked by the sibling branch. Guard tests back it: an invented schema property must be reported missing, an allowlisted field that becomes exercised fails, and the spec is pinned to the schema keywords the walks understand (an `allOf` refactor would otherwise silently exempt its subtree from every check in the file).

The first run surfaced 18 documented fields no fixture contained, and this PR resolves all of them:

- `precededBy`, `succeededBy` and nested `RelatedWork.partOf` were lost in the pipeline's move to catalogue_graph (absent from the Pydantic display models, confirmed against the live API), so they leave the spec. The include values are accepted and ignored rather than rejected, because iiif-builder sends them on every request; an enum test pins them as undocumented, and they can be rejected once iiif-builder stops. The response keys are stripped unconditionally so a rollback or `elasticCluster` override serving an old index can't leak them.
- Ten were real fields the deterministic fixture sample never populated: `Work.physicalDescription`, `Work.referenceNumber`, `Work.createdDate`, `Work.currentFrequency`, `Item.title`, `Item.note`, `AccessCondition.note`, `AccessCondition.terms`, `ProductionEvent.function` and `Agent.identifiers`. wellcomecollection/catalogue-pipeline#3566 teaches the generators to populate them via a new `work.visible.rare-fields.json` fixture, which this PR pulls in.
- Ids and identifiers on `Period` and `Place` leave the spec too: the ingestor's display transformer drops them even for identified concepts, and if it ever stops, the existing undocumented-fields walk forces re-documentation on the next fixture refresh.
- One field stays allowlisted with its reason in the code: `Image.withSimilarFeatures` is spliced in by the API at request time, so no indexed fixture can carry it.

Also fixed along the way, prompted by review: the stress tests passed `includes=` (a parameter name the API ignores) so they exercised no includes at all, now corrected to `include=`; and `copy_test_documents.py` now mirrors upstream deletions instead of only copying.

This branch carries the fixture wellcomecollection/catalogue-pipeline#3566 generates; that PR merged on 2026-08-17, so the fixtures here now match pipeline main and this is ready for review.

### Checklist

- [x] Does this patch need a change to the documentation? The test table in `reference/README.md` is updated; the developers site picks up the spec change via the existing sync. Its prose examples still mention the removed includes and need a small follow-up there.
- [x] Does this change the API surface? Yes: the spec drops the dead response fields. The deprecated include values remain accepted (and ignored) so no client breaks.

## How to test

```
yarn lint:openapi
sbt "search/testOnly weco.api.search.openapi.*"
sbt search/test
```

All 406 search tests pass. To see the new assertion work, add an invented property to the `Work` schema in `reference/catalogue.yaml` and `OpenApiSpecResponseTest` fails naming it.

## How can we measure success?

A display-model removal now fails CI the moment fixtures refresh, instead of leaving the spec documenting fields that no longer exist. The 18 stale documented fields found on the first run drop to 1, with its reason recorded.

## Have we considered potential risks?

- iiif-builder sends the deprecated includes by default, which is why they are tolerated rather than rejected; nothing changes for it. Rejecting them later needs an iiif-builder release first.
- Old indices still contain the removed fields, so the response path strips those keys unconditionally rather than relying on include gating.
- The remaining allowlist entry could hide a future regression, which is why the guard test fails if it becomes exercised.


