### PR TITLE
Trigger TypeScript type generation on wellcomecollection.org when the spec changes

### DIFF
--- a/.github/workflows/sync-catalogue-types.yml
+++ b/.github/workflows/sync-catalogue-types.yml
@@ -1,0 +1,36 @@
+name: Notify wellcomecollection.org of OpenAPI spec changes
+
+# wellcomecollection.org generates TypeScript types from this spec. Tell it
+# when the spec changes so it can regenerate them.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "reference/catalogue.yaml"
+  workflow_dispatch:
+
+jobs:
+  dispatch-spec-updated:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          # Both are stored as repo secrets on catalogue-api, shared with
+          # sync-openapi-spec.yml.
+          client-id: ${{ secrets.SYNC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          repositories: wellcomecollection.org
+
+      - name: Send repository_dispatch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/wellcomecollection/wellcomecollection.org/dispatches \
+            -f event_type=catalogue-spec-updated \
+            -f "client_payload[source_sha]=${{ github.sha }}"

--- a/reference/README.md
+++ b/reference/README.md
@@ -10,6 +10,12 @@ request against
 to update its copy at `reference/catalogue.yaml`. Don't edit that copy by hand; it will
 be overwritten by the next sync.
 
+[wellcomecollection.org](https://github.com/wellcomecollection/wellcomecollection.org)
+generates TypeScript types from this spec. When it changes on `main`,
+`.github/workflows/sync-catalogue-types.yml` sends that repo a
+`repository_dispatch` event (`catalogue-spec-updated`), and a workflow there
+regenerates its committed types and opens a pull request if they changed.
+
 ## What it covers
 
 One file, two services, because both are served under


### PR DESCRIPTION
- For https://github.com/wellcomecollection/platform/issues/6514

## What does this change?

This is step 4 of the plan in wellcomecollection/platform#6514: get TypeScript types generated from the OpenAPI spec in front of wellcomecollection.org, with the spec as the single source of truth.

Generation itself lives in wellcomecollection.org (openapi-typescript sits in their toolchain, they control the generator version and output location, and this repo doesn't carry a TypeScript artefact it never consumes). A companion draft PR over there adds the devDependency, a `generate:catalogue-types` script that reads `reference/catalogue.yaml` straight from this repo's `main`, the committed output, and a workflow that regenerates and opens an auto-PR when the output changes.

This PR adds the trigger half: `.github/workflows/sync-catalogue-types.yml` runs on pushes to `main` that touch `reference/catalogue.yaml` (or on manual dispatch), mints a token with the same GitHub App used by `sync-openapi-spec.yml`, and sends wellcomecollection.org a `repository_dispatch` event (`catalogue-spec-updated`). Their workflow listens for that event, with a weekly cron as a fallback so a missed dispatch self-heals. `reference/README.md` gets a short note describing the arrangement.

**Before this can run**, the sync GitHub App needs `wellcomecollection.org` added to its installation's repository access. The `SYNC_APP_CLIENT_ID` / `SYNC_APP_PRIVATE_KEY` secrets already exist in this repo for `sync-openapi-spec.yml`; no new secrets are needed. Until then the token minting step will fail. The workflow is also inert until the companion wellcomecollection.org PR merges, since nothing listens for the event yet.

### Checklist

- [x] Does this patch need a change to the documentation? (`reference/README.md` updated)
- [ ] Does this change the API surface? No.

## How to test

Once the app installation covers wellcomecollection.org and the companion PR is merged there, trigger the workflow via workflow_dispatch and check that wellcomecollection.org's `sync-catalogue-types` workflow runs and, if the spec changed since its last generation, opens an auto-PR.

## How can we measure success?

Spec changes reach wellcomecollection.org as reviewable auto-PRs updating their generated types, instead of relying on someone remembering to update hand-written types.

## Have we considered potential risks?

- Until the GitHub App installation is extended to wellcomecollection.org, the workflow fails visibly at the token step; nothing is silently dropped.
- The dispatch is fire-and-forget; if wellcomecollection.org's workflow is broken or the event is missed, their weekly cron regenerates anyway.
- The generated types describe the documented spec, not wellcomecollection.org's hand-written types. Known drift there (e.g. `availableOnline`) surfaces during reconciliation, which is deliberately a follow-up with the digital-experience team.
