### PR TITLE
Harden ResilientElasticClient against Elasticsearch API key rotation

### DIFF
--- a/search/src/main/scala/weco/api/search/elasticsearch/ResilientElasticClient.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/ResilientElasticClient.scala
@@ -1,60 +1,184 @@
 package weco.api.search.elasticsearch
 
-import com.sksamuel.elastic4s.{ElasticClient, Handler, Response}
+import com.sksamuel.elastic4s.{ElasticClient, ElasticRequest, Handler, Response}
 import grizzled.slf4j.Logging
 
 import java.time.Clock
-import scala.concurrent.{ExecutionContext, Future}
+import java.util.concurrent.{Executors, ThreadFactory, TimeUnit}
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success}
 
 class ResilientElasticClient(
   clientFactory: () => ElasticClient,
-  minRefreshIntervalMs: Long = 2000
+  minRefreshIntervalMs: Long = 2000,
+  closeGraceMs: Long = 30000,
+  probeTimeoutMs: Long = 5000
 )(implicit clock: Clock, ec: ExecutionContext)
-    extends Logging {
+    extends Logging
+    with AutoCloseable {
 
   @volatile private var client: ElasticClient = clientFactory()
   @volatile private var lastRefreshTime: Long = 0
 
+  // Dedicated thread keeps the factory's blocking Secrets Manager IO off the request dispatcher
+  private val refreshExecutor = Executors.newSingleThreadScheduledExecutor(
+    new ThreadFactory {
+      override def newThread(r: Runnable): Thread = {
+        val thread = new Thread(r, "resilient-elastic-client-refresh")
+        thread.setDaemon(true)
+        thread
+      }
+    }
+  )
+  private val refreshEc = ExecutionContext.fromExecutor(refreshExecutor)
+
+  private val refreshLock = new Object
+  private var inFlightRefresh: Option[Future[Unit]] = None
+  private var pendingClose: Option[ElasticClient] = None
+
   def execute[T, U](t: T)(implicit handler: Handler[T, U],
                           manifest: Manifest[U]): Future[Response[U]] = {
     val currentClient = client
-    currentClient.execute(t).flatMap { response =>
-      response.status match {
-        case 401 | 403 =>
-          warn(
-            s"Received ${response.status} from Elasticsearch, refreshing client and retrying...")
-          refreshClient(currentClient)
-          client.execute(t)
-        case _ => Future.successful(response)
-      }
+    currentClient.execute(t).transformWith {
+      case Success(response)
+          if response.status == 401 || response.status == 403 =>
+        warn(
+          s"Received ${response.status} from Elasticsearch, refreshing client and retrying...")
+        retryIfRefreshed(currentClient, t, response)
+      case Success(response)                               => Future.successful(response)
+      case Failure(NonFatal(e)) if client ne currentClient =>
+        // Our client was replaced mid-flight and likely closed under us
+        warn(
+          "Request failed on a replaced Elasticsearch client, retrying on the current one",
+          e)
+        client.execute(t)
+      // Transport errors are not rotation evidence: fail fast, no refresh
+      case Failure(e) => Future.failed(e)
     }
   }
 
-  private def refreshClient(failedClient: ElasticClient): Unit =
-    synchronized {
-      if (client == failedClient) {
-        val now = clock.millis()
-        if (now - lastRefreshTime > minRefreshIntervalMs) {
-          val oldClient = client
-          try {
-            info("Refreshing Elasticsearch client...")
-            client = clientFactory()
-            lastRefreshTime = now
-            oldClient.close()
-            info("Elasticsearch client refreshed.")
-          } catch {
-            case e: Throwable =>
-              error("Failed to refresh Elasticsearch client", e)
-              throw e
-          }
+  // Join the coalesced refresh, then retry only if the client actually changed:
+  // a retry on the same client is futile and just duplicates load
+  private def retryIfRefreshed[T, U](failedClient: ElasticClient,
+                                     t: T,
+                                     originalResponse: Response[U])(
+    implicit handler: Handler[T, U],
+    manifest: Manifest[U]): Future[Response[U]] =
+    triggerRefresh(failedClient).flatMap { _ =>
+      val current = client
+      if (current ne failedClient) current.execute(t)
+      else Future.successful(originalResponse)
+    }
+
+  // Coalesces concurrent requests onto one in-flight refresh instead of queueing on a lock
+  private def triggerRefresh(failedClient: ElasticClient): Future[Unit] =
+    refreshLock.synchronized {
+      inFlightRefresh.getOrElse {
+        if (client ne failedClient) {
+          info("Elasticsearch client already refreshed by another thread.")
+          Future.unit
         } else {
-          warn(
-            s"Refresh requested too soon (last refresh ${now - lastRefreshTime}ms ago). " +
-              s"Skipping, waiting on cooldown: ${minRefreshIntervalMs}ms"
-          )
+          val now = clock.millis()
+          if (now - lastRefreshTime > minRefreshIntervalMs) {
+            val refresh = doRefresh()
+            inFlightRefresh = Some(refresh)
+            refresh.onComplete { _ =>
+              refreshLock.synchronized { inFlightRefresh = None }
+            }(refreshEc)
+            refresh
+          } else {
+            warn(
+              s"Refresh requested too soon (last refresh ${now - lastRefreshTime}ms ago). " +
+                s"Skipping, waiting on cooldown: ${minRefreshIntervalMs}ms"
+            )
+            Future.unit
+          }
         }
-      } else {
-        info("Elasticsearch client already refreshed by another thread.")
       }
     }
+
+  private def doRefresh(): Future[Unit] = {
+    info("Refreshing Elasticsearch client...")
+    Future(clientFactory())(refreshEc)
+      .flatMap { candidate =>
+        probeAccepts(candidate).map { accepted =>
+          if (accepted) swapIn(candidate)
+          else {
+            // Secrets Manager may still be serving the invalidated key; keep the
+            // current client and probe again on the next post-cooldown failure
+            warn("Rebuilt Elasticsearch client failed to authenticate; keeping current client.")
+            if (candidate ne client) closeQuietly(candidate)
+          }
+        }(refreshEc)
+      }(refreshEc)
+      .recover {
+        case NonFatal(e) => error("Failed to refresh Elasticsearch client", e)
+      }(refreshEc)
+      // Throttle the next refresh attempt whether or not this one healed us
+      .andThen { case _ => lastRefreshTime = clock.millis() }(refreshEc)
+  }
+
+  // Reject only a definitive 401/403: an inconclusive probe (5xx, 429, 404, timeout,
+  // exception) must not block adopting a possibly-good key during a cluster incident,
+  // and security-disabled clusters answer 4xx/404 here
+  private def probeAccepts(candidate: ElasticClient): Future[Boolean] = {
+    val promise = Promise[Boolean]()
+    candidate.client.send(
+      ElasticRequest("GET", "/_security/_authenticate"), {
+        case Right(response) =>
+          promise.trySuccess(
+            response.statusCode != 401 && response.statusCode != 403)
+        case Left(_) => promise.trySuccess(true)
+      }
+    )
+    refreshExecutor.schedule(new Runnable {
+      override def run(): Unit = promise.trySuccess(true)
+    }, probeTimeoutMs, TimeUnit.MILLISECONDS)
+    promise.future
+  }
+
+  private def swapIn(candidate: ElasticClient): Unit = {
+    val oldClient = client
+    client = candidate
+    // The fixture factory can return the same client, so never close it in that case
+    if (oldClient ne candidate) deferClose(oldClient)
+    info("Elasticsearch client refreshed.")
+  }
+
+  // Grace period lets in-flight requests on the old client complete; at most one
+  // close is deferred, bounding connection-pool buildup if swaps repeat
+  private def deferClose(oldClient: ElasticClient): Unit =
+    refreshLock.synchronized {
+      pendingClose.foreach(closeQuietly)
+      pendingClose = Some(oldClient)
+      refreshExecutor.schedule(
+        new Runnable {
+          override def run(): Unit =
+            refreshLock.synchronized {
+              if (pendingClose.exists(_ eq oldClient)) {
+                pendingClose = None
+                closeQuietly(oldClient)
+              }
+            }
+        },
+        closeGraceMs,
+        TimeUnit.MILLISECONDS
+      )
+    }
+
+  private def closeQuietly(c: ElasticClient): Unit =
+    try c.close()
+    catch {
+      case NonFatal(e) => warn("Failed to close Elasticsearch client", e)
+    }
+
+  override def close(): Unit = {
+    refreshExecutor.shutdownNow()
+    refreshLock.synchronized {
+      pendingClose.foreach(closeQuietly)
+      pendingClose = None
+    }
+    closeQuietly(client)
+  }
 }

--- a/search/src/main/scala/weco/api/search/elasticsearch/ResilientElasticClient.scala
+++ b/search/src/main/scala/weco/api/search/elasticsearch/ResilientElasticClient.scala
@@ -48,11 +48,13 @@ class ResilientElasticClient(
         retryIfRefreshed(currentClient, t, response)
       case Success(response)                               => Future.successful(response)
       case Failure(NonFatal(e)) if client ne currentClient =>
-        // Our client was replaced mid-flight and likely closed under us
+        // Our client was replaced mid-flight and likely closed under us; retry
+        // through execute so a 401 on the retry still gets refresh handling.
+        // Re-entry is bounded: each level requires another swap to have happened.
         warn(
           "Request failed on a replaced Elasticsearch client, retrying on the current one",
           e)
-        client.execute(t)
+        execute(t)
       // Transport errors are not rotation evidence: fail fast, no refresh
       case Failure(e) => Future.failed(e)
     }
@@ -132,10 +134,11 @@ class ResilientElasticClient(
         case Left(_) => promise.trySuccess(true)
       }
     )
-    refreshExecutor.schedule(new Runnable {
+    val timeout = refreshExecutor.schedule(new Runnable {
       override def run(): Unit = promise.trySuccess(true)
     }, probeTimeoutMs, TimeUnit.MILLISECONDS)
-    promise.future
+    // Don't leave a timer queued for every probe that answered promptly
+    promise.future.andThen { case _ => timeout.cancel(false) }(refreshEc)
   }
 
   private def swapIn(candidate: ElasticClient): Unit = {

--- a/search/src/test/scala/weco/api/search/elasticsearch/ResilientElasticClientTest.scala
+++ b/search/src/test/scala/weco/api/search/elasticsearch/ResilientElasticClientTest.scala
@@ -7,28 +7,48 @@ import com.sksamuel.elastic4s.{
   HttpClient,
   HttpResponse
 }
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
+
+import java.io.IOException
 import java.time.Clock
-import scala.concurrent.Future
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch}
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.{Future, Promise}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class ResilientElasticClientTest
     extends AnyFunSpec
     with Matchers
-    with ScalaFutures {
+    with ScalaFutures
+    with Eventually
+    with IntegrationPatience
+    with BeforeAndAfterAll {
 
+  private def isAuthProbe(request: ElasticRequest): Boolean =
+    request.endpoint == "/_security/_authenticate"
+
+  // Counts real requests and auth probes separately, and records close()
   class MockHttpClient(responseFunction: ElasticRequest => Future[HttpResponse])
       extends HttpClient {
-    override def send(request: ElasticRequest,
-                      callback: Either[Throwable, HttpResponse] => Unit): Unit =
+    val requestCount = new AtomicInteger(0)
+    val probeCount = new AtomicInteger(0)
+    @volatile var closed = false
+
+    override def send(
+      request: ElasticRequest,
+      callback: Either[Throwable, HttpResponse] => Unit): Unit = {
+      if (isAuthProbe(request)) probeCount.incrementAndGet()
+      else requestCount.incrementAndGet()
       responseFunction(request).onComplete {
         case scala.util.Success(response)  => callback(Right(response))
         case scala.util.Failure(exception) => callback(Left(exception))
       }
+    }
 
-    override def close(): Unit = {}
+    override def close(): Unit = closed = true
   }
 
   def createResponse(statusCode: Int, body: String = ""): HttpResponse =
@@ -36,6 +56,16 @@ class ResilientElasticClientTest
       statusCode,
       Some(com.sksamuel.elastic4s.HttpEntity.StringEntity(body, None)),
       Map.empty)
+
+  def respond(statusCode: Int): ElasticRequest => Future[HttpResponse] =
+    _ => Future.successful(createResponse(statusCode))
+
+  def respondWith(probeStatus: Int,
+                  requestStatus: Int): ElasticRequest => Future[HttpResponse] =
+    request =>
+      Future.successful(
+        createResponse(
+          if (isAuthProbe(request)) probeStatus else requestStatus))
 
   // Dummy handler for string requests
   implicit val handler: Handler[String, String] = new Handler[String, String] {
@@ -49,259 +79,409 @@ class ResilientElasticClientTest
     override def build(t: String): ElasticRequest = ElasticRequest("GET", "/")
   }
 
-  describe("ResilientElasticClient") {
-    it("retries on 401") {
-      var callCount = 0
-      var factoryCallCount = 0
-      val clientFactory = () => {
-        factoryCallCount += 1
-        val httpClient = new MockHttpClient(_ => {
-          callCount += 1
-          if (callCount == 1) {
-            Future.successful(createResponse(401))
-          } else {
-            Future.successful(createResponse(200, "{}"))
-          }
-        })
-        ElasticClient(httpClient)
-      }
+  implicit val clock: Clock = Clock.systemUTC()
 
-      implicit val clock = Clock.systemUTC()
-      val resilientClient = new ResilientElasticClient(clientFactory)
+  // Wraps each mock in a fresh ElasticClient: call n gets the nth mock, the last repeats
+  def clientSequenceFactory(
+    clients: MockHttpClient*): (() => ElasticClient, AtomicInteger) = {
+    val calls = new AtomicInteger(0)
+    val factory = () => {
+      val n = calls.incrementAndGet()
+      ElasticClient(clients(math.min(n, clients.size) - 1))
+    }
+    (factory, calls)
+  }
+
+  private val createdClients =
+    new ConcurrentLinkedQueue[ResilientElasticClient]()
+
+  def newResilientClient(factory: () => ElasticClient,
+                         minRefreshIntervalMs: Long = 2000,
+                         closeGraceMs: Long = 30000): ResilientElasticClient = {
+    val resilientClient =
+      new ResilientElasticClient(factory, minRefreshIntervalMs, closeGraceMs)
+    createdClients.add(resilientClient)
+    resilientClient
+  }
+
+  override def afterAll(): Unit = {
+    createdClients.forEach(c => c.close())
+    super.afterAll()
+  }
+
+  describe("ResilientElasticClient") {
+    it("retries on 401 against a refreshed client") {
+      val broken = new MockHttpClient(respond(401))
+      val healthy = new MockHttpClient(respond(200))
+      val (factory, factoryCallCount) = clientSequenceFactory(broken, healthy)
+      val resilientClient = newResilientClient(factory)
 
       val future = resilientClient.execute("test request")
-
       whenReady(future) { response =>
         response.status shouldBe 200
-        callCount shouldBe 2
-        factoryCallCount shouldBe 2 // Initial + Refresh
+        factoryCallCount.get shouldBe 2 // Initial + refresh
+        broken.requestCount.get shouldBe 1
+        healthy.requestCount.get shouldBe 1
+        healthy.probeCount.get shouldBe 1 // Validated before swap
       }
     }
 
-    it("retries on 403") {
-      var callCount = 0
-      var factoryCallCount = 0
-      val clientFactory = () => {
-        factoryCallCount += 1
-        val httpClient = new MockHttpClient(_ => {
-          callCount += 1
-          if (callCount == 1) {
-            Future.successful(createResponse(403))
-          } else {
-            Future.successful(createResponse(200, "{}"))
-          }
-        })
-        ElasticClient(httpClient)
-      }
-
-      implicit val clock = Clock.systemUTC()
-      val resilientClient = new ResilientElasticClient(clientFactory)
+    it("retries on 403 against a refreshed client") {
+      val broken = new MockHttpClient(respond(403))
+      val healthy = new MockHttpClient(respond(200))
+      val (factory, factoryCallCount) = clientSequenceFactory(broken, healthy)
+      val resilientClient = newResilientClient(factory)
 
       val future = resilientClient.execute("test request")
-
       whenReady(future) { response =>
         response.status shouldBe 200
-        callCount shouldBe 2
-        factoryCallCount shouldBe 2
+        factoryCallCount.get shouldBe 2
+        broken.requestCount.get shouldBe 1
+        healthy.requestCount.get shouldBe 1
       }
     }
 
     it("does not retry on 404") {
-      var callCount = 0
-      var factoryCallCount = 0
-      val clientFactory = () => {
-        factoryCallCount += 1
-        val httpClient = new MockHttpClient(_ => {
-          callCount += 1
-          Future.successful(createResponse(404))
-        })
-        ElasticClient(httpClient)
-      }
-
-      implicit val clock = Clock.systemUTC()
-      val resilientClient = new ResilientElasticClient(clientFactory)
+      val httpClient = new MockHttpClient(respond(404))
+      val (factory, factoryCallCount) = clientSequenceFactory(httpClient)
+      val resilientClient = newResilientClient(factory)
 
       val future = resilientClient.execute("test request")
-
       whenReady(future) { response =>
         response.status shouldBe 404
-        callCount shouldBe 1
-        factoryCallCount shouldBe 1
+        httpClient.requestCount.get shouldBe 1
+        factoryCallCount.get shouldBe 1
       }
     }
 
     it("does not retry on 500") {
-      var callCount = 0
-      var factoryCallCount = 0
-      val clientFactory = () => {
-        factoryCallCount += 1
-        val httpClient = new MockHttpClient(_ => {
-          callCount += 1
-          Future.successful(createResponse(500))
-        })
-        ElasticClient(httpClient)
-      }
-
-      implicit val clock = Clock.systemUTC()
-      val resilientClient = new ResilientElasticClient(clientFactory)
+      val httpClient = new MockHttpClient(respond(500))
+      val (factory, factoryCallCount) = clientSequenceFactory(httpClient)
+      val resilientClient = newResilientClient(factory)
 
       val future = resilientClient.execute("test request")
-
       whenReady(future) { response =>
         response.status shouldBe 500
-        callCount shouldBe 1
-        factoryCallCount shouldBe 1
+        httpClient.requestCount.get shouldBe 1
+        factoryCallCount.get shouldBe 1
       }
     }
 
-    it("only retries once") {
-      var callCount = 0
-      var factoryCallCount = 0
-      val clientFactory = () => {
-        factoryCallCount += 1
-        val httpClient = new MockHttpClient(_ => {
-          callCount += 1
-          Future.successful(createResponse(401))
-        })
-        ElasticClient(httpClient)
-      }
-
-      implicit val clock = Clock.systemUTC()
-      val resilientClient = new ResilientElasticClient(clientFactory)
+    it("returns the original 401 without a retry if the refresh is rejected") {
+      val original = new MockHttpClient(respond(401))
+      val deadCandidate = new MockHttpClient(respond(401))
+      val (factory, factoryCallCount) =
+        clientSequenceFactory(original, deadCandidate)
+      val resilientClient = newResilientClient(factory)
 
       val future = resilientClient.execute("test request")
-
       whenReady(future) { response =>
         response.status shouldBe 401
-        callCount shouldBe 2
-        factoryCallCount shouldBe 2
+        factoryCallCount.get shouldBe 2
+        original.requestCount.get shouldBe 1 // No futile second execution
+        deadCandidate.probeCount.get shouldBe 1
+        deadCandidate.requestCount.get shouldBe 0 // Never swapped in
+        deadCandidate.closed shouldBe true
       }
+    }
+
+    it("accepts a swap when the probe is inconclusive") {
+      val broken = new MockHttpClient(respond(401))
+      // 5xx from the probe is not evidence of a bad key
+      val candidate = new MockHttpClient(respondWith(500, 200))
+      val (factory, factoryCallCount) = clientSequenceFactory(broken, candidate)
+      val resilientClient = newResilientClient(factory)
+
+      val future = resilientClient.execute("test request")
+      whenReady(future) { response =>
+        response.status shouldBe 200
+        factoryCallCount.get shouldBe 2
+        candidate.requestCount.get shouldBe 1
+      }
+    }
+
+    it("propagates a transport failure without refreshing") {
+      val boom = new IOException("connection reset")
+      val broken = new MockHttpClient(_ => Future.failed(boom))
+      val (factory, factoryCallCount) = clientSequenceFactory(broken)
+      val resilientClient = newResilientClient(factory)
+
+      val future = resilientClient.execute("test request")
+      whenReady(future.failed) { e =>
+        e should be theSameInstanceAs boom
+        broken.requestCount.get shouldBe 1 // Fail fast, no retry
+        factoryCallCount.get shouldBe 1 // No refresh triggered
+      }
+    }
+
+    it("retries a transport failure on the current client after a swap") {
+      val firstRequestGate = Promise[HttpResponse]()
+      val brokenSeen = new AtomicInteger(0)
+      // First request is held open; later requests fail fast with 401
+      val broken = new MockHttpClient(
+        _ =>
+          if (brokenSeen.incrementAndGet() == 1) firstRequestGate.future
+          else Future.successful(createResponse(401)))
+      val healthy = new MockHttpClient(respond(200))
+      val (factory, factoryCallCount) = clientSequenceFactory(broken, healthy)
+      val resilientClient = newResilientClient(factory)
+
+      val heldRequest = resilientClient.execute("held request")
+      eventually { broken.requestCount.get shouldBe 1 }
+
+      // This request triggers the refresh and swaps in the healthy client
+      val refreshingRequest = resilientClient.execute("fast request")
+      whenReady(refreshingRequest) { response =>
+        response.status shouldBe 200
+      }
+
+      // The held request now fails at transport level: its client was closed under it
+      firstRequestGate.failure(new IOException("connection closed"))
+      whenReady(heldRequest) { response =>
+        response.status shouldBe 200
+      }
+      factoryCallCount.get shouldBe 2 // The failure did not trigger a refresh
+      healthy.requestCount.get shouldBe 2
+    }
+
+    it("retries against the current client when it was refreshed mid-request") {
+      val firstRequestGate = Promise[HttpResponse]()
+      val brokenSeen = new AtomicInteger(0)
+      // First request is held open; later requests fail fast
+      val broken = new MockHttpClient(
+        _ =>
+          if (brokenSeen.incrementAndGet() == 1) firstRequestGate.future
+          else Future.successful(createResponse(401)))
+      val healthy = new MockHttpClient(respond(200))
+      val (factory, factoryCallCount) = clientSequenceFactory(broken, healthy)
+
+      // Huge cooldown: the held request must not be able to refresh again
+      val resilientClient =
+        newResilientClient(factory, minRefreshIntervalMs = 600000)
+
+      val heldRequest = resilientClient.execute("held request")
+      eventually { broken.requestCount.get shouldBe 1 }
+
+      // This request triggers the refresh and succeeds on the new client
+      val refreshingRequest = resilientClient.execute("fast request")
+      whenReady(refreshingRequest) { response =>
+        response.status shouldBe 200
+      }
+      factoryCallCount.get shouldBe 2
+
+      // The held request now fails with 401 but must retry on the refreshed client
+      firstRequestGate.success(createResponse(401))
+      whenReady(heldRequest) { response =>
+        response.status shouldBe 200
+      }
+      factoryCallCount.get shouldBe 2
+      broken.requestCount.get shouldBe 2 // No retry against the stale client
+      healthy.requestCount.get shouldBe 2
+    }
+
+    it("recovers once a dead secret starts serving a working key") {
+      @volatile var secretIsDead = true
+      val original = new MockHttpClient(respond(401))
+      val rebuilt = new ConcurrentLinkedQueue[MockHttpClient]()
+      val factoryCallCount = new AtomicInteger(0)
+
+      val factory = () =>
+        if (factoryCallCount.incrementAndGet() == 1) ElasticClient(original)
+        else {
+          // A client built from a dead key stays dead
+          val mock =
+            if (secretIsDead) new MockHttpClient(respond(401))
+            else new MockHttpClient(respond(200))
+          rebuilt.add(mock)
+          ElasticClient(mock)
+      }
+
+      val resilientClient =
+        newResilientClient(factory, minRefreshIntervalMs = 100)
+
+      // While the secret is dead the rebuilt client fails validation and is discarded
+      val deadFuture = resilientClient.execute("request 1")
+      whenReady(deadFuture) { response =>
+        response.status shouldBe 401
+        factoryCallCount.get shouldBe 2
+      }
+      original.requestCount.get shouldBe 1 // Original 401 returned, no retry
+      val deadRebuild = rebuilt.peek()
+      deadRebuild.probeCount.get shouldBe 1
+      deadRebuild.requestCount.get shouldBe 0 // Never swapped in
+      deadRebuild.closed shouldBe true
+
+      // After the cooldown, a refresh with a working key heals the client
+      Thread.sleep(150)
+      secretIsDead = false
+      val healedFuture = resilientClient.execute("request 2")
+      whenReady(healedFuture) { response =>
+        response.status shouldBe 200
+        factoryCallCount.get shouldBe 3
+      }
+      original.closed shouldBe false // Still in its close grace period
+    }
+
+    it("does not close the old client immediately after a refresh") {
+      val broken = new MockHttpClient(respond(401))
+      val healthy = new MockHttpClient(respond(200))
+      val (factory, _) = clientSequenceFactory(broken, healthy)
+      val resilientClient = newResilientClient(factory)
+
+      val future = resilientClient.execute("test request")
+      whenReady(future) { response =>
+        response.status shouldBe 200
+      }
+      broken.closed shouldBe false
+    }
+
+    it("closes the old client after the grace period") {
+      val broken = new MockHttpClient(respond(401))
+      val healthy = new MockHttpClient(respond(200))
+      val (factory, _) = clientSequenceFactory(broken, healthy)
+      val resilientClient = newResilientClient(factory, closeGraceMs = 50)
+
+      val future = resilientClient.execute("test request")
+      whenReady(future) { response =>
+        response.status shouldBe 200
+      }
+      eventually { broken.closed shouldBe true }
+    }
+
+    it("closes a pending old client as soon as another swap happens") {
+      val first = new MockHttpClient(respond(401))
+      // Second client authenticates but still 401s requests, forcing another swap
+      val second = new MockHttpClient(respondWith(200, 401))
+      val third = new MockHttpClient(respond(200))
+      val (factory, factoryCallCount) =
+        clientSequenceFactory(first, second, third)
+      val resilientClient =
+        newResilientClient(factory, minRefreshIntervalMs = 1)
+
+      val future1 = resilientClient.execute("request 1")
+      whenReady(future1) { response =>
+        response.status shouldBe 401 // Retried on second, which also 401s
+      }
+      first.closed shouldBe false // Deferred
+
+      Thread.sleep(10)
+
+      val future2 = resilientClient.execute("request 2")
+      whenReady(future2) { response =>
+        response.status shouldBe 200
+      }
+      factoryCallCount.get shouldBe 3
+      first.closed shouldBe true // Displaced by the newer pending close
+      second.closed shouldBe false // Now the one deferred
+    }
+
+    it("closes the current and pending clients on close()") {
+      val broken = new MockHttpClient(respond(401))
+      val healthy = new MockHttpClient(respond(200))
+      val (factory, _) = clientSequenceFactory(broken, healthy)
+      val resilientClient = newResilientClient(factory)
+
+      val future = resilientClient.execute("test request")
+      whenReady(future) { response =>
+        response.status shouldBe 200
+      }
+
+      resilientClient.close()
+      broken.closed shouldBe true
+      healthy.closed shouldBe true
     }
 
     it("throttles refresh requests within cooldown period") {
-      var callCount = 0
-      var factoryCallCount = 0
-
-      val clientFactory = () => {
-        factoryCallCount += 1
-        val httpClient = new MockHttpClient(_ => {
-          callCount += 1
-          // Always return 401 to trigger refresh
-          Future.successful(createResponse(401))
-        })
-        ElasticClient(httpClient)
+      val factoryCallCount = new AtomicInteger(0)
+      val factory = () => {
+        factoryCallCount.incrementAndGet()
+        ElasticClient(new MockHttpClient(respond(401)))
       }
 
-      implicit val clock = Clock.systemUTC()
       // Use a very short cooldown to test throttling without actual delays
       val resilientClient =
-        new ResilientElasticClient(clientFactory, minRefreshIntervalMs = 100)
+        newResilientClient(factory, minRefreshIntervalMs = 100)
 
       // First request - should refresh
-      var future = resilientClient.execute("test request 1")
-      whenReady(future) { response =>
+      val future1 = resilientClient.execute("test request 1")
+      whenReady(future1) { response =>
         response.status shouldBe 401
-        factoryCallCount shouldBe 2 // Initial + first refresh
+        factoryCallCount.get shouldBe 2 // Initial + first refresh
       }
 
       // Second request immediately after (within cooldown) - should NOT refresh
-      future = resilientClient.execute("test request 2")
-      whenReady(future) { response =>
+      val future2 = resilientClient.execute("test request 2")
+      whenReady(future2) { response =>
         response.status shouldBe 401
-        factoryCallCount shouldBe 2 // No new refresh
+        factoryCallCount.get shouldBe 2 // No new refresh
       }
 
       // Wait for cooldown to expire
       Thread.sleep(150)
 
       // Third request after cooldown - should refresh
-      val oldFactoryCallCount = factoryCallCount
-      future = resilientClient.execute("test request 3")
-      whenReady(future) { response =>
+      val oldFactoryCallCount = factoryCallCount.get
+      val future3 = resilientClient.execute("test request 3")
+      whenReady(future3) { response =>
         response.status shouldBe 401
-        factoryCallCount shouldBe oldFactoryCallCount + 1 // New refresh
+        factoryCallCount.get shouldBe oldFactoryCallCount + 1 // New refresh
       }
     }
 
     it("allows configurable cooldown period") {
-      var callCount = 0
-      var factoryCallCount = 0
-
-      val clientFactory = () => {
-        factoryCallCount += 1
-        val httpClient = new MockHttpClient(_ => {
-          callCount += 1
-          Future.successful(createResponse(401))
-        })
-        ElasticClient(httpClient)
+      val factoryCallCount = new AtomicInteger(0)
+      val factory = () => {
+        factoryCallCount.incrementAndGet()
+        ElasticClient(new MockHttpClient(respond(401)))
       }
 
-      implicit val clock = Clock.systemUTC()
       // Use a very short cooldown of 50ms
       val resilientClient =
-        new ResilientElasticClient(clientFactory, minRefreshIntervalMs = 50)
+        newResilientClient(factory, minRefreshIntervalMs = 50)
 
       // First request - should refresh
-      var future = resilientClient.execute("test request 1")
-      whenReady(future) { response =>
-        factoryCallCount shouldBe 2
+      val future1 = resilientClient.execute("test request 1")
+      whenReady(future1) { _ =>
+        factoryCallCount.get shouldBe 2
       }
 
       // Wait for cooldown to expire
       Thread.sleep(100)
 
       // Second request after cooldown - should refresh
-      future = resilientClient.execute("test request 2")
-      whenReady(future) { response =>
-        factoryCallCount shouldBe 3 // Another refresh
+      val future2 = resilientClient.execute("test request 2")
+      whenReady(future2) { _ =>
+        factoryCallCount.get shouldBe 3 // Another refresh
       }
     }
 
-    it("only one thread refreshes during concurrent 401 errors") {
-      var callCount = 0
-      var factoryCallCount = 0
-      var concurrentCallsAtPeak = 0
-      val concurrentCallsLock = new Object()
+    it("coalesces concurrent 401 errors onto one refresh") {
+      // Hold every request until both concurrent requests have arrived
+      val bothArrived = new CountDownLatch(2)
+      val broken = new MockHttpClient(_ =>
+        Future {
+          bothArrived.countDown()
+          bothArrived.await()
+          createResponse(401)
+      })
+      val healthy = new MockHttpClient(respond(200))
+      val (factory, factoryCallCount) = clientSequenceFactory(broken, healthy)
+      val resilientClient = newResilientClient(factory)
 
-      val clientFactory = () => {
-        factoryCallCount += 1
-        val httpClient = new MockHttpClient(_ => {
-          concurrentCallsLock.synchronized {
-            callCount += 1
-            concurrentCallsAtPeak = Math.max(concurrentCallsAtPeak, callCount)
-          }
-          // Small delay to allow concurrent execution
-          Thread.sleep(10)
-          concurrentCallsLock.synchronized {
-            callCount -= 1
-          }
-          Future.successful(createResponse(401))
-        })
-        ElasticClient(httpClient)
-      }
-
-      implicit val clock = Clock.systemUTC()
-      val resilientClient = new ResilientElasticClient(clientFactory)
-
-      // Create concurrent requests that all get 401
-      // Using Future.sequence ensures they execute concurrently
       val futures = Future.sequence(
-        (1 to 3).map(_ => resilientClient.execute("concurrent request"))
+        (1 to 2).map(_ => resilientClient.execute("concurrent request"))
       )
 
       whenReady(futures) { responses =>
         responses.foreach { response =>
-          response.status shouldBe 401
+          response.status shouldBe 200
         }
       }
 
-      // Verify concurrent execution happened (at least 2 concurrent calls)
-      concurrentCallsAtPeak should be >= 2
-
-      // Even though we had multiple concurrent 401s, factory should only be called:
-      // 1 initial + 1 first refresh = 2
-      // The other threads should see the client already refreshed
-      factoryCallCount shouldBe 2
+      // Both 401s share a single refresh: 1 initial + 1 refresh
+      factoryCallCount.get shouldBe 2
+      broken.requestCount.get shouldBe 2
+      healthy.requestCount.get shouldBe 2
     }
   }
 }

--- a/search/src/test/scala/weco/api/search/elasticsearch/ResilientElasticClientTest.scala
+++ b/search/src/test/scala/weco/api/search/elasticsearch/ResilientElasticClientTest.scala
@@ -16,7 +16,7 @@ import java.io.IOException
 import java.time.Clock
 import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch}
 import java.util.concurrent.atomic.AtomicInteger
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{blocking, Future, Promise}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class ResilientElasticClientTest
@@ -244,6 +244,45 @@ class ResilientElasticClientTest
       healthy.requestCount.get shouldBe 2
     }
 
+    it("refreshes again if the retry after a mid-flight swap gets a 401") {
+      val firstRequestGate = Promise[HttpResponse]()
+      val firstSeen = new AtomicInteger(0)
+      // First request is held open; later requests fail fast with 401
+      val first = new MockHttpClient(
+        _ =>
+          if (firstSeen.incrementAndGet() == 1) firstRequestGate.future
+          else Future.successful(createResponse(401)))
+      // Second client authenticates but still 401s requests
+      val second = new MockHttpClient(respondWith(200, 401))
+      val third = new MockHttpClient(respond(200))
+      val (factory, factoryCallCount) =
+        clientSequenceFactory(first, second, third)
+      val resilientClient =
+        newResilientClient(factory, minRefreshIntervalMs = 1)
+
+      val heldRequest = resilientClient.execute("held request")
+      eventually { first.requestCount.get shouldBe 1 }
+
+      // Swap in the second client via a fast 401
+      val refreshingRequest = resilientClient.execute("fast request")
+      whenReady(refreshingRequest) { response =>
+        response.status shouldBe 401 // Retried on second, which also 401s
+      }
+      factoryCallCount.get shouldBe 2
+
+      // Let the cooldown lapse so the recursive retry can refresh again
+      Thread.sleep(10)
+
+      // The held request's transport-failure retry 401s on second, so it
+      // must go through the full refresh path and succeed on third
+      firstRequestGate.failure(new IOException("connection closed"))
+      whenReady(heldRequest) { response =>
+        response.status shouldBe 200
+      }
+      factoryCallCount.get shouldBe 3
+      third.requestCount.get shouldBe 1
+    }
+
     it("retries against the current client when it was refreshed mid-request") {
       val firstRequestGate = Promise[HttpResponse]()
       val brokenSeen = new AtomicInteger(0)
@@ -461,7 +500,7 @@ class ResilientElasticClientTest
       val broken = new MockHttpClient(_ =>
         Future {
           bothArrived.countDown()
-          bothArrived.await()
+          blocking(bothArrived.await())
           createResponse(401)
       })
       val healthy = new MockHttpClient(respond(200))


### PR DESCRIPTION
## What does this change?

During a pipeline API key rotation the catalogue API served bursts of user-facing 5xx (wellcomecollection/platform#6528). `ResilientElasticClient` did refresh on a 401/403, but the refresh could capture the still-dead key from Secrets Manager, start the cooldown anyway, and then retry against a client it already knew was broken. Closing the old client failed requests that still held it, and the refresh blocked the request dispatcher inside a `synchronized` block while it made four Secrets Manager calls.

The client now:

- coalesces concurrent refreshes, and retries only when the client instance actually changed. Otherwise it returns the original response rather than duplicating a request that cannot succeed.
- validates a rebuilt client with a `GET /_security/_authenticate` probe before swapping it in. Only a definitive 401/403 rejects the candidate, so an inconclusive probe (cluster 5xx, timeout, security disabled) cannot block adoption of a good key. A dead key served by a stale secret no longer poisons the cooldown: the client keeps probing each cooldown and heals on the first key that authenticates.
- does the blocking secret fetches on a dedicated single-threaded executor instead of the pekko dispatcher, with the probe non-blocking on a 5s timeout.
- closes the replaced client after a 30s grace period so in-flight requests finish, with at most one deferred close outstanding.

Transport failures no longer trigger a refresh. They retry once only when the client was swapped mid-request, which is the case where we closed the old client under an in-flight request, and otherwise propagate unchanged. Timeouts and parse errors are not evidence of rotation, so they keep failing fast.

Constructor and `execute` signatures are unchanged, so no call sites move.

### Checklist

- [x] Does this patch need a change to the documentation? No, this is internal client behaviour.
- [x] Does this change the API surface? No, neither the request surface nor the response schema changes.

## How to test

`(cd search && docker compose up -d)` then `sbt "project search" test`. The 17 tests in `ResilientElasticClientTest` cover each behaviour above (coalescing, cooldown, probe outcomes, the no-refresh transport path, deferred close), and the full search suite of 415 tests passes.

## How can we measure success?

No `catalogue-api-prod-5xx-alarm` burst the next time an apply replaces the pipeline `catalogue_api` key, and no ECS task left stuck on a dead key. The refresh path logs each attempt and each rejected candidate, so recovery is visible in the API logs.

## Have we considered potential risks?

The refresh path only runs on a 401/403, so steady-state request handling is untouched. The probe adds one request per refresh and needs no privilege the key does not already have. The grace-period close trades a brief overlap of two connection pools for not failing in-flight requests, bounded by only ever deferring one close. This is the catalogue API half of the issue only: the terraform `create_before_destroy` change, the concepts API, and the snapshot generator are still outstanding.
